### PR TITLE
fix(import): fix select dropdowns sizes and consistency

### DIFF
--- a/frontend/web/templates/admin_import.html
+++ b/frontend/web/templates/admin_import.html
@@ -98,7 +98,7 @@
                         <label class="label py-0">
                             <span class="label-text text-xs">Категория (массово)</span>
                         </label>
-                        <select id="bulk-article" class="select select-bordered w-full">
+                        <select id="bulk-article" class="select select-bordered select-sm w-full">
                             <option value="">-- Выберите категорию --</option>
                         </select>
                     </div>
@@ -498,13 +498,13 @@ function renderStagingTable() {
                     </select>
                 </td>
                 <td>
-                    <select class="select select-bordered select-sm" id="fc-${record.id}" onchange="updateRecord(${record.id}, 'financial_center_id', this.value)">
+                    <select class="select select-bordered select-sm w-40 max-w-xs" id="fc-${record.id}" onchange="updateRecord(${record.id}, 'financial_center_id', this.value)">
                         <option value="">-- Выбрать --</option>
                         ${financialCentersData.map(fc => `<option value="${fc.id}" ${fc.id === record.financial_center_id ? 'selected' : ''}>${fc.name}</option>`).join('')}
                     </select>
                 </td>
                 <td>
-                    <select class="select select-bordered select-sm" id="cc-${record.id}" onchange="updateRecord(${record.id}, 'cost_center_id', this.value)">
+                    <select class="select select-bordered select-sm w-32 max-w-xs" id="cc-${record.id}" onchange="updateRecord(${record.id}, 'cost_center_id', this.value)">
                         <option value="">-- Нет --</option>
                         ${costCentersData.map(cc => `<option value="${cc.id}" ${cc.id === record.cost_center_id ? 'selected' : ''}>${cc.name}</option>`).join('')}
                     </select>


### PR DESCRIPTION
- Add select-sm class to bulk-article select for size consistency
- Add w-40 max-w-xs to financial center selects in table rows
- Add w-32 max-w-xs to cost center selects in table rows
- Fix vertical height issues with select elements
- Ensure consistent appearance across all dropdowns

Fixes visual issues where select placeholder/value was cut off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>