### PR TITLE
fix: Исправить проблему с UTC timezone в webapp (today.html и др.)

### DIFF
--- a/docs/prd/08-ui-design.md
+++ b/docs/prd/08-ui-design.md
@@ -821,6 +821,30 @@ if (!DateFormatter.isValidDisplayFormat(dateStr)) {
 
 #### 8.10.7 Changelog
 
+**2025-11-01 (Timezone Fix):**
+- ✅ **CRITICAL FIX:** Исправлена проблема с UTC vs LOCAL timezone
+- ✅ `DateFormatter.todayISO()` - заменен `.toISOString()` на локальное форматирование
+- ✅ Исправлены 6 файлов webapp: today.html, index.html, add.html, summary.html, stats.html, addplan.html
+- ✅ Все даты теперь используют LOCAL timezone вместо UTC
+
+**Проблема:**
+- `.toISOString()` возвращает UTC время, что приводит к смещению дат
+- Пример: 02.11.2025 01:00 MSK → `toISOString()` → "2025-11-01" (неправильно!)
+- Транзакции за "сегодня" не отображались из-за неправильного dateFrom
+
+**Решение:**
+```javascript
+// ❌ Старый код (UTC)
+const dateFrom = new Date().toISOString().split('T')[0];
+
+// ✅ Новый код (LOCAL)
+const today = new Date();
+const year = today.getFullYear();
+const month = String(today.getMonth() + 1).padStart(2, '0');
+const day = String(today.getDate()).padStart(2, '0');
+const dateFrom = `${year}-${month}-${day}`;
+```
+
 **2025-11-01:**
 - ✅ Адаптирован DateFormatter для формата DD.MM.YYYY (с точками вместо дефисов)
 - ✅ Портирован DateFormatter в `web/static/js/`
@@ -834,6 +858,7 @@ if (!DateFormatter.isValidDisplayFormat(dateStr)) {
 - ✅ Независимость от локали браузера
 - ✅ Улучшенная валидация на клиенте
 - ✅ Централизованное управление форматированием
+- ✅ Корректная работа с LOCAL timezone (MSK, UTC+3)
 
 **Технический долг:**
 - [ ] Добавить маску ввода для автоформатирования (DD.MM.YYYY)

--- a/webapp/add.html
+++ b/webapp/add.html
@@ -435,8 +435,11 @@
                     const date = new Date();
                     date.setDate(date.getDate() + daysOffset);
 
-                    // Format for API (YYYY-MM-DD)
-                    const isoDate = date.toISOString().split('T')[0];
+                    // Format for API (YYYY-MM-DD) - use LOCAL timezone, not UTC
+                    const year = date.getFullYear();
+                    const month = String(date.getMonth() + 1).padStart(2, '0');
+                    const day = String(date.getDate()).padStart(2, '0');
+                    const isoDate = `${year}-${month}-${day}`;
                     formState.factDate = isoDate;
 
                     // Format for display (DD.MM.YYYY)

--- a/webapp/addplan.html
+++ b/webapp/addplan.html
@@ -566,8 +566,16 @@
             // End: last day of target month
             endDate = new Date(targetYear, targetMonth + 1, 0);
 
-            formState.periodStart = startDate.toISOString().split('T')[0];
-            formState.periodEnd = endDate.toISOString().split('T')[0];
+            // Format dates for API (YYYY-MM-DD) - use LOCAL timezone, not UTC
+            const formatLocalDate = (date) => {
+                const year = date.getFullYear();
+                const month = String(date.getMonth() + 1).padStart(2, '0');
+                const day = String(date.getDate()).padStart(2, '0');
+                return `${year}-${month}-${day}`;
+            };
+
+            formState.periodStart = formatLocalDate(startDate);
+            formState.periodEnd = formatLocalDate(endDate);
         }
 
         async function loadCategories() {

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -413,15 +413,20 @@
 
         async function loadQuickStats(app) {
             try {
-                // Get today's date range
+                // Get today's date range (use LOCAL timezone, not UTC)
                 const today = new Date();
-                const todayStart = new Date(today.getFullYear(), today.getMonth(), today.getDate());
-                const todayEnd = new Date(todayStart);
-                todayEnd.setDate(todayEnd.getDate() + 1);
+                const year = today.getFullYear();
+                const month = String(today.getMonth() + 1).padStart(2, '0');
+                const day = String(today.getDate()).padStart(2, '0');
+                const dateFrom = `${year}-${month}-${day}`;
 
-                // Format dates for API
-                const dateFrom = todayStart.toISOString().split('T')[0];
-                const dateTo = todayEnd.toISOString().split('T')[0];
+                // Tomorrow's date for upper bound
+                const tomorrow = new Date(today);
+                tomorrow.setDate(tomorrow.getDate() + 1);
+                const yearTomorrow = tomorrow.getFullYear();
+                const monthTomorrow = String(tomorrow.getMonth() + 1).padStart(2, '0');
+                const dayTomorrow = String(tomorrow.getDate()).padStart(2, '0');
+                const dateTo = `${yearTomorrow}-${monthTomorrow}-${dayTomorrow}`;
 
                 // Fetch today's facts
                 const result = await app.api.listFacts({

--- a/webapp/static/js/dateFormatter.js
+++ b/webapp/static/js/dateFormatter.js
@@ -68,6 +68,7 @@ class DateFormatter {
 
   /**
    * Get current date in YYYY-MM-DD format (for API).
+   * Uses LOCAL timezone, not UTC.
    *
    * @returns {string} Current date in YYYY-MM-DD format
    *
@@ -76,7 +77,10 @@ class DateFormatter {
    */
   static todayISO() {
     const now = new Date();
-    return now.toISOString().split('T')[0];
+    const year = now.getFullYear();
+    const month = String(now.getMonth() + 1).padStart(2, '0');
+    const day = String(now.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
   }
 
   /**

--- a/webapp/stats.html
+++ b/webapp/stats.html
@@ -439,9 +439,17 @@
                     break;
             }
 
+            // Format dates for API (YYYY-MM-DD) - use LOCAL timezone, not UTC
+            const formatLocalDate = (date) => {
+                const year = date.getFullYear();
+                const month = String(date.getMonth() + 1).padStart(2, '0');
+                const day = String(date.getDate()).padStart(2, '0');
+                return `${year}-${month}-${day}`;
+            };
+
             return {
-                dateFrom: dateFrom.toISOString().split('T')[0],
-                dateTo: dateTo.toISOString().split('T')[0]
+                dateFrom: formatLocalDate(dateFrom),
+                dateTo: formatLocalDate(dateTo)
             };
         }
 

--- a/webapp/summary.html
+++ b/webapp/summary.html
@@ -461,9 +461,17 @@
                     break;
             }
 
+            // Format dates for API (YYYY-MM-DD) - use LOCAL timezone, not UTC
+            const formatLocalDate = (date) => {
+                const year = date.getFullYear();
+                const month = String(date.getMonth() + 1).padStart(2, '0');
+                const day = String(date.getDate()).padStart(2, '0');
+                return `${year}-${month}-${day}`;
+            };
+
             return {
-                dateFrom: dateFrom.toISOString().split('T')[0],
-                dateTo: dateTo.toISOString().split('T')[0]
+                dateFrom: formatLocalDate(dateFrom),
+                dateTo: formatLocalDate(dateTo)
             };
         }
 

--- a/webapp/today.html
+++ b/webapp/today.html
@@ -254,11 +254,12 @@
                 categories = categoriesResult.articles || [];
 
                 // Get today's date range (only today, not including tomorrow)
+                // Use LOCAL timezone, not UTC (fixes timezone bug)
                 const today = new Date();
-                const todayStart = new Date(today.getFullYear(), today.getMonth(), today.getDate());
-
-                // Format date for API (today only)
-                const dateFrom = todayStart.toISOString().split('T')[0];
+                const year = today.getFullYear();
+                const month = String(today.getMonth() + 1).padStart(2, '0');
+                const day = String(today.getDate()).padStart(2, '0');
+                const dateFrom = `${year}-${month}-${day}`;
                 const dateTo = dateFrom; // Same day - API uses inclusive range
 
                 // Fetch facts


### PR DESCRIPTION
Проблема:
- .toISOString() возвращает UTC время, что приводит к смещению дат
- Транзакции за "сегодня" не отображались при разнице UTC vs LOCAL
- Пример: 02.11.2025 01:00 MSK → toISOString() → "2025-11-01" (неправильно!)

Решение:
- DateFormatter.todayISO() - заменен на локальное форматирование
- Исправлены 6 файлов webapp: today.html, index.html, add.html,
  summary.html, stats.html, addplan.html
- Все даты теперь используют LOCAL timezone (MSK, UTC+3)

Затронутые файлы:
- webapp/static/js/dateFormatter.js - обновлен todayISO()
- webapp/today.html - использует локальную дату
- webapp/index.html - Quick Stats с локальной датой
- webapp/add.html - кнопки быстрого выбора даты
- webapp/summary.html - период планирования
- webapp/stats.html - период статистики
- webapp/addplan.html - период создания плана
- docs/prd/08-ui-design.md - документирован fix в Changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>