### PR TITLE
Feature/backup-monitoring

### DIFF
--- a/backend/app/api/health.py
+++ b/backend/app/api/health.py
@@ -169,7 +169,6 @@ def check_backup_status() -> ComponentHealth:
         possible_paths = [
             Path(__file__).parent.parent.parent.parent / "scripts" / "check_backup_health.sh",
             Path("/opt/budget/scripts/check_backup_health.sh"),
-            Path("/opt/familybudget/scripts/check_backup_health.sh"),
         ]
 
         script_path = None

--- a/backend/app/api/health.py
+++ b/backend/app/api/health.py
@@ -195,7 +195,13 @@ def check_backup_status() -> ComponentHealth:
         if result.returncode not in [0, 1, 2]:
             return ComponentHealth(
                 status="down",
-                message=f"Backup health check failed with exit code {result.returncode}"
+                message=f"Backup health check failed with exit code {result.returncode}. stderr: {result.stderr[:200]}"
+            )
+
+        if not result.stdout or result.stdout.strip() == "":
+            return ComponentHealth(
+                status="down",
+                message=f"Backup health check returned empty output. stderr: {result.stderr[:200]}, returncode: {result.returncode}"
             )
 
         backup_data = json.loads(result.stdout)

--- a/backend/app/api/health.py
+++ b/backend/app/api/health.py
@@ -4,9 +4,12 @@ Health Check API Endpoints.
 Provides comprehensive health and readiness checks for monitoring systems.
 """
 
+import json
 import platform
+import subprocess
 import sys
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 
 import psutil
@@ -153,6 +156,92 @@ def get_system_info() -> dict[str, Any]:
             "platform": platform.system(),
             "python_version": sys.version.split()[0],
         }
+
+
+def check_backup_status() -> ComponentHealth:
+    """
+    Check backup status using check_backup_health.sh script.
+
+    Returns:
+        ComponentHealth: Backup status with latest backup info
+    """
+    try:
+        script_path = Path(__file__).parent.parent.parent.parent / "scripts" / "check_backup_health.sh"
+
+        if not script_path.exists():
+            return ComponentHealth(
+                status="down",
+                message="Backup health check script not found"
+            )
+
+        result = subprocess.run(
+            [str(script_path), "--json"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False
+        )
+
+        if result.returncode not in [0, 1, 2]:
+            return ComponentHealth(
+                status="down",
+                message=f"Backup health check failed with exit code {result.returncode}"
+            )
+
+        backup_data = json.loads(result.stdout)
+
+        latest_backup = backup_data.get("backups", {}).get("latest", "")
+        backup_count = backup_data.get("backups", {}).get("count", 0)
+        overall_status = backup_data.get("status", {}).get("overall", "unhealthy")
+
+        if latest_backup and latest_backup != "":
+            parts = latest_backup.split("_")
+            if len(parts) >= 3:
+                date_str = parts[1]
+                time_str = parts[2].replace(".sql.gz", "")
+                formatted_date = f"{date_str[:4]}-{date_str[4:6]}-{date_str[6:8]}"
+                formatted_time = f"{time_str[:2]}:{time_str[2:4]}:{time_str[4:6]}"
+                backup_datetime = f"{formatted_date} {formatted_time}"
+            else:
+                backup_datetime = latest_backup
+
+            backup_path = Path(backup_data.get("backups", {}).get("directory", "")) / latest_backup
+            if backup_path.exists():
+                backup_size_mb = backup_path.stat().st_size / (1024 * 1024)
+                size_info = f", Size: {backup_size_mb:.2f} MB"
+            else:
+                size_info = ""
+
+            status_map = {
+                "healthy": "up",
+                "unhealthy": "down"
+            }
+
+            return ComponentHealth(
+                status=status_map.get(overall_status, "down"),
+                message=f"Latest: {backup_datetime}, File: {latest_backup}{size_info}, Total backups: {backup_count}"
+            )
+        else:
+            return ComponentHealth(
+                status="down",
+                message="No backups found"
+            )
+
+    except subprocess.TimeoutExpired:
+        return ComponentHealth(
+            status="down",
+            message="Backup health check timed out"
+        )
+    except json.JSONDecodeError as e:
+        return ComponentHealth(
+            status="down",
+            message=f"Failed to parse backup health check output: {str(e)}"
+        )
+    except Exception as e:
+        return ComponentHealth(
+            status="down",
+            message=f"Backup health check error: {str(e)}"
+        )
 
 
 def calculate_uptime() -> float:
@@ -329,7 +418,12 @@ async def detailed_health_check(
     if db_health.status == "up":
         db_health.message = f"Database operational. Users: {db_stats['total_users']}, Facts: {db_stats['total_facts']}"
 
-    components = {"database": db_health}
+    backup_health = check_backup_status()
+
+    components = {
+        "database": db_health,
+        "backup": backup_health
+    }
 
     # Determine overall status
     overall_status = determine_overall_status(components)

--- a/backend/app/api/health.py
+++ b/backend/app/api/health.py
@@ -5,6 +5,7 @@ Provides comprehensive health and readiness checks for monitoring systems.
 """
 
 import json
