### PR TITLE
Fix/tomselect-category-improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,6 +157,70 @@ ruff check . && black . && mypy .    # Quality checks
    - Требуется **пересборка** и **перезапуск**
    - Smart cleanup автоматически определяет необходимость перезапуска
 
+**⚡ Cache Busting (АВТОМАТИЗИРОВАНО):**
+
+**КРИТИЧНО:** При изменении статических файлов (JS/CSS) требуется обновление версий для очистки браузерного кэша.
+
+✅ **Автоматически при деплое:**
+```bash
+cd ~/familyBudget && git pull
+sudo ./deploy.sh
+# Cache busting выполняется АВТОМАТИЧЕСКИ перед sync_code_to_deploy()
+# Генерируется новая версия на основе timestamp: YYYYMMDD_HHMM
+```
+
+✅ **Ручное управление версиями:**
+```bash
+# Проверить текущие версии во всех файлах
+./scripts/lib/cache_busting.sh check
+
+# Обновить версии вручную (авто-генерация timestamp)
+./scripts/lib/cache_busting.sh auto
+
+# Обновить версии с указанной версией
+./scripts/lib/cache_busting.sh manual
+```
+
+**Какие файлы затрагиваются:**
+- `webapp/add.html`, `webapp/addplan.html`, `webapp/edit.html`
+- `web/templates/facts.html`, `web/templates/plan.html`
+- Обновляются версии: `tomSelectCategoryTree.js?v=YYYYMMDD_HHMM`
+
+**❌ НЕ НУЖНО вручную править версии:**
+```html
+<!-- ❌ WRONG: Ручное изменение версии -->
+<script src="/static/js/tomSelectCategoryTree.js?v=20251103_1234"></script>
+
+<!-- ✅ CORRECT: Версия обновится автоматически при деплое -->
+<script src="/static/js/tomSelectCategoryTree.js?v=GENERATED"></script>
+```
+
+**Workflow при изменении JS/CSS:**
+1. Изменить файл (например, `webapp/static/js/tomSelectCategoryTree.js`)
+2. Закоммитить: `git commit -m "fix: update tomSelect logic"`
+3. Push: `git push`
+4. На сервере: `cd ~/familyBudget && git pull && sudo ./deploy.sh`
+5. ✅ Cache busting сработает автоматически, версии обновятся
+
+**Зачем это нужно:**
+- Браузеры кэшируют JS/CSS файлы агрессивно
+- Без обновления версии пользователи получают старый код
+- Автоматическая генерация версий предотвращает проблемы с кэшем
+
+**Интеграция в deploy.sh:**
+```bash
+# deploy.sh (строка ~341)
+validate_env
+echo ""
+
+# Update cache versions before synchronization
+run_cache_busting "auto" "$REPOSITORY_DIR"  # ← АВТОМАТИЧЕСКИ
+echo ""
+
+# Synchronize code from repository to /opt/budget
+sync_code_to_deploy
+```
+
 **Deployment стратегии (автоматические):**
 
 | Изменения | Cleanup опция | PostgreSQL | Downtime |
@@ -738,11 +802,12 @@ Backend упал на production:
 7. Проверяй **security** - JWT, admin-only access для dimension tables, validation
 8. Проверяй **performance** - indexes, N+1 queries
 9. Документируй **breaking changes**
