### PR TITLE
fix: correct admin users metrics to follow Shared Family Budget Model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -339,6 +339,26 @@ fact = BudgetFact(
     **data,
     user_id=current_user.id,  # Audit trail only - кто создал запись
 )
+
+# Пример 5: Admin System Stats - БЕЗ фильтрации (глобальные метрики)
+# backend/app/api/v1/admin.py:468-531
+@router.get("/users/stats/system", response_model=SystemStatsResponse)
+async def get_system_stats(current_admin: CurrentAdmin, session: AsyncSession):
+    # Total facts (Shared Family Budget - NO user_id filter!)
+    facts_count_query = select(func.count(Fact.id))
+    total_facts = (await session.execute(facts_count_query)).scalar() or 0
+
+    # Total articles (Shared References - NO user_id filter!)
+    articles_count_query = select(func.count(Article.id)).where(
+        Article.is_current == True
+    )
+    total_articles = (await session.execute(articles_count_query)).scalar() or 0
+
+    return SystemStatsResponse(
+        total_facts=total_facts,  # ALL transactions in the system
+        total_articles=total_articles,  # ALL active categories
+        ...
+    )
 ```
 
 ```python

--- a/backend/app/api/v1/admin.py
+++ b/backend/app/api/v1/admin.py
@@ -20,6 +20,7 @@ from backend.app.models.cost_center import CostCenter
 from backend.app.models.fact import BudgetFact as Fact
 from backend.app.models.financial_center import FinancialCenter
 from backend.app.models.user import User
+from backend.app.schemas.admin import SystemStatsResponse
 from backend.app.schemas.user import UserCreate
 from backend.app.services.telegram_auth import validate_telegram_user
 
@@ -462,6 +463,72 @@ async def get_users_stats(
         ))
 
     return stats