+import os
 import platform
 import subprocess
 import sys
@@ -189,7 +190,12 @@ def check_backup_status() -> ComponentHealth:
             capture_output=True,
             text=True,
             timeout=5,
-            check=False
+            check=False,
+            env={
+                **os.environ.copy(),
+                "BACKUP_DIR": "/app/backups",
+                "PATH": os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin")
+            }
         )
 
         if result.returncode not in [0, 1, 2]:
@@ -199,9 +205,11 @@ def check_backup_status() -> ComponentHealth:
             )
 
         if not result.stdout or result.stdout.strip() == "":
+            stderr_preview = result.stderr[:500] if result.stderr else "(empty)"
+            stdout_preview = result.stdout[:200] if result.stdout else "(empty)"
             return ComponentHealth(
                 status="down",
-                message=f"Backup health check returned empty output. stderr: {result.stderr[:200]}, returncode: {result.returncode}"
+                message=f"Backup health check returned empty output. returncode: {result.returncode}, stdout: {stdout_preview}, stderr: {stderr_preview}"
             )
 
         backup_data = json.loads(result.stdout)

--- a/backend/app/api/health.py
+++ b/backend/app/api/health.py
@@ -166,12 +166,23 @@ def check_backup_status() -> ComponentHealth:
         ComponentHealth: Backup status with latest backup info
     """
     try:
-        script_path = Path(__file__).parent.parent.parent.parent / "scripts" / "check_backup_health.sh"
+        possible_paths = [
+            Path(__file__).parent.parent.parent.parent / "scripts" / "check_backup_health.sh",
+            Path("/opt/budget/scripts/check_backup_health.sh"),
+            Path("/opt/familybudget/scripts/check_backup_health.sh"),
+        ]
 
-        if not script_path.exists():
+        script_path = None
+        for path in possible_paths:
+            if path.exists():
+                script_path = path
+                break
+
+        if not script_path:
+            searched_paths = ", ".join(str(p) for p in possible_paths)
             return ComponentHealth(
                 status="down",
-                message="Backup health check script not found"
+                message=f"Backup health check script not found. Searched: {searched_paths}"
             )
 
         result = subprocess.run(

--- a/backend/app/api/health.py
+++ b/backend/app/api/health.py
@@ -4,11 +4,9 @@ Health Check API Endpoints.
 Provides comprehensive health and readiness checks for monitoring systems.
 """
 
-import json
-import os
 import platform
-import subprocess
 import sys
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -161,110 +159,69 @@ def get_system_info() -> dict[str, Any]:
 
 def check_backup_status() -> ComponentHealth:
     """
-    Check backup status using check_backup_health.sh script.
+    Check backup status by scanning backup directory.
+
+    Pure Python implementation - no bash scripts or Docker CLI needed.
 
     Returns:
         ComponentHealth: Backup status with latest backup info
     """
     try:
-        possible_paths = [
-            Path(__file__).parent.parent.parent.parent / "scripts" / "check_backup_health.sh",
-            Path("/opt/budget/scripts/check_backup_health.sh"),
-        ]
+        backup_dir = Path("/app/backups")
 
-        script_path = None
-        for path in possible_paths:
-            if path.exists():
-                script_path = path
-                break
-
-        if not script_path:
-            searched_paths = ", ".join(str(p) for p in possible_paths)
+        # Check if backup directory exists
+        if not backup_dir.exists():
             return ComponentHealth(
                 status="down",
-                message=f"Backup health check script not found. Searched: {searched_paths}"
+                message=f"Backup directory not found: {backup_dir}"
             )
 
-        result = subprocess.run(
-            [str(script_path), "--json"],
-            capture_output=True,
-            text=True,
-            timeout=5,
-            check=False,
-            env={
-                **os.environ.copy(),
-                "BACKUP_DIR": "/app/backups",
-                "PATH": os.environ.get("PATH", "/usr/local/bin:/usr/bin:/bin")
-            }
-        )
+        # Find all backup files (backup_YYYYMMDD_HHMMSS.sql.gz)
+        backup_files = list(backup_dir.glob("backup_*.sql.gz"))
 