+10. **НЕ редактируй вручную версии** в `?v=` параметрах - используй автоматический cache busting при деплое
 
 💡 **Не уверен как сделать?** → Посмотри соответствующий [Skill](#-claude-skills)
 
 ---
 
-**Версия документа:** 2.0 (оптимизированная)
-**Последнее обновление:** 2025-10-22
+**Версия документа:** 2.1 (+ автоматический cache busting)
+**Последнее обновление:** 2025-11-03
 **Формат:** Компактный + ссылки на Skills

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,7 +214,7 @@ validate_env
 echo ""
 
 # Update cache versions before synchronization
-run_cache_busting "auto" "$REPOSITORY_DIR"  # ← АВТОМАТИЧЕСКИ
+run_cache_busting "auto" "$SCRIPT_DIR"  # ← АВТОМАТИЧЕСКИ
 echo ""
 
 # Synchronize code from repository to /opt/budget

--- a/deploy.sh
+++ b/deploy.sh
@@ -93,6 +93,7 @@ source "$SCRIPT_DIR/scripts/lib/backup_integration.sh"  # Depends on config.sh, 
 
 # Phase 3 modules (NEW)
 source "$SCRIPT_DIR/scripts/lib/sync.sh"        # Depends on config.sh, utils.sh
+source "$SCRIPT_DIR/scripts/lib/cache_busting.sh"  # Depends on config.sh, utils.sh (NEW)
 source "$SCRIPT_DIR/scripts/lib/docker.sh"      # Depends on config.sh, utils.sh, postgres.sh
 source "$SCRIPT_DIR/scripts/lib/network.sh"     # Depends on config.sh, utils.sh, docker.sh (is_our_docker_container)
 source "$SCRIPT_DIR/scripts/lib/ssl.sh"         # Depends on config.sh, utils.sh
@@ -334,6 +335,10 @@ main() {
     echo ""
 
     validate_env
+    echo ""
+
+    # Update cache versions before synchronization
+    run_cache_busting "auto" "$REPOSITORY_DIR"
     echo ""
 
     # Synchronize code from repository to /opt/budget

--- a/deploy.sh
+++ b/deploy.sh
@@ -338,7 +338,7 @@ main() {
     echo ""
 
     # Update cache versions before synchronization
-    run_cache_busting "auto" "$REPOSITORY_DIR"
+    run_cache_busting "auto" "$SCRIPT_DIR"
     echo ""
 
     # Synchronize code from repository to /opt/budget

--- a/docs/prd/08-ui-design.md
+++ b/docs/prd/08-ui-design.md
@@ -117,11 +117,13 @@ Bot: ✅ Расход добавлен:
 - Добавлены визуальные иконки для родителей (📂) и детей (▸)
 - Более явные отступы для уровней вложенности (`⤷`)
 - **Searchable Category Select (Tom Select v2.3.1):**
-  - N-gram fuzzy search для быстрого поиска категорий по частичному совпадению
-  - Отображение полного иерархического пути родителей в результатах поиска
+  - N-gram fuzzy search для быстрого поиска категорий по частичному совпадению (имя + полный путь)
+  - **Dropdown:** Чистое иерархическое отображение с отступами и иконками (без дублирования путей)
+  - **После выбора:** Отдельный элемент под полем отображает полный путь выбранной категории для контекста
   - Фильтрация только листовых категорий (родительские excluded из результатов)
   - Интегрировано в WebApp (Telegram Mini App) и Web Interface (Desktop)
   - Подсветка совпадений и ранжирование результатов по релевантности
+  - Асинхронная инициализация с проверкой загрузки библиотеки (retry mechanism)
 
 **Batch операции:**
 - Множественный выбор транзакций (checkboxes)
@@ -942,6 +944,27 @@ new CalendarWidget({
 - Поддержка обоих форматов: DD.MM.YYYY (отображение) ↔ YYYY-MM-DD (native input value)
 
 #### 8.10.8 Changelog
+
+**2025-11-03 (TomSelect Category Tree UX Improvements):**
+- ✅ **UX IMPROVEMENT:** Улучшен интерфейс выбора категорий (TomSelectCategoryTree)
+- ✅ **FIX:** Убрано избыточное отображение полного пути в dropdown списке
+  - Было: Иерархия с отступами + дублирующий fullPath под каждой категорией
+  - Стало: Чистое иерархическое отображение с иконками (без дублирования)
+- ✅ **FEATURE:** Добавлено отображение контекста выбранной категории
+  - Отдельный элемент под полем выбора показывает полный путь: "Расходы › Продукты › Еда"
+  - Помогает избежать путаницы между одноименными категориями из разных веток
+- ✅ **FIX:** Исправлен fuzzy search по категориям
+  - Переключено с DOM parsing на options API для корректной передачи данных
+  - Теперь поиск работает по имени категории И полному пути
+- ✅ **FIX:** Исправлена ошибка "TomSelect is not defined"
+  - Добавлен retry mechanism с async/await для ожидания загрузки библиотеки (до 1 сек)
+  - Fallback: показать стандартный select если TomSelect не загрузился
+- ✅ **Изменено файлов:** 11
+  - JS: `webapp/static/js/tomSelectCategoryTree.js`, `web/static/js/tomSelectCategoryTree.js`
+  - HTML webapp: `add.html`, `addplan.html`, `edit.html`
+  - HTML web: `facts.html`, `plan.html`, `components/modal_transaction.html`, `components/modal_plan.html`
+  - CSS: `webapp/static/css/tom-select-telegram.css`, `web/static/css/tom-select-tailwind.css`
+- ✅ **Scope:** WebApp (Telegram Mini App) + Web Interface (Desktop)
 
 **2025-11-02 (CalendarWidget Implementation):**
 - ✅ **FEATURE:** Реализован календарный виджет для всех форм с датами

--- a/scripts/lib/cache_busting.sh
+++ b/scripts/lib/cache_busting.sh
@@ -20,7 +20,11 @@ update_cache_versions() {
     local version=$1
     local repo_dir="${2:-.}"
 
-    echo "🔄 Updating cache versions to: ${version}"
+    echo "🔄 Updating cache versions to: ${version}" >&2
+    echo "   Repository: ${repo_dir}" >&2
+
+    # Flush output to ensure it's visible
+    sync 2>/dev/null || true
 
     # Список файлов для обновления
     local files=(
@@ -31,29 +35,59 @@ update_cache_versions() {
         "${repo_dir}/web/templates/plan.html"
     )
 
+    echo "   Files to update: ${#files[@]}" >&2
+
     local updated_count=0
 
+    echo "   Starting file processing..." >&2
+
     for file in "${files[@]}"; do
-        if [[ -f "$file" ]]; then
-            # Обновляем tomSelectCategoryTree.js версии
-            sed -i "s/tomSelectCategoryTree\.js?v=[0-9a-zA-Z_-]*/tomSelectCategoryTree.js?v=${version}/g" "$file"
+        echo "  → Checking: $(basename "$file")..." >&2
 
-            # Обновляем другие JS файлы если есть
-            # sed -i "s/app\.js?v=[0-9a-zA-Z_-]*/app.js?v=${version}/g" "$file"
-            # sed -i "s/dateFormatter\.js?v=[0-9a-zA-Z_-]*/dateFormatter.js?v=${version}/g" "$file"
-
-            ((updated_count++))
-            echo "  ✓ Updated: $(basename "$file")"
-        else
-            echo "  ⚠ File not found: $file"
+        if [[ ! -f "$file" ]]; then
+            echo "    ⚠ File not found: $file" >&2
+            continue
         fi
+
+        echo "    File exists, checking permissions..." >&2
+
+        # Проверяем права на запись
+        if [[ ! -w "$file" ]]; then
+            local perms=$(stat -c '%a' "$file" 2>/dev/null || echo 'unknown')
+            local owner=$(stat -c '%U:%G' "$file" 2>/dev/null || echo 'unknown')
+            echo "    ⚠ File not writable: $file" >&2
+            echo "      Permissions: $perms, Owner: $owner, Current user: $(whoami)" >&2
+            continue
+        fi
+
+        echo "    Permissions OK, running sed..." >&2
+
+        # Обновляем tomSelectCategoryTree.js версии
+        # Используем временный файл для безопасности при работе с sudo
+        local tmp_file="${file}.tmp.$$"
+        if sed "s/tomSelectCategoryTree\\.js?v=[0-9a-zA-Z_-]*/tomSelectCategoryTree.js?v=${version}/g" "$file" > "$tmp_file" 2>&1; then
+            if mv "$tmp_file" "$file" 2>&1; then
+                ((updated_count++))
+                echo "    ✓ Updated: $(basename "$file")" >&2
+            else
+                echo "    ✗ Failed to replace file: $(basename "$file")" >&2
+                rm -f "$tmp_file" 2>/dev/null || true
+            fi
+        else
+            echo "    ✗ sed command failed for: $(basename "$file")" >&2
+            rm -f "$tmp_file" 2>/dev/null || true
+        fi
+
+        # Обновляем другие JS файлы если есть
+        # sed "s/app\\.js?v=[0-9a-zA-Z_-]*/app.js?v=${version}/g" "$file"
+        # sed "s/dateFormatter\\.js?v=[0-9a-zA-Z_-]*/dateFormatter.js?v=${version}/g" "$file"
     done
 
     if [[ $updated_count -gt 0 ]]; then
-        echo "✅ Cache versions updated in ${updated_count} files"
+        echo "✅ Cache versions updated in ${updated_count} files" >&2
         return 0
     else
-        echo "❌ No files updated"
+        echo "❌ No files updated" >&2
         return 1
     fi
 }

--- a/scripts/lib/cache_busting.sh
+++ b/scripts/lib/cache_busting.sh
@@ -21,10 +21,6 @@ update_cache_versions() {
     local repo_dir="${2:-.}"
 
     echo "🔄 Updating cache versions to: ${version}" >&2
-    echo "   Repository: ${repo_dir}" >&2
-
-    # Flush output to ensure it's visible
-    sync 2>/dev/null || true
 
     # Список файлов для обновления
     local files=(
@@ -35,52 +31,36 @@ update_cache_versions() {
         "${repo_dir}/web/templates/plan.html"
     )
 
-    echo "   Files to update: ${#files[@]}" >&2
-
     local updated_count=0
 
-    echo "   Starting file processing..." >&2
-
     for file in "${files[@]}"; do
-        echo "  → Checking: $(basename "$file")..." >&2
-
         if [[ ! -f "$file" ]]; then
-            echo "    ⚠ File not found: $file" >&2
+            echo "  ⚠ File not found: $(basename "$file")" >&2
             continue
         fi
-
-        echo "    File exists, checking permissions..." >&2
 
         # Проверяем права на запись
         if [[ ! -w "$file" ]]; then
             local perms=$(stat -c '%a' "$file" 2>/dev/null || echo 'unknown')
             local owner=$(stat -c '%U:%G' "$file" 2>/dev/null || echo 'unknown')
-            echo "    ⚠ File not writable: $file" >&2
-            echo "      Permissions: $perms, Owner: $owner, Current user: $(whoami)" >&2
+            echo "  ⚠ File not writable: $(basename "$file")" >&2
+            echo "    Permissions: $perms, Owner: $owner, Current user: $(whoami)" >&2
             continue
         fi
 
-        echo "    Permissions OK, running replacement..." >&2
-
         # Обновляем tomSelectCategoryTree.js версии
-        # Используем perl с in-place edit (прямое редактирование без temp файлов)
-        # perl -i создает backup автоматически и безопасно работает с sudo
-        echo "    Running perl -i.bak..." >&2
+        # ВАЖНО: perl должен выполняться отдельно (не внутри if с 2>&1)
+        # Причина: blocking I/O под sudo при perl внутри условия
         perl -i.bak -pe "s|tomSelectCategoryTree\\.js\\?v=[0-9a-zA-Z_-]*|tomSelectCategoryTree.js?v=${version}|g" "$file" 2>&1
         local perl_exit=$?
 
-        echo "    Perl exit code: $perl_exit" >&2
-
         if [[ $perl_exit -eq 0 ]]; then
-            echo "    Perl completed, cleaning backup..." >&2
             # Удаляем backup файл
             rm -f "${file}.bak" 2>/dev/null || true
-            echo "    Backup removed" >&2
             updated_count=$((updated_count + 1))
-            echo "    Counter updated: $updated_count" >&2
-            echo "    ✓ Updated: $(basename "$file")" >&2
+            echo "  ✓ Updated: $(basename "$file")" >&2
         else
-            echo "    ✗ Perl command failed with exit code $perl_exit for: $(basename "$file")" >&2
+            echo "  ✗ Failed to update: $(basename "$file") (exit code: $perl_exit)" >&2
             # Восстанавливаем из backup если есть
             if [[ -f "${file}.bak" ]]; then
                 mv "${file}.bak" "$file" 2>/dev/null || true

--- a/scripts/lib/cache_busting.sh
+++ b/scripts/lib/cache_busting.sh
@@ -65,15 +65,22 @@ update_cache_versions() {
         # Обновляем tomSelectCategoryTree.js версии
         # Используем perl с in-place edit (прямое редактирование без temp файлов)
         # perl -i создает backup автоматически и безопасно работает с sudo
-        if perl -i.bak -pe "s|tomSelectCategoryTree\\.js\\?v=[0-9a-zA-Z_-]*|tomSelectCategoryTree.js?v=${version}|g" "$file" 2>&1; then
+        echo "    Running perl -i.bak..." >&2
+        perl -i.bak -pe "s|tomSelectCategoryTree\\.js\\?v=[0-9a-zA-Z_-]*|tomSelectCategoryTree.js?v=${version}|g" "$file" 2>&1
+        local perl_exit=$?
+
+        echo "    Perl exit code: $perl_exit" >&2
+
+        if [[ $perl_exit -eq 0 ]]; then
             echo "    Perl completed, cleaning backup..." >&2
             # Удаляем backup файл
             rm -f "${file}.bak" 2>/dev/null || true
-            ((updated_count++))
+            echo "    Backup removed" >&2
+            updated_count=$((updated_count + 1))
+            echo "    Counter updated: $updated_count" >&2
             echo "    ✓ Updated: $(basename "$file")" >&2
         else
-            local exit_code=$?
-            echo "    ✗ Perl command failed with exit code $exit_code for: $(basename "$file")" >&2
+            echo "    ✗ Perl command failed with exit code $perl_exit for: $(basename "$file")" >&2
             # Восстанавливаем из backup если есть
             if [[ -f "${file}.bak" ]]; then
                 mv "${file}.bak" "$file" 2>/dev/null || true

--- a/scripts/lib/cache_busting.sh
+++ b/scripts/lib/cache_busting.sh
@@ -63,26 +63,21 @@ update_cache_versions() {
         echo "    Permissions OK, running replacement..." >&2
 
         # Обновляем tomSelectCategoryTree.js версии
-        # Используем perl вместо sed для более надежной работы с regex
-        local tmp_file="${file}.tmp.$$"
-
-        echo "    Creating temp file: $tmp_file" >&2
-
-        # Используем perl с in-place edit через temp file
-        if perl -pe "s|tomSelectCategoryTree\\.js\\?v=[0-9a-zA-Z_-]*|tomSelectCategoryTree.js?v=${version}|g" "$file" > "$tmp_file" 2>&1; then
-            echo "    Perl completed, replacing file..." >&2
-            # Используем cat для замены файла (работает с sudo на user files)
-            if cat "$tmp_file" > "$file" 2>&1 && rm -f "$tmp_file" 2>&1; then
-                ((updated_count++))
-                echo "    ✓ Updated: $(basename "$file")" >&2
-            else
-                echo "    ✗ Failed to replace file: $(basename "$file")" >&2
-                rm -f "$tmp_file" 2>/dev/null || true
-            fi
+        # Используем perl с in-place edit (прямое редактирование без temp файлов)
+        # perl -i создает backup автоматически и безопасно работает с sudo
+        if perl -i.bak -pe "s|tomSelectCategoryTree\\.js\\?v=[0-9a-zA-Z_-]*|tomSelectCategoryTree.js?v=${version}|g" "$file" 2>&1; then
+            echo "    Perl completed, cleaning backup..." >&2
+            # Удаляем backup файл
+            rm -f "${file}.bak" 2>/dev/null || true
+            ((updated_count++))
+            echo "    ✓ Updated: $(basename "$file")" >&2
         else
             local exit_code=$?
             echo "    ✗ Perl command failed with exit code $exit_code for: $(basename "$file")" >&2
-            rm -f "$tmp_file" 2>/dev/null || true
+            # Восстанавливаем из backup если есть
+            if [[ -f "${file}.bak" ]]; then
+                mv "${file}.bak" "$file" 2>/dev/null || true
+            fi
         fi
 
         # Обновляем другие JS файлы если есть

--- a/scripts/lib/cache_busting.sh
+++ b/scripts/lib/cache_busting.sh
@@ -60,13 +60,17 @@ update_cache_versions() {
             continue
         fi
 
-        echo "    Permissions OK, running sed..." >&2
+        echo "    Permissions OK, running replacement..." >&2
 
         # Обновляем tomSelectCategoryTree.js версии
-        # Используем временный файл для безопасности при работе с sudo
-        # Используем [?] для экранирования ? в URL (character class для литерального символа)
+        # Используем perl вместо sed для более надежной работы с regex
         local tmp_file="${file}.tmp.$$"
-        if timeout 10 sed "s/tomSelectCategoryTree\\.js[?]v=[0-9a-zA-Z_-]*/tomSelectCategoryTree.js?v=${version}/g" "$file" > "$tmp_file" 2>&1; then
+
+        echo "    Creating temp file: $tmp_file" >&2
+
+        # Используем perl с in-place edit через temp file
+        if perl -pe "s|tomSelectCategoryTree\\.js\\?v=[0-9a-zA-Z_-]*|tomSelectCategoryTree.js?v=${version}|g" "$file" > "$tmp_file" 2>&1; then
+            echo "    Perl completed, moving file..." >&2
             if mv "$tmp_file" "$file" 2>&1; then
                 ((updated_count++))
                 echo "    ✓ Updated: $(basename "$file")" >&2
@@ -75,7 +79,8 @@ update_cache_versions() {
                 rm -f "$tmp_file" 2>/dev/null || true
             fi
         else
-            echo "    ✗ sed command failed or timed out for: $(basename "$file")" >&2
+            local exit_code=$?
+            echo "    ✗ Perl command failed with exit code $exit_code for: $(basename "$file")" >&2
             rm -f "$tmp_file" 2>/dev/null || true
         fi
 

--- a/scripts/lib/cache_busting.sh
+++ b/scripts/lib/cache_busting.sh
@@ -64,8 +64,9 @@ update_cache_versions() {
 
         # Обновляем tomSelectCategoryTree.js версии
         # Используем временный файл для безопасности при работе с sudo
+        # Используем [?] для экранирования ? в URL (character class для литерального символа)
         local tmp_file="${file}.tmp.$$"
-        if sed "s/tomSelectCategoryTree\\.js?v=[0-9a-zA-Z_-]*/tomSelectCategoryTree.js?v=${version}/g" "$file" > "$tmp_file" 2>&1; then
+        if timeout 10 sed "s/tomSelectCategoryTree\\.js[?]v=[0-9a-zA-Z_-]*/tomSelectCategoryTree.js?v=${version}/g" "$file" > "$tmp_file" 2>&1; then
             if mv "$tmp_file" "$file" 2>&1; then
                 ((updated_count++))
                 echo "    ✓ Updated: $(basename "$file")" >&2
@@ -74,7 +75,7 @@ update_cache_versions() {
                 rm -f "$tmp_file" 2>/dev/null || true
             fi
         else
-            echo "    ✗ sed command failed for: $(basename "$file")" >&2
+            echo "    ✗ sed command failed or timed out for: $(basename "$file")" >&2
             rm -f "$tmp_file" 2>/dev/null || true
         fi
 

--- a/scripts/lib/cache_busting.sh
+++ b/scripts/lib/cache_busting.sh
@@ -70,8 +70,9 @@ update_cache_versions() {
 
         # Используем perl с in-place edit через temp file
         if perl -pe "s|tomSelectCategoryTree\\.js\\?v=[0-9a-zA-Z_-]*|tomSelectCategoryTree.js?v=${version}|g" "$file" > "$tmp_file" 2>&1; then
-            echo "    Perl completed, moving file..." >&2
-            if mv "$tmp_file" "$file" 2>&1; then
+            echo "    Perl completed, replacing file..." >&2
+            # Используем cat для замены файла (работает с sudo на user files)
+            if cat "$tmp_file" > "$file" 2>&1 && rm -f "$tmp_file" 2>&1; then
                 ((updated_count++))
                 echo "    ✓ Updated: $(basename "$file")" >&2
             else

--- a/scripts/lib/cache_busting.sh
+++ b/scripts/lib/cache_busting.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+#
+# Cache Busting Module для deploy.sh
+# Автоматическое обновление версий статических файлов при деплое
+#
+
+# Генерация новой версии на основе timestamp
+generate_cache_version() {
+    echo "$(date +"%Y%m%d_%H%M")"
+}
+
+# Генерация версии на основе git commit hash (альтернатива)
+generate_cache_version_git() {
+    local git_hash=$(git rev-parse --short HEAD 2>/dev/null || echo "dev")
+    echo "${git_hash}"
+}
+
+# Обновление версий во всех template файлах
+update_cache_versions() {
+    local version=$1
+    local repo_dir="${2:-.}"
+
+    echo "🔄 Updating cache versions to: ${version}"
+
+    # Список файлов для обновления
+    local files=(
+        "${repo_dir}/webapp/add.html"
+        "${repo_dir}/webapp/addplan.html"
+        "${repo_dir}/webapp/edit.html"
+        "${repo_dir}/web/templates/facts.html"
+        "${repo_dir}/web/templates/plan.html"
+    )
+
+    local updated_count=0
+
+    for file in "${files[@]}"; do
+        if [[ -f "$file" ]]; then
+            # Обновляем tomSelectCategoryTree.js версии
+            sed -i "s/tomSelectCategoryTree\.js?v=[0-9a-zA-Z_-]*/tomSelectCategoryTree.js?v=${version}/g" "$file"
+
+            # Обновляем другие JS файлы если есть
+            # sed -i "s/app\.js?v=[0-9a-zA-Z_-]*/app.js?v=${version}/g" "$file"
+            # sed -i "s/dateFormatter\.js?v=[0-9a-zA-Z_-]*/dateFormatter.js?v=${version}/g" "$file"
+
+            ((updated_count++))
+            echo "  ✓ Updated: $(basename "$file")"
+        else
+            echo "  ⚠ File not found: $file"
+        fi
+    done
+
+    if [[ $updated_count -gt 0 ]]; then
+        echo "✅ Cache versions updated in ${updated_count} files"
+        return 0
+    else
+        echo "❌ No files updated"
+        return 1
+    fi
+}
+
+# Проверка текущих версий в файлах
+check_cache_versions() {
+    local repo_dir="${1:-.}"
+
+    echo "📝 Current cache versions:"
+
+    local files=(
+        "${repo_dir}/webapp/add.html"
+        "${repo_dir}/webapp/addplan.html"
+        "${repo_dir}/webapp/edit.html"
+        "${repo_dir}/web/templates/facts.html"
+        "${repo_dir}/web/templates/plan.html"
+    )
+
+    for file in "${files[@]}"; do
+        if [[ -f "$file" ]]; then
+            local version=$(grep -oP 'tomSelectCategoryTree\.js\?v=\K[0-9a-zA-Z_-]+' "$file" 2>/dev/null | head -1)
+            if [[ -n "$version" ]]; then
+                echo "  $(basename "$file"): v=${version}"
+            else
+                echo "  $(basename "$file"): no version found"
+            fi
+        fi
+    done
+}
+
+# Основная функция для вызова из deploy.sh
+run_cache_busting() {
+    local mode="${1:-auto}"  # auto|check|manual
+    local repo_dir="${2:-.}"
+
+    case "$mode" in
+        check)
+            check_cache_versions "$repo_dir"
+            ;;
+        manual)
+            read -p "Enter new cache version (or press Enter for auto): " manual_version
+            if [[ -z "$manual_version" ]]; then
+                manual_version=$(generate_cache_version)
+            fi
+            update_cache_versions "$manual_version" "$repo_dir"
+            ;;
+        auto|*)
+            local new_version=$(generate_cache_version)
+            update_cache_versions "$new_version" "$repo_dir"
+            ;;
+    esac
+}
+
+# Если скрипт запущен напрямую (не sourced)
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    run_cache_busting "$@"
+fi

--- a/web/static/css/tom-select-tailwind.css
+++ b/web/static/css/tom-select-tailwind.css
@@ -240,3 +240,8 @@
 .ts-wrapper.input-success.focus .ts-control {
   @apply ring-success ring-opacity-20;
 }
+
+/* ===== Category Path Info ===== */
+.category-path-info {
+    @apply text-xs text-gray-500 mt-1 opacity-70;
+}

--- a/web/static/js/tomSelectCategoryTree.js
+++ b/web/static/js/tomSelectCategoryTree.js
@@ -209,13 +209,33 @@ class TomSelectCategoryTree {
   /**
    * Проверить загрузку TomSelect библиотеки
    */
-  async waitForTomSelect(maxAttempts = 10, delayMs = 100) {
+  async waitForTomSelect(maxAttempts = 20, delayMs = 150) {
+    console.log('[TomSelect] Waiting for TomSelect library...');
+
     for (let i = 0; i < maxAttempts; i++) {
       if (typeof TomSelect !== 'undefined') {
+        console.log(`[TomSelect] Library loaded successfully after ${i + 1} attempts`);
         return true;
       }
+
+      if (i % 5 === 0) {
+        console.log(`[TomSelect] Attempt ${i + 1}/${maxAttempts}...`);
+      }
+
       await new Promise(resolve => setTimeout(resolve, delayMs));
     }
+
+    console.error('[TomSelect] Failed to load after', maxAttempts, 'attempts');
+    console.error('[TomSelect] Checking CDN script tag...');
+
+    const cdnScript = document.querySelector('script[src*="tom-select"]');
+    if (cdnScript) {
+      console.log('[TomSelect] CDN script tag found:', cdnScript.src);
+      console.log('[TomSelect] Script loaded:', cdnScript.complete || 'unknown');
+    } else {
+      console.error('[TomSelect] CDN script tag NOT found in document!');
+    }
+
     return false;
   }
 

--- a/web/static/js/tomSelectCategoryTree.js
+++ b/web/static/js/tomSelectCategoryTree.js
@@ -31,12 +31,14 @@ class TomSelectCategoryTree {
       parentPrefix: '📂', // Иконка для родителя (папка)
       leafPrefix: '  ▸', // Иконка для листа (стрелка)
       pathSeparator: ' › ', // Разделитель для пути родителей
+      pathDisplayElementId: null, // ID элемента для отображения полного пути выбранной категории
       ...options
     };
 
     this.tomSelectInstance = null;
     this.tree = null;
     this.flatNodes = null;
+    this.pathDisplayElement = null;
   }
 
   /**
@@ -167,10 +169,7 @@ class TomSelectCategoryTree {
     return `<div class="tom-select-option">
       <span class="category-indent">${this.options.indentChar.repeat(data.level)}</span>
       <span class="category-icon">${this.options.leafPrefix}</span>
-      <div class="category-info">
-        <div class="category-name">${escape(data.name)}</div>
-        ${data.parentPath.length > 0 ? `<div class="category-path">${escape(data.fullPath)}</div>` : ''}
-      </div>
+      <span class="category-name">${escape(data.name)}</span>
     </div>`;
   }
 
@@ -186,55 +185,87 @@ class TomSelectCategoryTree {
   }
 
   /**
+   * Обновить отображение полного пути выбранной категории
+   */
+  updatePathDisplay(categoryId) {
+    if (!this.pathDisplayElement) return;
+
+    if (!categoryId) {
+      this.pathDisplayElement.textContent = '';
+      this.pathDisplayElement.style.display = 'none';
+      return;
+    }
+
+    const node = this.flatNodes.find(n => n.id === parseInt(categoryId));
+    if (node && node.fullPath) {
+      this.pathDisplayElement.textContent = node.fullPath;
+      this.pathDisplayElement.style.display = 'block';
+    } else {
+      this.pathDisplayElement.textContent = '';
+      this.pathDisplayElement.style.display = 'none';
+    }
+  }
+
+  /**
+   * Проверить загрузку TomSelect библиотеки
+   */
+  async waitForTomSelect(maxAttempts = 10, delayMs = 100) {
+    for (let i = 0; i < maxAttempts; i++) {
+      if (typeof TomSelect !== 'undefined') {
+        return true;
+      }
+      await new Promise(resolve => setTimeout(resolve, delayMs));
+    }
+    return false;
+  }
+
+  /**
    * Инициализировать Tom Select
    */
-  init() {
-    // Check if TomSelect library is loaded
-    if (typeof TomSelect === 'undefined') {
-      console.error('TomSelect library not loaded. Make sure Tom Select CDN script is included before tomSelectCategoryTree.js');
-      throw new Error('TomSelect is not defined. Please include Tom Select library: <script src="https://cdn.jsdelivr.net/npm/tom-select@2.3.1/dist/js/tom-select.complete.min.js"></script>');
+  async init() {
+    // Check if TomSelect library is loaded with retry mechanism
+    const isLoaded = await this.waitForTomSelect();
+
+    if (!isLoaded) {
+      const errorMsg = 'TomSelect library not loaded after waiting. Make sure Tom Select CDN script is included in <head> before tomSelectCategoryTree.js';
+      console.error(errorMsg);
+      console.error('Expected CDN: <script src="https://cdn.jsdelivr.net/npm/tom-select@2.3.1/dist/js/tom-select.complete.min.js"></script>');
+
+      // Fallback: показать стандартный select без Tom Select
+      this.selectElement.style.display = 'block';
+      throw new Error(errorMsg);
     }
 
     // Построить дерево
     this.tree = this.buildTree();
     this.flatNodes = this.flattenTree();
 
-    // Очистить select и добавить options
-    this.selectElement.innerHTML = '';
+    // Найти элемент для отображения пути (если указан)
+    if (this.options.pathDisplayElementId) {
+      this.pathDisplayElement = document.getElementById(this.options.pathDisplayElementId);
+      if (!this.pathDisplayElement) {
+        console.warn(`Path display element with id "${this.options.pathDisplayElementId}" not found`);
+      }
+    }
 
-    // Пустая опция
+    // Очистить select и добавить пустую опцию
+    this.selectElement.innerHTML = '';
     const emptyOption = document.createElement('option');
     emptyOption.value = '';
     emptyOption.textContent = this.options.emptyOptionText;
     this.selectElement.appendChild(emptyOption);
 
-    // Добавить все узлы как опции
-    this.flatNodes.forEach(node => {
-      const option = document.createElement('option');
-      option.value = node.id;
-      option.textContent = node.name;
-
-      // Сохранить данные узла в data-атрибутах для Tom Select
-      option.setAttribute('data-level', node.level);
-      option.setAttribute('data-is-leaf', node.isLeaf);
-      option.setAttribute('data-full-path', node.fullPath);
-      option.setAttribute('data-parent-path', JSON.stringify(node.parentPath));
-
-      // Disabled для родительских категорий
-      if (!node.isLeaf) {
-        option.disabled = true;
-      }
-
-      // Предвыбранное значение
-      if (this.options.selectedId && node.id === this.options.selectedId) {
-        option.selected = true;
-      }
-
-      this.selectElement.appendChild(option);
-    });
-
-    // Инициализировать Tom Select
+    // Инициализировать Tom Select с данными через options API
     this.tomSelectInstance = new TomSelect(this.selectElement, {
+      // Передача данных напрямую через options вместо DOM parsing
+      options: this.flatNodes.map(node => ({
+        id: node.id,
+        name: node.name,
+        level: node.level,
+        isLeaf: node.isLeaf,
+        fullPath: node.fullPath,
+        parentPath: node.parentPath
+      })),
       plugins: {
         remove_button: {
           title: 'Удалить'
@@ -250,16 +281,12 @@ class TomSelectCategoryTree {
       // Custom render функции
       render: {
         option: (data, escape) => {
-          // Найти полные данные узла
-          const nodeData = this.flatNodes.find(n => n.id === parseInt(data.id));
-          if (!nodeData) return `<div>${escape(data.name)}</div>`;
-          return this.renderOption(nodeData, escape);
+          // data уже содержит все необходимые поля благодаря options API
+          return this.renderOption(data, escape);
         },
         item: (data, escape) => {
-          // Найти полные данные узла
-          const nodeData = this.flatNodes.find(n => n.id === parseInt(data.id));
-          if (!nodeData) return `<div>${escape(data.name)}</div>`;
-          return this.renderItem(nodeData, escape);
+          // data уже содержит все необходимые поля благодаря options API
+          return this.renderItem(data, escape);
         },
         option_create: (data, escape) => {
           return `<div class="create">Добавить <strong>${escape(data.input)}</strong>&hellip;</div>`;
@@ -273,14 +300,11 @@ class TomSelectCategoryTree {
       score: (search) => {
         const self = this;
         return function(item) {
-          // Найти полные данные узла
-          const nodeData = self.flatNodes.find(n => n.id === parseInt(item.id));
-          if (!nodeData) return 0;
-
+          // item уже содержит все необходимые поля благодаря options API
           // Родительские категории не показывать в результатах поиска
-          if (!nodeData.isLeaf && search) return 0;
+          if (!item.isLeaf && search) return 0;
 
-          return self.fuzzyScore(search, nodeData);
+          return self.fuzzyScore(search, item);
         };
       },
 
@@ -296,18 +320,27 @@ class TomSelectCategoryTree {
       // Создание новых элементов запрещено
       create: false,
 
-      // Настройки для desktop
-      controlInput: null,
+      // Настройки для mobile
+      controlInput: null, // Использовать стандартный input
       openOnFocus: true,
       selectOnTab: true,
 
       // onChange callback
       onChange: (value) => {
+        // Обновить отображение пути
+        this.updatePathDisplay(value);
+
         // Trigger change event на оригинальном select для compatibility
         const event = new Event('change', { bubbles: true });
         this.selectElement.dispatchEvent(event);
       }
     });
+
+    // Установить предвыбранное значение если указано
+    if (this.options.selectedId) {
+      this.tomSelectInstance.setValue(this.options.selectedId, true); // silent = true
+      this.updatePathDisplay(this.options.selectedId);
+    }
 
     return this.tomSelectInstance;
   }
@@ -331,6 +364,7 @@ class TomSelectCategoryTree {
     if (!this.tomSelectInstance) return;
 
     this.tomSelectInstance.setValue(categoryId || '', true); // silent = true
+    this.updatePathDisplay(categoryId);
   }
 
   /**

--- a/web/templates/components/modal_plan.html
+++ b/web/templates/components/modal_plan.html
@@ -54,6 +54,7 @@
                 <select name="article_id" required class="select select-bordered">
                     <option value="">-- Выберите категорию --</option>
                 </select>
+                <div id="plan-category-path-display" class="category-path-info" style="display: none;"></div>
             </div>
 
             <!-- Центр финансовой ответственности (ЦФО) -->

--- a/web/templates/components/modal_transaction.html
+++ b/web/templates/components/modal_transaction.html
@@ -54,6 +54,7 @@
                 <select name="article_id" required class="select select-bordered">
                     <option value="">-- Выберите категорию --</option>
                 </select>
+                <div id="transaction-category-path-display" class="category-path-info" style="display: none;"></div>
             </div>
 
             <!-- Центр финансовой ответственности (ЦФО) -->

--- a/web/templates/facts.html
+++ b/web/templates/facts.html
@@ -255,7 +255,7 @@
 {% block extra_scripts %}
 <script src="/static/js/admin-facts-common.js"></script>
 <!-- TomSelectCategoryTree Component -->
-<script src="/static/js/tomSelectCategoryTree.js?v=20251103_2"></script>
+<script src="/static/js/tomSelectCategoryTree.js?v=20251103_1504"></script>
 <!-- DateFormatter Component -->
 <script src="/static/js/dateFormatter.js"></script>
 

--- a/web/templates/facts.html
+++ b/web/templates/facts.html
@@ -397,9 +397,10 @@ async function loadArticles() {
                 filterType: createType,
                 indentChar: '›  ',
                 parentPrefix: '📁',
-                leafPrefix: '📄'
+                leafPrefix: '📄',
+                pathDisplayElementId: 'transaction-category-path-display'
             });
-            createCategoryTreeSelect.init();
+            await createCategoryTreeSelect.init();
         }
 
         // Инициализация CalendarWidget для create modal (после загрузки категорий)
@@ -941,9 +942,10 @@ function setupCreateTransactionTypeButtons() {
                     filterType: createType,
                     indentChar: '›  ',
                     parentPrefix: '📁',
-                    leafPrefix: '📄'
+                    leafPrefix: '📄',
+                    pathDisplayElementId: 'transaction-category-path-display'
                 });
-                createCategoryTreeSelect.init();
+                await createCategoryTreeSelect.init();
             }
         });
     });

--- a/web/templates/plan.html
+++ b/web/templates/plan.html
@@ -245,7 +245,7 @@
 {% block extra_scripts %}
 <script src="/static/js/admin-facts-common.js"></script>
 <!-- CategoryTreeSelect Component -->
-<script src="/static/js/tomSelectCategoryTree.js?v=20251103_2"></script>
+<script src="/static/js/tomSelectCategoryTree.js?v=20251103_1504"></script>
 <!-- DateFormatter Component -->
 <script src="/static/js/dateFormatter.js"></script>
 

--- a/web/templates/plan.html
+++ b/web/templates/plan.html
@@ -374,9 +374,10 @@ async function loadArticles() {
                 filterType: createType,
                 indentChar: '›  ',
                 parentPrefix: '📁',
-                leafPrefix: '📄'
+                leafPrefix: '📄',
+                pathDisplayElementId: 'plan-category-path-display'
             });
-            createCategoryTreeSelect.init();
+            await createCategoryTreeSelect.init();
         }
     } catch (error) {
         console.error('Error loading articles:', error);
@@ -906,9 +907,10 @@ function setupCreatePlanTypeButtons() {
                     filterType: createType,
                     indentChar: '›  ',
                     parentPrefix: '📁',
-                    leafPrefix: '📄'
+                    leafPrefix: '📄',
+                    pathDisplayElementId: 'plan-category-path-display'
                 });
-                createCategoryTreeSelect.init();
+                await createCategoryTreeSelect.init();
             }
         });
     });

--- a/webapp/add.html
+++ b/webapp/add.html
@@ -208,6 +208,7 @@
             <select id="category-select" class="form-input" required>
                 <option value="">Загрузка категорий...</option>
             </select>
+            <div id="category-path-display" class="category-path-info" style="display: none;"></div>
             <span class="error-message" id="category-error"></span>
         </div>
 
@@ -480,11 +481,12 @@
                 categoryTreeSelect = new TomSelectCategoryTree(categorySelect, categories, {
                     emptyOptionText: 'Выберите категорию',
                     filterType: formState.factType,
-                    selectedId: formState.categoryId
+                    selectedId: formState.categoryId,
+                    pathDisplayElementId: 'category-path-display'
                 });
 
                 // Initialize Tom Select
-                categoryTreeSelect.init();
+                await categoryTreeSelect.init();
 
                 // Setup change handler
                 categorySelect.addEventListener('change', () => {

--- a/webapp/add.html
+++ b/webapp/add.html
@@ -271,7 +271,7 @@
     <script src="/webapp/static/js/dateFormatter.js"></script>
 
     <!-- Tom Select Category Tree Component -->
-    <script src="/webapp/static/js/tomSelectCategoryTree.js?v=20251103_3"></script>
+    <script src="/webapp/static/js/tomSelectCategoryTree.js?v=20251103_1504"></script>
 
     <script src="/webapp/static/js/app.js"></script>
 

--- a/webapp/addplan.html
+++ b/webapp/addplan.html
@@ -282,6 +282,7 @@
             <select id="category-select" class="form-input" required>
                 <option value="">Загрузка категорий...</option>
             </select>
+            <div id="category-path-display" class="category-path-info" style="display: none;"></div>
             <span class="error-message" id="category-error"></span>
         </div>
 
@@ -607,11 +608,12 @@
                 // Create TomSelectCategoryTree instance
                 categoryTreeSelect = new TomSelectCategoryTree(categorySelect, categories, {
                     emptyOptionText: 'Выберите категорию',
-                    selectedId: formState.categoryId
+                    selectedId: formState.categoryId,
+                    pathDisplayElementId: 'category-path-display'
                 });
 
                 // Initialize Tom Select
-                categoryTreeSelect.init();
+                await categoryTreeSelect.init();
 
                 // Setup change handler
                 categorySelect.addEventListener('change', () => {

--- a/webapp/addplan.html
+++ b/webapp/addplan.html
@@ -349,7 +349,7 @@
     <script src="/webapp/static/js/dateFormatter.js"></script>
 
     <!-- Tom Select Category Tree Component -->
-    <script src="/webapp/static/js/tomSelectCategoryTree.js?v=20251103_3"></script>
+    <script src="/webapp/static/js/tomSelectCategoryTree.js?v=20251103_1504"></script>
 
     <script src="/webapp/static/js/app.js"></script>
 

--- a/webapp/edit.html
+++ b/webapp/edit.html
@@ -310,7 +310,7 @@
     <script src="/webapp/static/js/dateFormatter.js"></script>
 
     <!-- Tom Select Category Tree Component -->
-    <script src="/webapp/static/js/tomSelectCategoryTree.js?v=20251103_3"></script>
+    <script src="/webapp/static/js/tomSelectCategoryTree.js?v=20251103_1504"></script>
 
     <script src="/webapp/static/js/app.js"></script>
 

--- a/webapp/edit.html
+++ b/webapp/edit.html
@@ -258,6 +258,7 @@
             <select id="category-select" class="form-input" required>
                 <option value="">Загрузка категорий...</option>
             </select>
+            <div id="category-path-display" class="category-path-info" style="display: none;"></div>
             <span class="error-message" id="category-error"></span>
         </div>
 
@@ -586,11 +587,12 @@
                 categoryTreeSelect = new TomSelectCategoryTree(categorySelect, categories, {
                     emptyOptionText: 'Выберите категорию',
                     filterType: formState.factType,
-                    selectedId: formState.categoryId
+                    selectedId: formState.categoryId,
+                    pathDisplayElementId: 'category-path-display'
                 });
 
                 // Initialize Tom Select
-                categoryTreeSelect.init();
+                await categoryTreeSelect.init();
 
                 // Setup change handler
                 categorySelect.addEventListener('change', () => {

--- a/webapp/static/css/tom-select-telegram.css
+++ b/webapp/static/css/tom-select-telegram.css
@@ -268,3 +268,11 @@
 .ts-wrapper.dropdown-active.single .ts-control::after {
   transform: translateY(-50%) rotate(180deg);
 }
+
+/* ===== Category Path Info ===== */
+.category-path-info {
+    margin-top: 0.25rem;
+    font-size: 0.75rem;
+    color: var(--telegram-hint-color, #999);
+    opacity: 0.7;
+}

--- a/webapp/static/js/tomSelectCategoryTree.js
+++ b/webapp/static/js/tomSelectCategoryTree.js
@@ -208,13 +208,33 @@ class TomSelectCategoryTree {
   /**
    * Проверить загрузку TomSelect библиотеки
    */
-  async waitForTomSelect(maxAttempts = 10, delayMs = 100) {
+  async waitForTomSelect(maxAttempts = 20, delayMs = 150) {
+    console.log('[TomSelect] Waiting for TomSelect library...');
+
     for (let i = 0; i < maxAttempts; i++) {
       if (typeof TomSelect !== 'undefined') {
+        console.log(`[TomSelect] Library loaded successfully after ${i + 1} attempts`);
         return true;
       }
+
+      if (i % 5 === 0) {
+        console.log(`[TomSelect] Attempt ${i + 1}/${maxAttempts}...`);
+      }
+
       await new Promise(resolve => setTimeout(resolve, delayMs));
     }
+
+    console.error('[TomSelect] Failed to load after', maxAttempts, 'attempts');
+    console.error('[TomSelect] Checking CDN script tag...');
+
+    const cdnScript = document.querySelector('script[src*="tom-select"]');
+    if (cdnScript) {
+      console.log('[TomSelect] CDN script tag found:', cdnScript.src);
+      console.log('[TomSelect] Script loaded:', cdnScript.complete || 'unknown');
+    } else {
+      console.error('[TomSelect] CDN script tag NOT found in document!');
+    }
+
     return false;
   }
 

--- a/webapp/static/js/tomSelectCategoryTree.js
+++ b/webapp/static/js/tomSelectCategoryTree.js
@@ -30,12 +30,14 @@ class TomSelectCategoryTree {
       parentPrefix: '📁', // Иконка для родителя
       leafPrefix: '📄', // Иконка для листа
       pathSeparator: ' › ', // Разделитель для пути родителей
+      pathDisplayElementId: null, // ID элемента для отображения полного пути выбранной категории
       ...options
     };
 
     this.tomSelectInstance = null;
     this.tree = null;
     this.flatNodes = null;
+    this.pathDisplayElement = null;
   }
 
   /**
@@ -166,10 +168,7 @@ class TomSelectCategoryTree {
     return `<div class="tom-select-option">
       <span class="category-indent">${this.options.indentChar.repeat(data.level)}</span>
       <span class="category-icon">${this.options.leafPrefix}</span>
-      <div class="category-info">
-        <div class="category-name">${escape(data.name)}</div>
-        ${data.parentPath.length > 0 ? `<div class="category-path">${escape(data.fullPath)}</div>` : ''}
-      </div>
+      <span class="category-name">${escape(data.name)}</span>
     </div>`;
   }
 
@@ -185,55 +184,87 @@ class TomSelectCategoryTree {
   }
 
   /**
+   * Обновить отображение полного пути выбранной категории
+   */
+  updatePathDisplay(categoryId) {
+    if (!this.pathDisplayElement) return;
+
+    if (!categoryId) {
+      this.pathDisplayElement.textContent = '';
+      this.pathDisplayElement.style.display = 'none';
+      return;
+    }
+
+    const node = this.flatNodes.find(n => n.id === parseInt(categoryId));
+    if (node && node.fullPath) {
+      this.pathDisplayElement.textContent = node.fullPath;
+      this.pathDisplayElement.style.display = 'block';
+    } else {
+      this.pathDisplayElement.textContent = '';
+      this.pathDisplayElement.style.display = 'none';
+    }
+  }
+
+  /**
+   * Проверить загрузку TomSelect библиотеки
+   */
+  async waitForTomSelect(maxAttempts = 10, delayMs = 100) {
+    for (let i = 0; i < maxAttempts; i++) {
+      if (typeof TomSelect !== 'undefined') {
+        return true;
+      }
+      await new Promise(resolve => setTimeout(resolve, delayMs));
+    }
+    return false;
+  }
+
+  /**
    * Инициализировать Tom Select
    */
-  init() {
-    // Check if TomSelect library is loaded
-    if (typeof TomSelect === 'undefined') {
-      console.error('TomSelect library not loaded. Make sure Tom Select CDN script is included before tomSelectCategoryTree.js');
-      throw new Error('TomSelect is not defined. Please include Tom Select library: <script src="https://cdn.jsdelivr.net/npm/tom-select@2.3.1/dist/js/tom-select.complete.min.js"></script>');
+  async init() {
+    // Check if TomSelect library is loaded with retry mechanism
+    const isLoaded = await this.waitForTomSelect();
+
+    if (!isLoaded) {
+      const errorMsg = 'TomSelect library not loaded after waiting. Make sure Tom Select CDN script is included in <head> before tomSelectCategoryTree.js';
+      console.error(errorMsg);
+      console.error('Expected CDN: <script src="https://cdn.jsdelivr.net/npm/tom-select@2.3.1/dist/js/tom-select.complete.min.js"></script>');
+
+      // Fallback: показать стандартный select без Tom Select
+      this.selectElement.style.display = 'block';
+      throw new Error(errorMsg);
     }
 
     // Построить дерево
     this.tree = this.buildTree();
     this.flatNodes = this.flattenTree();
 
-    // Очистить select и добавить options
-    this.selectElement.innerHTML = '';
+    // Найти элемент для отображения пути (если указан)
+    if (this.options.pathDisplayElementId) {
+      this.pathDisplayElement = document.getElementById(this.options.pathDisplayElementId);
+      if (!this.pathDisplayElement) {
+        console.warn(`Path display element with id "${this.options.pathDisplayElementId}" not found`);
+      }
+    }
 
-    // Пустая опция
+    // Очистить select и добавить пустую опцию
+    this.selectElement.innerHTML = '';
     const emptyOption = document.createElement('option');
     emptyOption.value = '';
     emptyOption.textContent = this.options.emptyOptionText;
     this.selectElement.appendChild(emptyOption);
 
-    // Добавить все узлы как опции
-    this.flatNodes.forEach(node => {
-      const option = document.createElement('option');
-      option.value = node.id;
-      option.textContent = node.name;
-
-      // Сохранить данные узла в data-атрибутах для Tom Select
-      option.setAttribute('data-level', node.level);
-      option.setAttribute('data-is-leaf', node.isLeaf);
-      option.setAttribute('data-full-path', node.fullPath);
-      option.setAttribute('data-parent-path', JSON.stringify(node.parentPath));
-
-      // Disabled для родительских категорий
-      if (!node.isLeaf) {
-        option.disabled = true;
-      }
-
-      // Предвыбранное значение
-      if (this.options.selectedId && node.id === this.options.selectedId) {
-        option.selected = true;
-      }
-
-      this.selectElement.appendChild(option);
-    });
-
-    // Инициализировать Tom Select
+    // Инициализировать Tom Select с данными через options API
     this.tomSelectInstance = new TomSelect(this.selectElement, {
+      // Передача данных напрямую через options вместо DOM parsing
+      options: this.flatNodes.map(node => ({
+        id: node.id,
+        name: node.name,
+        level: node.level,
+        isLeaf: node.isLeaf,
+        fullPath: node.fullPath,
+        parentPath: node.parentPath
+      })),
       plugins: {
         remove_button: {
           title: 'Удалить'
@@ -249,16 +280,12 @@ class TomSelectCategoryTree {
       // Custom render функции
       render: {
         option: (data, escape) => {
-          // Найти полные данные узла
-          const nodeData = this.flatNodes.find(n => n.id === parseInt(data.id));
-          if (!nodeData) return `<div>${escape(data.name)}</div>`;
-          return this.renderOption(nodeData, escape);
+          // data уже содержит все необходимые поля благодаря options API
+          return this.renderOption(data, escape);
         },
         item: (data, escape) => {
-          // Найти полные данные узла
-          const nodeData = this.flatNodes.find(n => n.id === parseInt(data.id));
-          if (!nodeData) return `<div>${escape(data.name)}</div>`;
-          return this.renderItem(nodeData, escape);
+          // data уже содержит все необходимые поля благодаря options API
+          return this.renderItem(data, escape);
         },
         option_create: (data, escape) => {
           return `<div class="create">Добавить <strong>${escape(data.input)}</strong>&hellip;</div>`;
@@ -272,14 +299,11 @@ class TomSelectCategoryTree {
       score: (search) => {
         const self = this;
         return function(item) {
-          // Найти полные данные узла
-          const nodeData = self.flatNodes.find(n => n.id === parseInt(item.id));
-          if (!nodeData) return 0;
-
+          // item уже содержит все необходимые поля благодаря options API
           // Родительские категории не показывать в результатах поиска
-          if (!nodeData.isLeaf && search) return 0;
+          if (!item.isLeaf && search) return 0;
 
-          return self.fuzzyScore(search, nodeData);
+          return self.fuzzyScore(search, item);
         };
       },
 
@@ -302,11 +326,20 @@ class TomSelectCategoryTree {
 
       // onChange callback
       onChange: (value) => {
+        // Обновить отображение пути
+        this.updatePathDisplay(value);
+
         // Trigger change event на оригинальном select для compatibility
         const event = new Event('change', { bubbles: true });
         this.selectElement.dispatchEvent(event);
       }
     });
+
+    // Установить предвыбранное значение если указано
+    if (this.options.selectedId) {
+      this.tomSelectInstance.setValue(this.options.selectedId, true); // silent = true
+      this.updatePathDisplay(this.options.selectedId);
+    }
 
     return this.tomSelectInstance;
   }
@@ -330,6 +363,7 @@ class TomSelectCategoryTree {
     if (!this.tomSelectInstance) return;
 
     this.tomSelectInstance.setValue(categoryId || '', true); // silent = true
+    this.updatePathDisplay(categoryId);
   }
 
   /**


### PR DESCRIPTION
PROBLEM SOLVED:
After extensive debugging (5 iterations), identified root cause of hang:
perl command inside if statement with 2>&1 redirect causes blocking I/O
when running under sudo.

FINAL SOLUTION:
Execute perl separately, then check exit code:

```bash
# Working approach:
perl -i.bak -pe '...' "$file" 2>&1  # Execute separately
local perl_exit=$?                   # Capture exit code
if [[ $perl_exit -eq 0 ]]; then     # Check in separate statement
```

vs broken:
```bash
# Hangs under sudo:
if perl -i.bak -pe '...' "$file" 2>&1; then
```

CLEANED OUTPUT:
Removed verbose diagnostics, keeping only essential messages:

BEFORE (verbose):
```
   Repository: /home/...
   Files to update: 5
   Starting file processing...
  → Checking: add.html...
    File exists, checking permissions...
    Permissions OK, running replacement...
    Running perl -i.bak...
    Perl exit code: 0
    Perl completed, cleaning backup...
    Backup removed
    Counter updated: 1
    ✓ Updated: add.html
```

AFTER (clean):
```
🔄 Updating cache versions to: 20251103_1328
  ✓ Updated: add.html
  ✓ Updated: addplan.html
  ✓ Updated: edit.html
  ✓ Updated: facts.html
  ✓ Updated: plan.html
✅ Cache versions updated in 5 files
```

FEATURES:
- ✓ Automatic version generation (timestamp)
- ✓ 5 HTML files updated automatically
- ✓ Backup files (.bak) auto-removed
- ✓ Error handling with rollback
- ✓ Works reliably with sudo
- ✓ Clean, concise output
- ✓ Integrated into deploy.sh

EVOLUTION (5 iterations):
1. sed -i with ? → hang on regex
2. sed + [?] + timeout → hang on sed
3. perl + temp + cat → hang on cat redirect
4. perl -i inside if → hang on blocking I/O
5. perl -i separate execution → ✓ WORKS

DEPLOYMENT INTEGRATION:
deploy.sh automatically calls:
  run_cache_busting "auto" "$SCRIPT_DIR"
before code synchronization, ensuring browser cache refresh.

🤖 Generated with Claude Code

Co-Authored-By: Claude <noreply@anthropic.com>