### PR TITLE
fix(frontend): предотвратить ошибки загрузки справочников для неавторизованных пользователей

### DIFF
--- a/docs/prd/09-security-authentication.md
+++ b/docs/prd/09-security-authentication.md
@@ -263,5 +263,148 @@ async def telegram_auth(request: Request, data: TelegramAuthData):
 **Telegram bot flood protection:**
 python-telegram-bot имеет встроенную защиту от флуда.
 
+### 9.8 Graceful Degradation для неавторизованных пользователей
+
+**Проблема:**
+При доступе к защищенным ресурсам (справочники, API endpoints) неавторизованный пользователь получает HTTP 401 ошибки, которые могут генерировать шумные error messages в UI.
+
+**Решение (реализовано в v5.0.0-beta):**
+
+#### 9.8.1 Frontend: Условный рендеринг (index.html)
+
+**Jinja2 Template Guards:**
+```html
+{% if user %}
+    <!-- Модальные формы добавления транзакций/планов -->
+    {{ transaction_modal('modal_add_transaction') }}
+    {{ plan_modal('modal_add_plan') }}
+
+    <!-- JavaScript инициализация справочников -->
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            loadCategories();
+            loadFinancialCenters();
+            loadCostCenters();
+        });
+    </script>
+{% endif %}
+```
+
+**Защита:**
+- Модальные формы НЕ рендерятся в DOM для неавторизованных пользователей
+- JavaScript код инициализации НЕ выполняется
+- Библиотеки (Choices.js, ChoicesCategoryTree) НЕ загружаются
+
+#### 9.8.2 Frontend: DOM Element Checks (defense in depth)
+
+**Проверка существования select элементов перед инициализацией:**
+```javascript
+async function loadTransactionCategories() {
+    try {
+        // Check if select element exists (defense in depth)
+        const selectElement = document.querySelector('#form_modal_add_transaction select[name="article_id"]');
+        if (!selectElement) {
+            console.log('[loadTransactionCategories] Select element not found - skipping initialization');
+            return;
+        }
+
+        // ... инициализация ChoicesCategoryTree
+    } catch (error) {
+        console.error('Failed to load transaction categories:', error);
+        showToast('Ошибка при загрузке категорий транзакций', 'error');
+    }
+}
+```
+
+#### 9.8.3 Frontend: Silent Fail для 401 ошибок
+
+**Graceful degradation в loadFinancialCenters():**
+```javascript
+async function loadFinancialCenters() {
+    try {
+        const response = await fetch('/api/v1/financial-centers?limit=1000');
+        if (!response.ok) {
+            // Graceful degradation for 401 Unauthorized
+            if (response.status === 401) {
+                console.log('[loadFinancialCenters] User not authenticated - not loaded');
+                return;  // Silent fail - don't show error toast
+            }
+
+            // For other errors, show error toast
+            console.warn('Failed to fetch: HTTP', response.status);
+            showToast('Не удалось загрузить список ЦФО', 'error');
+            return;
+        }
+        // ... обработка данных
+    } catch (error) {
+        console.error('Failed to load financial centers:', error);
+        showToast('Ошибка при загрузке ЦФО', 'error');
+    }
+}
+```
+
+#### 9.8.4 Shared Component: ChoicesCategoryTree graceful degradation
+
+**ChoicesCategoryTree.loadCategories() с 401 handling:**
+```javascript
+async loadCategories() {
+    const url = `${this.options.apiBaseUrl}/articles?type=${this.options.type}`;
+
+    const response = await fetch(url, {
+        headers: headers,
+        credentials: 'same-origin',
+    });
+
+    if (!response.ok) {
+        // Graceful degradation for 401 Unauthorized
+        if (response.status === 401) {
+            console.log('[ChoicesCategoryTree] User not authenticated - categories not loaded');
+            this.categories = [];  // Empty categories array
+            return;  // Silent fail - don't throw error
+        }
+
+        // For other errors, throw with detailed status
+        throw new Error(`Failed to load categories: HTTP ${response.status}`);
+    }
+
+    const data = await response.json();
+    this.categories = data.articles || [];
+}
+```
+
+**Преимущества:**
+- Компонент используется в Telegram WebApps (Bearer token auth) и web interface (cookie auth)
+- Graceful degradation работает для обоих случаев
+- Не показывает error alerts для ожидаемых 401 статусов
+
+#### 9.8.5 Backend: Public vs Protected Endpoints
+
+**Public endpoints (не требуют авторизацию):**
+- `/` - главная страница (использует `CurrentUserOptional`)
+- `/analytics` - страница аналитики (использует `CurrentUserOptional`)
+- `/api/v1/auth/*` - authentication endpoints
+- `/static/*`, `/webapp/*` - статические файлы
+
+**Protected endpoints (требуют CurrentUser dependency):**
+- `/api/v1/articles` - список категорий бюджета
+- `/api/v1/financial-centers` - список ЦФО
+- `/api/v1/cost-centers` - список МВЗ
+- `/api/v1/facts/*` - CRUD транзакций
+
+**ВАЖНО:** Справочники намеренно защищены авторизацией, так как содержат бизнес-логику и категории семейного бюджета (не public data).
+
+#### 9.8.6 UX Benefits
+
+**Для неавторизованных пользователей:**
+- ✅ Чистая консоль браузера (нет 401 ошибок)
+- ✅ Нет лишних error toast уведомлений
+- ✅ Нет попыток загрузки защищенных ресурсов
+- ✅ Меньший DOM (модальные формы не рендерятся)
+- ✅ Меньше загруженных JS библиотек
+
+**Для авторизованных пользователей:**
+- ✅ Все функции доступны как обычно
+- ✅ Никаких изменений в UX
+
 ---
 