-        if result.returncode not in [0, 1, 2]:
-            return ComponentHealth(
-                status="down",
-                message=f"Backup health check failed with exit code {result.returncode}. stderr: {result.stderr[:200]}"
-            )
-
-        if not result.stdout or result.stdout.strip() == "":
-            stderr_preview = result.stderr[:500] if result.stderr else "(empty)"
-            stdout_preview = result.stdout[:200] if result.stdout else "(empty)"
-            return ComponentHealth(
-                status="down",
-                message=f"Backup health check returned empty output. returncode: {result.returncode}, stdout: {stdout_preview}, stderr: {stderr_preview}"
-            )
-
-        backup_data = json.loads(result.stdout)
-
-        latest_backup = backup_data.get("backups", {}).get("latest", "")
-        backup_count = backup_data.get("backups", {}).get("count", 0)
-        overall_status = backup_data.get("status", {}).get("overall", "unhealthy")
-
-        if latest_backup and latest_backup != "":
-            parts = latest_backup.split("_")
-            if len(parts) >= 3:
-                date_str = parts[1]
-                time_str = parts[2].replace(".sql.gz", "")
-                formatted_date = f"{date_str[:4]}-{date_str[4:6]}-{date_str[6:8]}"
-                formatted_time = f"{time_str[:2]}:{time_str[2:4]}:{time_str[4:6]}"
-                backup_datetime = f"{formatted_date} {formatted_time}"
-            else:
-                backup_datetime = latest_backup
-
-            backup_path = Path(backup_data.get("backups", {}).get("directory", "")) / latest_backup
-            if backup_path.exists():
-                backup_size_mb = backup_path.stat().st_size / (1024 * 1024)
-                size_info = f", Size: {backup_size_mb:.2f} MB"
-            else:
-                size_info = ""
-
-            status_map = {
-                "healthy": "up",
-                "unhealthy": "down"
-            }
-
-            return ComponentHealth(
-                status=status_map.get(overall_status, "down"),
-                message=f"Latest: {backup_datetime}, File: {latest_backup}{size_info}, Total backups: {backup_count}"
-            )
-        else:
+        if not backup_files:
             return ComponentHealth(
                 status="down",
                 message="No backups found"
             )
 
-    except subprocess.TimeoutExpired:
+        # Sort by filename (contains timestamp) and get latest
+        backup_files.sort(reverse=True)
+        latest_backup = backup_files[0]
+
+        # Parse filename: backup_YYYYMMDD_HHMMSS.sql.gz
+        filename = latest_backup.name
+        parts = filename.split("_")
+
+        if len(parts) >= 3:
+            date_str = parts[1]  # YYYYMMDD
+            time_str = parts[2].replace(".sql.gz", "")  # HHMMSS
+
+            formatted_date = f"{date_str[:4]}-{date_str[4:6]}-{date_str[6:8]}"
+            formatted_time = f"{time_str[:2]}:{time_str[2:4]}:{time_str[4:6]}"
+            backup_datetime = f"{formatted_date} {formatted_time}"
+        else:
+            backup_datetime = filename
+
+        # Get file size
+        backup_size_mb = latest_backup.stat().st_size / (1024 * 1024)
+
+        # Check if backup is recent (< 26 hours old)
+        backup_age_seconds = time.time() - latest_backup.stat().st_mtime
+        backup_age_hours = backup_age_seconds / 3600
+
+        # Status: up if backup is recent and size > 100KB
+        status = "up" if (backup_age_hours < 26 and backup_size_mb > 0.1) else "down"
+
         return ComponentHealth(
-            status="down",
-            message="Backup health check timed out"
+            status=status,
+            message=f"Latest: {backup_datetime}, File: {filename}, Size: {backup_size_mb:.2f} MB, Total backups: {len(backup_files)}"
         )
-    except json.JSONDecodeError as e:
-        return ComponentHealth(
-            status="down",
-            message=f"Failed to parse backup health check output: {str(e)}"
-        )
+
     except Exception as e:
         return ComponentHealth(
             status="down",
-            message=f"Backup health check error: {str(e)}"
+            message=f"Backup check error: {str(e)}"
         )
 
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -477,6 +477,121 @@ collect_deployment_parameters() {
     echo ""
 }
 