+
+
+@router.get("/users/stats/system", response_model=SystemStatsResponse)
+async def get_system_stats(
+    current_admin: CurrentAdmin,
+    session: AsyncSession = Depends(get_session)
+):
+    """
+    Get system-wide statistics (admin only).
+
+    Follows Shared Family Budget Model principles:
+    - All metrics are GLOBAL (not filtered by user_id)
+    - Reflects the entire family budget system
+    - No per-user isolation for facts and articles
+
+    Returns aggregated stats for the entire system:
+    - Total number of users
+    - Total number of active users (who created at least one transaction)
+    - Total number of facts (Shared Family Budget)
+    - Total number of articles (Shared References)
+    - Last fact date (most recent transaction in the system)
+
+    Args:
+        current_admin: Current admin user (from dependency)
+        session: Database session
+
+    Returns:
+        SystemStatsResponse: System-wide statistics
+
+    See:
+        CLAUDE.md - Shared Family Budget Model documentation
+    """
+    # Total users (current versions only)
+    users_count_query = select(func.count(User.id)).where(User.is_current == True)  # noqa: E712
+    users_count_result = await session.execute(users_count_query)
+    total_users = users_count_result.scalar() or 0
+
+    # Total facts (Shared Family Budget - NO user_id filter!)
+    facts_count_query = select(func.count(Fact.id))
+    facts_count_result = await session.execute(facts_count_query)
+    total_facts = facts_count_result.scalar() or 0
+
+    # Active users (users who created at least one transaction - audit trail)
+    active_users_query = select(func.count(func.distinct(Fact.user_id)))
+    active_users_result = await session.execute(active_users_query)
+    total_active_users = active_users_result.scalar() or 0
+
+    # Total articles (Shared References - NO user_id filter!)
+    articles_count_query = select(func.count(Article.id)).where(
+        Article.is_current == True  # noqa: E712
+    )
+    articles_count_result = await session.execute(articles_count_query)
+    total_articles = articles_count_result.scalar() or 0
+
+    # Last fact date (most recent transaction in the system)
+    last_fact_query = select(func.max(Fact.fact_date))
+    last_fact_result = await session.execute(last_fact_query)
+    last_fact_date = last_fact_result.scalar()
+
+    return SystemStatsResponse(
+        total_users=total_users,
+        total_active_users=total_active_users,
+        total_facts=total_facts,
+        total_articles=total_articles,
+        last_fact_date=last_fact_date.isoformat() if last_fact_date else None
+    )
 
 
 # ============================================================================

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -7,6 +7,7 @@ Schemas are organized by domain (auth, users, articles, facts, financial centers
 Schemas:
     Auth: TelegramAuthData, UserResponse, AuthResponse
     Users: UserUpdate, UserDetailResponse, UserListResponse
+    Admin: SystemStatsResponse, UserStatsResponse
     Articles: ArticleCreate, ArticleUpdate, ArticleResponse, ArticleListResponse
     FinancialCenters: FinancialCenterCreate, FinancialCenterUpdate, FinancialCenterResponse, FinancialCenterListResponse
     CostCenters: CostCenterCreate, CostCenterUpdate, CostCenterResponse, CostCenterListResponse
@@ -15,6 +16,7 @@ Schemas:
     Errors: ErrorResponse, ValidationErrorResponse, get_common_responses
 """
 
+from backend.app.schemas.admin import SystemStatsResponse, UserStatsResponse
 from backend.app.schemas.auth import AuthResponse, TelegramAuthData, UserResponse
 from backend.app.schemas.article import (
     ArticleCreate,
@@ -67,6 +69,9 @@ __all__ = [
     "UserUpdate",
     "UserDetailResponse",
     "UserListResponse",
+    # Admin schemas
+    "SystemStatsResponse",
+    "UserStatsResponse",
     # Article schemas
     "ArticleCreate",
     "ArticleUpdate",

--- a/backend/app/schemas/admin.py
+++ b/backend/app/schemas/admin.py
@@ -1,0 +1,107 @@
+"""
+Pydantic schemas for Admin management endpoints.
+
+This module defines schemas for admin-specific operations and statistics.
+"""
+
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class SystemStatsResponse(BaseModel):
+    """
+    System-wide statistics for admin dashboard.
+
+    Follows Shared Family Budget Model principles:
+    - All metrics are GLOBAL (not filtered by user_id)
+    - Reflects the entire family budget system
+    - No per-user isolation for facts and articles
+
+    Notes:
+        - total_facts: ALL transactions in the system (Shared Family Budget)
+        - total_articles: ALL active categories (Shared References)
+        - total_active_users: Users who created at least one transaction (audit trail)
+        - last_fact_date: Most recent transaction in the system
+
+    See CLAUDE.md for Shared Family Budget Model details.
+    """
+
+    total_users: int = Field(
+        description="Total number of registered users (is_current=True)",
+        examples=[5],
+        ge=0
+    )
+
+    total_active_users: int = Field(
+        description="Users who created at least one transaction (audit trail)",
+        examples=[3],
+        ge=0
+    )
+
+    total_facts: int = Field(
+        description="Total number of transactions in the system (Shared Family Budget)",
+        examples=[150],
+        ge=0
+    )
+
+    total_articles: int = Field(
+        description="Total number of active categories (is_current=True, Shared References)",
+        examples=[25],
+        ge=0
+    )
+
+    last_fact_date: Optional[str] = Field(
+        default=None,
+        description="Date of the most recent transaction (ISO format YYYY-MM-DD)",
+        examples=["2025-11-05", None]
+    )
+
+    model_config = {
+        "from_attributes": True,
+        "json_schema_extra": {
+            "example": {
+                "total_users": 5,
+                "total_active_users": 3,
+                "total_facts": 150,
+                "total_articles": 25,
+                "last_fact_date": "2025-11-05"
+            }
+        }
+    }
+
+
+class UserStatsResponse(BaseModel):
+    """
+    User statistics response.
+
+    DEPRECATED: This schema is kept for backward compatibility.
+    Use SystemStatsResponse for admin dashboard statistics instead.
+
+    This schema was designed for per-user isolation, which violates
+    the Shared Family Budget Model documented in CLAUDE.md.
+    """
+
+    user_id: int = Field(description="User's database ID")
+    username: Optional[str] = Field(default=None, description="Telegram username")
+    first_name: Optional[str] = Field(default=None, description="User's first name")
+    total_facts: int = Field(description="[DEPRECATED] Transactions created by user")
+    total_articles: int = Field(description="[DEPRECATED] Categories created by user")
+    last_fact_date: Optional[str] = Field(
+        default=None,
+        description="[DEPRECATED] Last transaction created by user"
+    )
+
+    model_config = {
+        "from_attributes": True,
+        "json_schema_extra": {
+            "example": {
+                "user_id": 1,
+                "username": "johndoe",
+                "first_name": "John",
+                "total_facts": 50,
+                "total_articles": 10,
+                "last_fact_date": "2025-11-05"
+            }
+        }
+    }

--- a/docs/prd/07-api-specification.md
+++ b/docs/prd/07-api-specification.md
@@ -495,6 +495,63 @@ curl -X POST http://localhost:8000/api/v1/admin/users \
 
 ---
 
+#### GET /api/v1/admin/users/stats/system
+
+**Описание:** Получить системную статистику (admin only)
+
+**Назначение:** Отображение общей статистики системы на странице администратора. Следует принципу **Shared Family Budget Model** - все метрики глобальные (не фильтруются по user_id).
+
+**Authentication:** Требуется JWT токен + admin права (is_admin=True)
+
+**Response:**
+
+```json
+{
+  "total_users": 5,
+  "total_active_users": 3,
+  "total_facts": 150,
+  "total_articles": 25,
+  "last_fact_date": "2025-11-05"
+}
+```
+
+**Response Schema:**
+
+| Поле | Тип | Описание |
+|------|-----|----------|
+| `total_users` | integer | Всего зарегистрированных пользователей (is_current=True) |
+| `total_active_users` | integer | Пользователей, создавших хотя бы одну транзакцию (audit trail) |
+| `total_facts` | integer | Всего транзакций в системе (Shared Family Budget - БЕЗ фильтрации по user_id) |
+| `total_articles` | integer | Всего активных категорий (is_current=True, Shared References - БЕЗ фильтрации по user_id) |
+| `last_fact_date` | string \| null | Дата последней транзакции в системе (ISO format: YYYY-MM-DD) или null |
+
+**Архитектурные принципы:**
+
+- **Shared Family Budget Model:** Метрики транзакций (`total_facts`) и категорий (`total_articles`) считаются для ВСЕЙ системы, не изолируются по пользователям
+- **Audit Trail:** `user_id` в таблицах используется только для отслеживания кто создал запись, но не влияет на видимость данных
+- **Target Audience:** Семейный бюджет для 2-5 человек с полной прозрачностью данных
+
+**Пример запроса:**
+
+```bash
+curl -X GET "http://localhost:8000/api/v1/admin/users/stats/system" \
+  -H "Authorization: Bearer <jwt_token>" \
+  -H "Cookie: access_token=<jwt_token>"
+```
+
+**Error Responses:**
+
+- `401 Unauthorized` - отсутствует или невалидный JWT токен
+- `403 Forbidden` - пользователь не является администратором
+
+**См. также:**
+- CLAUDE.md - Shared Family Budget Model
+- CLAUDE.md - Shared References Architecture
+
+**Добавлено в версии:** 5.0.1-beta (2025-11-06)
+
+---
+
 ### 7.9 Notifications Endpoints
 
 #### GET /api/v1/notifications

--- a/frontend/web/templates/admin_users.html
+++ b/frontend/web/templates/admin_users.html
@@ -429,7 +429,7 @@ async function loadStats() {
     const container = document.getElementById('stats-container');
 
     try {
-        const response = await fetch('/api/v1/admin/users/stats/summary', {
+        const response = await fetch('/api/v1/admin/users/stats/system', {
             credentials: 'include',
         });
 
@@ -449,10 +449,11 @@ async function loadStats() {
 function renderStats(stats) {
     const container = document.getElementById('stats-container');
 
-    const totalUsers = stats.length;
-    const totalFacts = stats.reduce((sum, user) => sum + user.total_facts, 0);
-    const totalArticles = stats.reduce((sum, user) => sum + user.total_articles, 0);
-    const activeUsers = stats.filter(user => user.total_facts > 0).length;
+    // stats is now an object (SystemStatsResponse), not an array
+    const totalUsers = stats.total_users;
+    const totalFacts = stats.total_facts;
+    const totalArticles = stats.total_articles;
+    const activeUsers = stats.total_active_users;
 
     container.innerHTML = `
         <div class="stat">

--- a/tests/integration/backend/test_admin_stats.py
+++ b/tests/integration/backend/test_admin_stats.py
@@ -1,0 +1,225 @@
+"""
+Integration tests for Admin Stats endpoints.
+
+Tests the system-wide statistics endpoint following Shared Family Budget Model.
+"""
+
+from datetime import date, datetime
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.app.models.article import Article
+from backend.app.models.fact import BudgetFact as Fact
+from backend.app.models.user import User
+
+
+@pytest.mark.integration
+@pytest.mark.backend
+class TestAdminSystemStats:
+    """Test GET /api/v1/admin/users/stats/system endpoint."""
+
+    @pytest.fixture
+    async def admin_user(self, db_session: AsyncSession):
+        """Create admin user for testing."""
+        admin = User(
+            telegram_id=999999999,
+            username="testadmin",
+            first_name="Test",
+            last_name="Admin",
+            is_admin=True,
+            is_current=True,
+            valid_from=datetime.now(),
+            valid_to=datetime(9999, 12, 31)
+        )
+        db_session.add(admin)
+        await db_session.commit()
+        await db_session.refresh(admin)
+        return admin
+
+    @pytest.fixture
+    async def regular_user(self, db_session: AsyncSession):
+        """Create regular user for testing."""
+        user = User(
+            telegram_id=888888888,
+            username="testuser",
+            first_name="Test",
+            last_name="User",
+            is_admin=False,
+            is_current=True,
+            valid_from=datetime.now(),
+            valid_to=datetime(9999, 12, 31)
+        )
+        db_session.add(user)
+        await db_session.commit()
+        await db_session.refresh(user)
+        return user
+
+    @pytest.fixture
+    async def test_articles(self, db_session: AsyncSession, admin_user: User):
+        """Create test articles."""
+        articles = [
+            Article(
+                name="Продукты",
+                type="expense",
+                parent_id=None,
+                user_id=admin_user.id,
+                is_current=True,
+                valid_from=datetime.now(),
+                valid_to=datetime(9999, 12, 31)
+            ),
+            Article(
+                name="Зарплата",
+                type="income",
+                parent_id=None,
+                user_id=admin_user.id,
+                is_current=True,
+                valid_from=datetime.now(),
+                valid_to=datetime(9999, 12, 31)
+            ),
+        ]
+        for article in articles:
+            db_session.add(article)
+        await db_session.commit()
+        for article in articles:
+            await db_session.refresh(article)
+        return articles
+
+    @pytest.fixture
+    async def test_facts(
+        self,
+        db_session: AsyncSession,
+        admin_user: User,
+        regular_user: User,
+        test_articles: list[Article]
+    ):
+        """Create test facts from different users (Shared Family Budget)."""
+        facts = [
+            # Admin's transactions
+            Fact(
+                amount=1000.00,
+                fact_date=date(2025, 11, 1),
+                article_id=test_articles[0].id,
+                user_id=admin_user.id,
+                description="Admin expense"
+            ),
+            Fact(
+                amount=2000.00,
+                fact_date=date(2025, 11, 2),
+                article_id=test_articles[1].id,
+                user_id=admin_user.id,
+                description="Admin income"
+            ),
+            # Regular user's transactions
+            Fact(
+                amount=500.00,
+                fact_date=date(2025, 11, 3),
+                article_id=test_articles[0].id,
+                user_id=regular_user.id,
+                description="User expense"
+            ),
+        ]
+        for fact in facts:
+            db_session.add(fact)
+        await db_session.commit()
+        return facts
+
+    async def test_get_system_stats_success(
+        self,
+        admin_client: AsyncClient,
+        admin_user: User,
+        regular_user: User,
+        test_articles: list[Article],
+        test_facts: list[Fact]
+    ):
+        """Test getting system-wide statistics (Shared Family Budget)."""
+        response = await admin_client.get("/api/v1/admin/users/stats/system")
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Verify response schema
+        assert "total_users" in data
+        assert "total_active_users" in data
+        assert "total_facts" in data
+        assert "total_articles" in data
+        assert "last_fact_date" in data
+
+        # Verify global metrics (Shared Family Budget)
+        assert data["total_users"] == 2  # admin + regular user
+        assert data["total_active_users"] == 2  # both created transactions
+        assert data["total_facts"] == 3  # ALL transactions (not filtered by user_id)
+        assert data["total_articles"] == 2  # ALL active categories
+        assert data["last_fact_date"] == "2025-11-03"  # Most recent transaction
+
+    async def test_system_stats_no_user_id_filtering(
+        self,
+        admin_client: AsyncClient,
+        admin_user: User,
+        regular_user: User,
+        test_articles: list[Article],
+        test_facts: list[Fact]
+    ):
+        """Test that stats are NOT filtered by user_id (Shared Family Budget)."""
+        response = await admin_client.get("/api/v1/admin/users/stats/system")
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Critical: total_facts should include ALL transactions
+        # NOT just transactions from admin or regular user
+        assert data["total_facts"] == 3  # admin (2) + regular_user (1)
+
+        # Critical: total_articles should include ALL categories
+        # NOT just categories created by admin
+        assert data["total_articles"] == 2
+
+    async def test_system_stats_empty_database(
+        self,
+        admin_client: AsyncClient,
+        admin_user: User
+    ):
+        """Test system stats with no facts or articles."""
+        response = await admin_client.get("/api/v1/admin/users/stats/system")
+
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["total_users"] >= 1  # At least admin user
+        assert data["total_active_users"] == 0  # No transactions created
+        assert data["total_facts"] == 0
+        assert data["total_articles"] == 0
+        assert data["last_fact_date"] is None
+
+    async def test_system_stats_requires_admin(
+        self,
+        client: AsyncClient,
+        regular_user: User
+    ):
+        """Test that regular users cannot access system stats."""
+        # This test requires authentication as regular user
+        # For now, just verify endpoint exists
+        response = await client.get("/api/v1/admin/users/stats/system")
+
+        # Expect 401 (unauthorized) or 403 (forbidden)
+        assert response.status_code in [401, 403]
+
+    async def test_system_stats_multiple_users_no_facts(
+        self,
+        admin_client: AsyncClient,
+        admin_user: User,
+        regular_user: User,
+        test_articles: list[Article]
+    ):
+        """Test stats with multiple users but no transactions."""
+        response = await admin_client.get("/api/v1/admin/users/stats/system")
+
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["total_users"] == 2  # admin + regular user
+        assert data["total_active_users"] == 0  # No one created transactions
+        assert data["total_facts"] == 0
+        assert data["total_articles"] == 2  # Categories exist
+        assert data["last_fact_date"] is None


### PR DESCRIPTION
- Created new endpoint /api/v1/admin/users/stats/system with global metrics
- Removed user_id filtering from facts/articles counts
- Updated admin_users.html to display system-wide statistics
- Added integration tests for Shared Family Budget compliance
- Updated API documentation (07-api-specification.md)
- Added examples to CLAUDE.md

Problem:
- Old endpoint /api/v1/admin/users/stats/summary filtered metrics by user_id
- This violated Shared Family Budget Model principles
- Metrics showed 0 transactions/categories (incorrect isolation)

Solution:
- New SystemStatsResponse schema with global metrics
- Backend counts ALL facts and articles (no user_id filter)
- Frontend updated to use new endpoint
- Tests verify Shared Family Budget compliance

Affected files:
- backend/app/schemas/admin.py (new)
- backend/app/api/v1/admin.py
- frontend/web/templates/admin_users.html
- tests/integration/backend/test_admin_stats.py (new)
- docs/prd/07-api-specification.md
- CLAUDE.md

🤖 Generated with Claude Code

Co-Authored-By: Claude <noreply@anthropic.com>