--- a/frontend/shared/static/js/choicesCategoryTree.js
+++ b/frontend/shared/static/js/choicesCategoryTree.js
@@ -138,7 +138,15 @@ class ChoicesCategoryTree {
         });
 
         if (!response.ok) {
-            throw new Error(`Failed to load categories: ${response.status}`);
+            // Graceful degradation for 401 Unauthorized (user not authenticated)
+            if (response.status === 401) {
+                console.log('[ChoicesCategoryTree] User not authenticated - categories not loaded (this is expected for unauthenticated users)');
+                this.categories = [];  // Empty categories array
+                return;  // Silent fail - don't throw error
+            }
+
+            // For other errors, throw with detailed status
+            throw new Error(`Failed to load categories: HTTP ${response.status} ${response.statusText}`);
         }
 
         const data = await response.json();
@@ -336,7 +344,14 @@ class ChoicesCategoryTree {
         });
 
         if (!response.ok) {
-            throw new Error(`Failed to load ancestors: ${response.status}`);
+            // Graceful degradation for 401 Unauthorized (user not authenticated)
+            if (response.status === 401) {
+                console.log('[ChoicesCategoryTree] User not authenticated - ancestors not loaded');
+                return [];  // Empty path array
+            }
+
+            // For other errors, throw with detailed status
+            throw new Error(`Failed to load ancestors: HTTP ${response.status} ${response.statusText}`);
         }
 
         const data = await response.json();

--- a/frontend/web/templates/index.html
+++ b/frontend/web/templates/index.html
@@ -144,15 +144,18 @@
     {% endif %}
 </div>
 
-<!-- Modal: Добавить транзакцию -->
-{{ transaction_modal('modal_add_transaction') }}
+{% if user %}
+    <!-- Modal: Добавить транзакцию -->
+    {{ transaction_modal('modal_add_transaction') }}
 
-<!-- Modal: Добавить план -->
-{{ plan_modal('modal_add_plan') }}
+    <!-- Modal: Добавить план -->
+    {{ plan_modal('modal_add_plan') }}
+{% endif %}
 
 {% endblock %}
 
 {% block extra_scripts %}
+{% if user %}
 <!-- Choices.js Library -->
 <link rel="stylesheet" href="/static/css/vendor/choices.min.css">
 <link rel="stylesheet" href="/static/css/choices-tailwind.min.css?v=PLACEHOLDER">
@@ -297,6 +300,13 @@ async function loadCategories() {
 // Загрузить категории только для формы транзакций
 async function loadTransactionCategories() {
     try {
+        // Check if select element exists (defense in depth)
+        const selectElement = document.querySelector('#form_modal_add_transaction select[name="article_id"]');
+        if (!selectElement) {
+            console.log('[loadTransactionCategories] Select element not found - skipping initialization');
+            return;
+        }
+
         // Get current transaction type
         const transactionType = document.querySelector('#form_modal_add_transaction input[name="record_type"]:checked')?.value || 'expense';
 
@@ -326,6 +336,13 @@ async function loadTransactionCategories() {
 // Загрузить категории только для формы планов
 async function loadPlanCategories() {
     try {
+        // Check if select element exists (defense in depth)
+        const selectElement = document.querySelector('#form_modal_add_plan select[name="article_id"]');
+        if (!selectElement) {
+            console.log('[loadPlanCategories] Select element not found - skipping initialization');
+            return;
+        }
+
         // Get current plan type
         const planType = document.querySelector('#form_modal_add_plan input[name="plan_type"]:checked')?.value || 'expense';
 
@@ -357,6 +374,13 @@ async function loadFinancialCenters() {
     try {
         const response = await fetch('/api/v1/financial-centers?limit=1000&include_global=true&is_current=true');
         if (!response.ok) {
+            // Graceful degradation for 401 Unauthorized (user not authenticated)
+            if (response.status === 401) {
+                console.log('[loadFinancialCenters] User not authenticated - financial centers not loaded');
+                return;  // Silent fail - don't show error toast
+            }
+
+            // For other errors, show error toast
             console.warn('Failed to fetch financial centers: HTTP', response.status);
             showToast('Не удалось загрузить список ЦФО', 'error');
             return;
@@ -757,4 +781,5 @@ function setupPlanTypeButtons() {
 }
 </script>
 
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
Проблема:
- При входе на главную страницу без авторизации JavaScript пытался
  загрузить справочники (categories, financial centers, cost centers)
- API endpoints возвращали 401 для неавторизованных пользователей
- Показывались error toast уведомления "Не удалось загрузить список ЦФО"

Решение:
1. ChoicesCategoryTree: добавлен graceful degradation для 401 ошибок
   - Silent fail для unauthenticated users
   - Улучшены error messages

2. index.html: обернут script блок в {% if user %} условие
   - JavaScript код не выполняется для неавторизованных пользователей
   - Модальные формы не рендерятся в DOM
   - Добавлена проверка существования select элементов

3. Улучшена обработка ошибок в loadFinancialCenters()
   - Silent fail для 401 статуса
   - Toast показывается только для реальных ошибок (5xx, network)

4. Обновлена документация ПРД
   - Добавлен раздел об обработке неавторизованных пользователей
   - Документирован подход к graceful degradation

Затронутые файлы:
- frontend/shared/static/js/choicesCategoryTree.js
- frontend/web/templates/index.html
- docs/prd/09-security-authentication.md

Fixes: https://budget-dev.ikeniborn.ru/ - ошибки для неавторизованных

🤖 Generated with Claude Code

Co-Authored-By: Claude <noreply@anthropic.com>