### PR TITLE
fix(admin): добавить поле is_active в ArticleResponse схему

### DIFF
--- a/backend/app/api/v1/admin.py
+++ b/backend/app/api/v1/admin.py
@@ -58,6 +58,7 @@ class ArticleResponse(BaseModel):
     parent_id: int | None
     name: str
     type: str
+    is_active: bool
     is_current: bool
     valid_from: str
     valid_to: str | None


### PR DESCRIPTION
Root cause: Pydantic схема ArticleResponse не содержала поле is_active,
из-за чего JSON response не передавал признак архивности на frontend.

Результат: Frontend получал undefined для is_active и отображал
все категории как архивные (!undefined = true).

Решение: Добавлено поле is_active: bool в ArticleResponse схему.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>