+# =============================================================================
+# FIREWALL VALIDATION
+# =============================================================================
+
+validate_firewall_rules() {
+    step "Validating Firewall Rules"
+
+    # Check if UFW is installed
+    if ! command -v ufw &> /dev/null; then
+        warning "UFW not installed, skipping firewall validation"
+        return 0
+    fi
+
+    # Get current UFW status
+    local ufw_status
+    if ! ufw_status=$(sudo ufw status numbered 2>/dev/null); then
+        warning "Cannot read UFW status, skipping validation"
+        return 0
+    fi
+
+    local has_errors=false
+
+    # Check required ports
+    info "Checking required open ports..."
+
+    # SSH (22) - CRITICAL
+    if echo "$ufw_status" | grep -q "22/tcp.*ALLOW"; then
+        success "✓ Port 22 (SSH) is open"
+    else
+        error "✗ Port 22 (SSH) is NOT open - SSH access will be blocked!"
+        has_errors=true
+    fi
+
+    # HTTPS (443) - REQUIRED
+    if echo "$ufw_status" | grep -q "443/tcp.*ALLOW"; then
+        success "✓ Port 443 (HTTPS) is open"
+    else
+        warning "⚠ Port 443 (HTTPS) is NOT open - HTTPS will not work"
+        info "This is normal if SSL is not configured yet"
+    fi
+
+    echo ""
+    info "Checking security rules..."
+
+    # HTTP (80) - SHOULD BE CLOSED (except during certbot)
+    if echo "$ufw_status" | grep -q "80/tcp.*ALLOW"; then
+        warning "⚠ Port 80 (HTTP) is OPEN"
+        echo ""
+        warning "SECURITY ISSUE: Port 80 should be closed!"
+        info "Port 80 should only open temporarily during certbot renewal"
+        info "The deploy script will close it automatically"
+        echo ""
+    else
+        success "✓ Port 80 (HTTP) is closed (correct)"
+    fi
+
+    # PostgreSQL (5432) - Check if restricted
+    if echo "$ufw_status" | grep -q "5432.*ALLOW"; then
+        local pg_rules=$(echo "$ufw_status" | grep "5432.*ALLOW")
+
+        if echo "$pg_rules" | grep -q " from "; then
+            # Restricted access
+            local allowed_ip=$(echo "$pg_rules" | grep -oP 'from \K[0-9.]+' | head -1)
+            success "✓ PostgreSQL (5432) - restricted to IP: $allowed_ip"
+        else
+            # Open to all!
+            error "✗ PostgreSQL (5432) - OPEN TO ALL IPs!"
+            echo ""
+            error "CRITICAL SECURITY ISSUE: PostgreSQL is accessible from anywhere!"
+            echo ""
+            warning "ACTION REQUIRED:"
+            echo "  1. sudo ufw delete allow 5432/tcp"
+            echo "  2. sudo ufw allow from <YOUR_IP> to any port 5432"
+            echo "  OR re-run: ./setup.sh (choose PostgreSQL external access)"
+            echo ""
+            has_errors=true
+        fi
+    else
+        success "✓ PostgreSQL (5432) - closed (most secure)"
+    fi
+
+    echo ""
+
+    # Show current status
+    info "Current UFW rules:"
+    sudo ufw status numbered | grep -E "ALLOW|DENY" || echo "  (none)"
+    echo ""
+
+    # Error handling
+    if [[ "$has_errors" == "true" ]]; then
+        error "Firewall validation FAILED - critical security issues detected!"
+        echo ""
+        warning "RECOMMENDED ACTIONS:"
+        echo "  • Fix critical issues listed above"
+        echo "  • Re-run install.sh to reset firewall: sudo ./install.sh"
+        echo "  • Or manually fix rules and re-run deploy"
+        echo ""
+
+        read -p "Continue deployment anyway? (y/N): " -n 1 -r
+        echo
+        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+            error "Deployment cancelled for security reasons"
+            exit 1
+        fi
+
+        warning "Continuing deployment with firewall issues (NOT RECOMMENDED)"
+        echo ""
+    else
+        success "Firewall validation passed"
+        echo ""
+    fi
+
+    return 0
+}
+
 main() {
     # Parse arguments
     parse_args "$@"
@@ -560,6 +675,9 @@ main() {
         fi
     fi
     echo ""
+
+    # Validate firewall rules before deployment
+    validate_firewall_rules
 
     # Check if HTTP/HTTPS ports are available (for full profile with nginx)
     if [[ "$COMPOSE_PROFILE" == "full" || "${DEPLOYMENT_PROFILE:-}" == "full" ]]; then

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -144,6 +144,7 @@ services:
       - ./backend:/app/backend:ro
       - ./frontend:/app/frontend:ro  # Frontend: web UI, Telegram Web Apps, shared modules
       - ./scripts:/app/scripts:ro  # Scripts: backup health check, deployment utilities
+      - ./backups:/app/backups:ro  # Backups directory (read-only for health checks)
       - ./logs:/app/logs
       - ./uploads:/app/uploads
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -143,6 +143,7 @@ services:
     volumes:
       - ./backend:/app/backend:ro
       - ./frontend:/app/frontend:ro  # Frontend: web UI, Telegram Web Apps, shared modules
+      - ./scripts:/app/scripts:ro  # Scripts: backup health check, deployment utilities
       - ./logs:/app/logs
       - ./uploads:/app/uploads
     ports:

--- a/frontend/web/templates/admin_monitoring.html
+++ b/frontend/web/templates/admin_monitoring.html
@@ -82,6 +82,19 @@
             </div>
         </div>
     </div>
+
+    <!-- Backup Status -->
+    <div class="card bg-base-100 shadow-lg">
+        <div class="card-body">
+            <h2 class="card-title text-2xl mb-4">💾 Статус бэкапирования</h2>
+
+            <div id="backup-container">
+                <div class="flex items-center justify-center py-8">
+                    <span class="loading loading-spinner loading-lg text-primary"></span>
+                </div>
+            </div>
+        </div>
+    </div>
 </div>
 {% endblock %}
 
@@ -151,6 +164,7 @@ function renderMonitoringData(data) {
     renderComponents(data.components);
     renderSystemResources(data.system);
     renderDatabaseStats(data.components.database);
+    renderBackupStatus(data.components.backup);
 }
 
 // Render overall status indicator
@@ -354,6 +368,75 @@ function renderDatabaseStats(dbComponent) {
                 <span class="badge ${statusBadge} badge-lg gap-2">
                     ${dbComponent.status === 'up' ? '✓' : '✗'} ${dbComponent.status.toUpperCase()}
                 </span>
+            </div>
+        </div>
+    `;
+}
+
+// Render backup status
+function renderBackupStatus(backupComponent) {
+    const container = document.getElementById('backup-container');
+
+    if (!backupComponent) {
+        container.innerHTML = `
+            <div class="alert alert-warning">
+                <span>⚠ Информация о бэкапах недоступна</span>
+            </div>
+        `;
+        return;
+    }
+
+    const message = backupComponent.message || '';
+
+    const latestMatch = message.match(/Latest: ([^,]+)/);
+    const fileMatch = message.match(/File: ([^,]+)/);
+    const sizeMatch = message.match(/Size: ([0-9.]+) MB/);
+    const countMatch = message.match(/Total backups: (\d+)/);
+
+    const latestBackup = latestMatch ? latestMatch[1] : '--';
+    const fileName = fileMatch ? fileMatch[1] : '--';
+    const fileSize = sizeMatch ? sizeMatch[1] + ' MB' : '--';
+    const totalBackups = countMatch ? countMatch[1] : '--';
+
+    const statusBadge = backupComponent.status === 'up' ? 'badge-success' : 'badge-error';
+    const alertClass = backupComponent.status === 'up' ? 'alert-success' : 'alert-error';
+    const statusIcon = backupComponent.status === 'up' ? '✓' : '✗';
+
+    container.innerHTML = `
+        <div class="alert ${alertClass}">
+            <div class="flex-1">
+                <div class="flex items-center justify-between mb-3">
+                    <h3 class="font-bold text-lg">Последний бэкап</h3>
+                    <span class="badge ${statusBadge} gap-1">${statusIcon} ${backupComponent.status.toUpperCase()}</span>
+                </div>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div>
+                        <div class="text-sm opacity-80 mb-1">📅 Дата и время</div>
+                        <div class="font-semibold text-lg">${latestBackup}</div>
+                    </div>
+
+                    <div>
+                        <div class="text-sm opacity-80 mb-1">📦 Размер файла</div>
+                        <div class="font-semibold text-lg">${fileSize}</div>
+                    </div>
+
+                    <div>
+                        <div class="text-sm opacity-80 mb-1">📄 Название файла</div>
+                        <div class="font-mono text-sm break-all">${fileName}</div>
+                    </div>
+
+                    <div>
+                        <div class="text-sm opacity-80 mb-1">🗂️ Всего бэкапов</div>
+                        <div class="font-semibold text-lg">${totalBackups}</div>
+                    </div>
+                </div>
+
+                ${backupComponent.status !== 'up' ? `
+                    <div class="mt-3 p-2 bg-base-100 rounded">
+                        <p class="text-sm"><strong>Сообщение:</strong> ${message}</p>
+                    </div>
+                ` : ''}
             </div>
         </div>
     `;

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -199,8 +199,10 @@ create_directories() {
     mkdir -p "$BACKUP_DIR"
     mkdir -p "$LOG_DIR"
 
-    chmod 700 "$BACKUP_DIR"
-    chmod 700 "$LOG_DIR"
+    # Set permissions: 755 for directories (readable by all, writable by owner)
+    # This allows backend container (running as appuser) to read backups for health checks
+    chmod 755 "$BACKUP_DIR"
+    chmod 755 "$LOG_DIR"
 
     # Now we can safely log (LOG_DIR exists)
     log_info "Creating backup directories..."
@@ -214,6 +216,10 @@ perform_backup() {
     # Perform pg_dump via Docker
     if docker compose -f "${PROJECT_ROOT}/docker-compose.yml" exec -T postgres \
         pg_dump -U "$POSTGRES_USER" "$POSTGRES_DB" | gzip > "$BACKUP_PATH"; then
+
+        # Set file permissions: 644 (readable by all, writable by owner)
+        # This allows backend container to read the backup file for health checks
+        chmod 644 "$BACKUP_PATH"
 
         local backup_size=$(du -h "$BACKUP_PATH" | cut -f1)
         log_success "Backup created: $BACKUP_PATH ($backup_size)"

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -390,12 +390,17 @@ main() {
 
     # Load environment variables from .env
     if [ -f "$PROJECT_ROOT/.env" ]; then
+        debug "Loading environment from: $PROJECT_ROOT/.env"
         set -a
         source "$PROJECT_ROOT/.env"
         set +a
+        debug "Environment loaded successfully"
     else
         echo "ERROR: .env file not found at $PROJECT_ROOT/.env"
-        echo "Please run this script from the project directory or create .env file"
+        echo "Expected location: $PROJECT_ROOT/.env"
+        echo "Current SCRIPT_DIR: $SCRIPT_DIR"
+        echo "Current PROJECT_ROOT: $PROJECT_ROOT"
+        echo "Please ensure .env file exists in /opt/budget/.env"
         exit 2
     fi
 

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -21,8 +21,8 @@
 #   POSTGRES_PASSWORD     PostgreSQL password (optional, for non-Docker mode)
 #
 # Environment Variables Optional (for S3):
-#   AWS_ACCESS_KEY_ID      Yandex Object Storage access key
-#   AWS_SECRET_ACCESS_KEY  Yandex Object Storage secret key
+#   S3_ACCESS_KEY_ID       S3/Yandex Object Storage access key
+#   S3_SECRET_ACCESS_KEY   S3/Yandex Object Storage secret key
 #   S3_BUCKET_NAME         S3 bucket name
 #   S3_ENDPOINT_URL        S3 endpoint URL (default: https://storage.yandexcloud.net)
 #
@@ -261,14 +261,20 @@ should_upload_to_s3() {
 }
 
 check_s3_config() {
-    if [ -z "$AWS_ACCESS_KEY_ID" ] || [ -z "$AWS_SECRET_ACCESS_KEY" ] || [ -z "$S3_BUCKET_NAME" ]; then
+    # Check S3_* variables from .env (matches docker-compose.yml naming)
+    if [ -z "$S3_ACCESS_KEY_ID" ] || [ -z "$S3_SECRET_ACCESS_KEY" ] || [ -z "$S3_BUCKET_NAME" ]; then
         log_warn "S3 credentials not configured, skipping upload"
-        log_warn "Set AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, S3_BUCKET_NAME to enable"
+        log_warn "Set S3_ACCESS_KEY_ID, S3_SECRET_ACCESS_KEY, S3_BUCKET_NAME to enable"
         return 1
     fi
 
+    # Export as AWS_* for aws-cli compatibility
+    export AWS_ACCESS_KEY_ID="$S3_ACCESS_KEY_ID"
+    export AWS_SECRET_ACCESS_KEY="$S3_SECRET_ACCESS_KEY"
+
     debug "S3_BUCKET_NAME: $S3_BUCKET_NAME"
     debug "S3_ENDPOINT_URL: $S3_ENDPOINT_URL"
+    debug "AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:0:10}***"
 
     return 0
 }

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -388,6 +388,17 @@ main() {
         esac
     done
 
+    # Load environment variables from .env
+    if [ -f "$PROJECT_ROOT/.env" ]; then
+        set -a
+        source "$PROJECT_ROOT/.env"
+        set +a
+    else
+        echo "ERROR: .env file not found at $PROJECT_ROOT/.env"
+        echo "Please run this script from the project directory or create .env file"
+        exit 2
+    fi
+
     # Initialize
     create_directories
     print_banner

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -195,14 +195,15 @@ remove_lock() {
 }
 
 create_directories() {
-    log_info "Creating backup directories..."
-
+    # Create directories FIRST (before any logging to file)
     mkdir -p "$BACKUP_DIR"
     mkdir -p "$LOG_DIR"
 
     chmod 700 "$BACKUP_DIR"
     chmod 700 "$LOG_DIR"
 
+    # Now we can safely log (LOG_DIR exists)
+    log_info "Creating backup directories..."
     log_success "Directories created: $BACKUP_DIR, $LOG_DIR"
 }
 

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -194,21 +194,6 @@ remove_lock() {
     fi
 }
 
-create_directories() {
-    # Create directories FIRST (before any logging to file)
-    mkdir -p "$BACKUP_DIR"
-    mkdir -p "$LOG_DIR"
-
-    # Set permissions: 755 for directories (readable by all, writable by owner)
-    # This allows backend container (running as appuser) to read backups for health checks
-    chmod 755 "$BACKUP_DIR"
-    chmod 755 "$LOG_DIR"
-
-    # Now we can safely log (LOG_DIR exists)
-    log_info "Creating backup directories..."
-    log_success "Directories created: $BACKUP_DIR, $LOG_DIR"
-}
-
 perform_backup() {
     log_info "Starting PostgreSQL backup..."
     log_info "Target: $BACKUP_PATH"
@@ -381,6 +366,13 @@ generate_backup_report() {
 # ============================================================================
 
 main() {
+    # Create directories FIRST - before any logging to file
+    # This must happen BEFORE any log/debug/info calls that use tee
+    mkdir -p "$BACKUP_DIR"
+    mkdir -p "$LOG_DIR"
+    chmod 755 "$BACKUP_DIR"
+    chmod 755 "$LOG_DIR"
+
     # Parse arguments
     while [[ $# -gt 0 ]]; do
         case $1 in
@@ -417,8 +409,8 @@ main() {
     fi
 
     # Initialize
-    create_directories
     print_banner
+    log_info "Backup directories ready: $BACKUP_DIR, $LOG_DIR"
 
     # Create lock file
     if ! create_lock; then

--- a/scripts/lib/backup_integration.sh
+++ b/scripts/lib/backup_integration.sh
@@ -24,12 +24,12 @@ setup_backup_cron() {
     set +a
 
     # Check if S3 backup is configured (optional)
-    if [[ -n "${S3_BUCKET_NAME:-}" ]] && [[ -n "${AWS_ACCESS_KEY_ID:-}" ]]; then
+    if [[ -n "${S3_BUCKET_NAME:-}" ]] && [[ -n "${S3_ACCESS_KEY_ID:-}" ]]; then
         info "S3 backup is configured: s3://${S3_BUCKET_NAME}"
         info "Weekly S3 uploads will occur on Sundays"
     else
         info "S3 backup not configured - only local backups will be created"
-        info "To enable S3: configure S3_BUCKET_NAME, AWS_ACCESS_KEY_ID in .env"
+        info "To enable S3: configure S3_BUCKET_NAME, S3_ACCESS_KEY_ID in .env"
     fi
 
     # Add cron job for daily backups at 2 AM (works with or without S3)

--- a/scripts/lib/backup_integration.sh
+++ b/scripts/lib/backup_integration.sh
@@ -23,15 +23,16 @@ setup_backup_cron() {
     source "$DEPLOY_DIR/.env" 2>/dev/null || true
     set +a
 
-    # Check if S3 backup is configured
-    if [[ -z "${S3_BUCKET_NAME:-}" ]] || [[ -z "${AWS_ACCESS_KEY_ID:-}" ]]; then
-        info "S3 backup not configured in .env, skipping backup automation"
-        return 0
+    # Check if S3 backup is configured (optional)
+    if [[ -n "${S3_BUCKET_NAME:-}" ]] && [[ -n "${AWS_ACCESS_KEY_ID:-}" ]]; then
+        info "S3 backup is configured: s3://${S3_BUCKET_NAME}"
+        info "Weekly S3 uploads will occur on Sundays"
+    else
+        info "S3 backup not configured - only local backups will be created"
+        info "To enable S3: configure S3_BUCKET_NAME, AWS_ACCESS_KEY_ID in .env"
     fi
 
-    info "S3 backup is configured: s3://${S3_BUCKET_NAME}"
-
-    # Add cron job for daily backups at 2 AM
+    # Add cron job for daily backups at 2 AM (works with or without S3)
     local cron_cmd="0 2 * * * cd $DEPLOY_DIR && bash scripts/backup.sh >> logs/backup.log 2>&1"
 
     # Check if cron job already exists

--- a/scripts/lib/firewall.sh
+++ b/scripts/lib/firewall.sh
@@ -18,11 +18,11 @@ configure_firewall_for_ssl() {
     step "Configuring Firewall for SSL"
 
     # Check current status
-    local port_80_status="not configured"
+    local port_80_status="closed"
     local port_443_status="not configured"
 
     if sudo ufw status 2>/dev/null | grep -q "80/tcp.*ALLOW"; then
-        port_80_status="✓ configured"
+        port_80_status="⚠ OPEN (should be closed)"
     fi
 
     if sudo ufw status 2>/dev/null | grep -q "443/tcp.*ALLOW"; then
@@ -34,17 +34,17 @@ configure_firewall_for_ssl() {
     echo "  Port 443 (HTTPS): $port_443_status"
     echo ""
 
-    info "Automatically opening ports 80 and 443 for SSL and HTTP→HTTPS redirect..."
-
-    # Open port 80 (HTTP)
-    if ! sudo ufw status 2>/dev/null | grep -q "80/tcp.*ALLOW"; then
-        sudo ufw allow 80/tcp comment 'HTTP for Family Budget' >> "$LOG_FILE" 2>&1 || true
-        success "✓ Port 80 (HTTP) opened in firewall"
+    # SECURITY: Port 80 should NOT be open permanently
+    # It opens ONLY temporarily during certbot renewal (managed by ssl_certificate_manager.sh)
+    if sudo ufw status 2>/dev/null | grep -q "80/tcp.*ALLOW"; then
+        warning "Port 80 is currently OPEN - closing for security"
+        sudo ufw delete allow 80/tcp 2>/dev/null || true
+        success "✓ Port 80 closed (will open temporarily for certbot when needed)"
     else
-        info "✓ Port 80 (HTTP) already open"
+        info "✓ Port 80 is closed (correct - certbot will open temporarily)"
     fi
 
-    # Open port 443 (HTTPS)
+    # Open port 443 (HTTPS) - this should be ALWAYS open
     if ! sudo ufw status 2>/dev/null | grep -q "443/tcp.*ALLOW"; then
         sudo ufw allow 443/tcp comment 'HTTPS for Family Budget' >> "$LOG_FILE" 2>&1 || true
         success "✓ Port 443 (HTTPS) opened in firewall"
@@ -53,5 +53,8 @@ configure_firewall_for_ssl() {
     fi
 
     echo ""
-    success "Firewall configured for SSL: Ports 80 and 443 are open"
+    success "Firewall configured for SSL"
+    info "Security policy:"
+    echo "  ✓ Port 443 (HTTPS): OPEN permanently"
+    echo "  ✓ Port 80 (HTTP): CLOSED (opens only for certbot renewal)"
 }

--- a/scripts/ssl_certificate_manager.sh
+++ b/scripts/ssl_certificate_manager.sh
@@ -430,11 +430,28 @@ create_deploy_hook() {
 #!/bin/bash
 # Family Budget Certificate Renewal Deploy Hook
 # Called by certbot after successful certificate renewal
-# Reloads nginx to pick up new certificates
+# Reloads nginx to pick up new certificates and ensures port 80 is closed
 
 LOG_FILE="/var/log/letsencrypt/deploy-hook.log"
 
 echo "[$(date)] Certificate renewed for: $RENEWED_DOMAINS" >> "$LOG_FILE"
+
+# SECURITY: Close port 80 after renewal (certbot may have opened it)
+echo "[$(date)] Checking port 80 status..." >> "$LOG_FILE"
+if command -v ufw &> /dev/null; then
+    if sudo ufw status | grep -q "80/tcp.*ALLOW"; then
+        echo "[$(date)] Port 80 is open, closing for security..." >> "$LOG_FILE"
+        if sudo ufw delete allow 80/tcp 2>> "$LOG_FILE"; then
+            echo "[$(date)] ✅ Port 80 closed" >> "$LOG_FILE"
+        else
+            echo "[$(date)] ⚠ Failed to close port 80" >> "$LOG_FILE"
+        fi
+    else
+        echo "[$(date)] ✅ Port 80 already closed" >> "$LOG_FILE"
+    fi
+else
+    echo "[$(date)] ⚠ UFW not available, skipping port 80 check" >> "$LOG_FILE"
+fi
 
 # Reload nginx inside Docker container
 if docker ps --format '{{.Names}}' | grep -q "familybudget-nginx"; then


### PR DESCRIPTION
PROBLEM: tee error - log directory doesn't exist when debug() is called

ROOT CAUSE: create_directories() was called AFTER .env loading,
but debug() during .env loading already uses tee >> LOG_FILE

FIX: Create directories inline at the very start of main() before
any logging/debug/info calls that use tee

Changes:
- Move mkdir/chmod to start of main() (before parsing args)
- Remove create_directories() function (no longer needed)
- Add log message after .env loading

Related: backup.sh:405 tee error