### PR TITLE
Fix/quick-amounts-errors

### DIFF
--- a/backend/app/api/v1/analytics.py
+++ b/backend/app/api/v1/analytics.py
@@ -1458,7 +1458,7 @@ async def get_recommended_amounts(
         gt=0,
         description="Optional category ID filter (omit for global recommendations)"
     ),
-    type: Optional[str] = Query(
+    article_type: Optional[str] = Query(
         None,
         regex="^(income|expense)$",
         description="Optional transaction type filter: 'income' or 'expense' (omit for all types)"
@@ -1483,7 +1483,7 @@ async def get_recommended_amounts(
 
     Query Parameters:
         - article_id: Optional category filter (NULL = global recommendations)
-        - type: Optional type filter ('income' | 'expense' | NULL = all)
+        - article_type: Optional type filter ('income' | 'expense' | NULL = all)
         - record_type: 'fact' (actual transactions) or 'plan' (planned transactions)
         - period: Analysis period ('month' | 'quarter' | 'year')
 
@@ -1493,9 +1493,9 @@ async def get_recommended_amounts(
         - metadata: Detailed calculation info (sample_size, min/max/avg, period_days)
 
     Examples:
-        GET /api/v1/analytics/recommended-amounts?record_type=fact&type=expense
+        GET /api/v1/analytics/recommended-amounts?record_type=fact&article_type=expense
         GET /api/v1/analytics/recommended-amounts?article_id=5&record_type=fact
-        GET /api/v1/analytics/recommended-amounts?record_type=plan&type=income
+        GET /api/v1/analytics/recommended-amounts?record_type=plan&article_type=income
 
     Notes:
         - Pre-calculated values are populated by nightly scheduler (recalculate_recommended_amounts)
@@ -1525,7 +1525,7 @@ async def get_recommended_amounts(
 
     result = await session.execute(
         cache_query,
-        {"article_id": article_id, "type": type, "record_type": record_type, "period": period}
+        {"article_id": article_id, "type": article_type, "record_type": record_type, "period": period}
     )
     row = result.first()
 
@@ -1555,12 +1555,12 @@ async def get_recommended_amounts(
     # Step 2: Cache miss - fallback to defaults
     # Note: On-demand calculation via PostgreSQL function removed
     # Pre-calculated values are populated by nightly scheduler (recalculate_recommended_amounts)
-    # Determine default key based on record_type and type
-    if type is None:
-        # If type is not specified, default to expense for facts, income for plans
+    # Determine default key based on record_type and article_type
+    if article_type is None:
+        # If article_type is not specified, default to expense for facts, income for plans
         default_type = "expense" if record_type == "fact" else "income"
     else:
-        default_type = type
+        default_type = article_type
 
     default_key = (record_type, default_type)
     default_amounts = DEFAULT_AMOUNTS.get(default_key, DEFAULT_AMOUNTS[("fact", "expense")])

--- a/backend/app/schemas/analytics.py
+++ b/backend/app/schemas/analytics.py
@@ -53,7 +53,7 @@ class RecommendedAmountsMetadata(BaseModel):
     )
 
     period_days: int = Field(
-        ...,
+        90,  # Default to quarter (90 days) for backward compatibility with cached data
         gt=0,
         description="Analysis period in days (7=week, 30=month, 90=quarter, 365=year)",
         examples=[7, 30, 90, 365]

--- a/frontend/web/static/js/admin-facts-common.js
+++ b/frontend/web/static/js/admin-facts-common.js
@@ -51,9 +51,72 @@ function syncFiltersUI(filters) {
     }
 }
 
+/**
+ * Update quick amount button labels with new amounts.
+ *
+ * @param {string} formId - ID модальной формы
+ * @param {Array<number>} amounts - Array of 4 recommended amounts
+ */
+function updateQuickAmountButtons(formId, amounts) {
+    if (!amounts || amounts.length !== 4) {
+        console.warn('[updateQuickAmountButtons] Invalid amounts array:', amounts);
+        return;
+    }
+
+    // Find buttons in the specified form
+    const form = document.getElementById(formId);
+    if (!form) {
+        console.warn(`[updateQuickAmountButtons] Form ${formId} not found`);
+        return;
+    }
+
+    // Find quick amount buttons (need to select parent container then buttons)
+    const buttons = form.querySelectorAll('.btn[onclick*="Amount"]');
+
+    amounts.forEach((amount, index) => {
+        if (buttons[index]) {
+            const amountValue = parseFloat(amount);
+
+            // Update button text with formatted amount
+            buttons[index].textContent = formatAmountForButton(amountValue) + ' ₽';
+
+            // Update onclick handler
+            const funcName = formId.includes('transaction') ? 'setTransactionAmount' : 'setPlanAmount';
+            buttons[index].setAttribute('onclick', `${funcName}(${amountValue})`);
+        }
+    });
+}
+
+/**
+ * Format amount for button display.
+ *
+ * Examples:
+ * - 100 → "100"
+ * - 1000 → "1k"
+ * - 1500 → "1.5k"
+ * - 10000 → "10k"
+ *
+ * @param {number} amount - Amount to format
+ * @returns {string} Formatted amount string
+ */
+function formatAmountForButton(amount) {
+    if (amount >= 1000) {
+        const thousands = amount / 1000;
+        // Check if it's a round number
+        if (Number.isInteger(thousands)) {
+            return `${thousands}k`;
+        } else {
+            return `${thousands.toFixed(1)}k`;
+        }
+    }
+    return amount.toString();
+}
+
 // Export для использования в других файлах
 if (typeof window !== 'undefined') {
     window.AdminFactsCommon = {
-        syncFiltersUI: syncFiltersUI
+        syncFiltersUI: syncFiltersUI,
+        updateQuickAmountButtons: updateQuickAmountButtons,
+        formatAmountForButton: formatAmountForButton
     };
 }

--- a/frontend/web/templates/facts.html
+++ b/frontend/web/templates/facts.html
@@ -399,7 +399,7 @@ async function loadRecommendedAmounts(formId, recordType = 'fact', category = nu
             }
 
             if (type) {
-                params.append('type', type);
+                params.append('article_type', type);
             }
 
             // Call API

--- a/frontend/web/templates/index.html
+++ b/frontend/web/templates/index.html
@@ -575,7 +575,7 @@ async function loadRecommendedAmounts(formId, recordType = 'fact', category = nu
             }
 
             if (type) {
-                params.append('type', type);
+                params.append('article_type', type);
             }
 
             // Call API

--- a/frontend/web/templates/plan.html
+++ b/frontend/web/templates/plan.html
@@ -384,7 +384,7 @@ async function loadRecommendedAmounts(formId, recordType = 'plan', category = nu
             }
 
             if (type) {
-                params.append('type', type);
+                params.append('article_type', type);
             }
 
             // Call API


### PR DESCRIPTION
ПРОБЛЕМА:
- Старые записи в t_recommended_amounts не содержат period_days в metadata JSONB
- При cache hit Pydantic выдавал 422 ValidationError: "Field required"

РЕШЕНИЕ:
- Изменён Field(...) на Field(90) - дефолтное значение quarter
- Обеспечена обратная совместимость с существующими кешированными данными

🤖 Generated with Claude Code

Co-Authored-By: Claude <noreply@anthropic.com>