### PR TITLE
fix(deploy): исправить PostgreSQL permissions для Alpine образа

### DIFF
--- a/scripts/lib/postgres.sh
+++ b/scripts/lib/postgres.sh
@@ -16,6 +16,32 @@
 #
 
 # =============================================================================
+# POSTGRESQL UID DETECTION
+# =============================================================================
+
+# Get PostgreSQL UID from Docker image
+get_postgres_uid_from_image() {
+    local image="${1:-postgres:16-alpine}"
+
+    # Try to get UID from running container first (faster)
+    local uid=$(docker run --rm --entrypoint id "$image" -u postgres 2>/dev/null | grep -oP 'uid=\K[0-9]+' || echo "")
+
+    if [[ -n "$uid" ]]; then
+        echo "$uid"
+        return 0
+    fi
+
+    # Fallback: Known defaults
+    # postgres:16-alpine uses UID 70
+    # postgres:16 (Debian) uses UID 999
+    if [[ "$image" == *"alpine"* ]]; then
+        echo "70"
+    else
+        echo "999"
+    fi
+}
+
+# =============================================================================
 # POSTGRESQL DIRECTORY INITIALIZATION
 # =============================================================================
 
@@ -30,19 +56,39 @@ initialize_postgres_directory() {
         return 0
     fi
 
-    # Detect current PostgreSQL UID from existing data (if any)
-    # Default: 999:999 (Alpine Linux PostgreSQL)
-    # Alternative: 70:70 (Debian/Ubuntu PostgreSQL)
-    local target_uid=999
-    local target_gid=999
+    # Detect PostgreSQL UID from existing data OR from Docker image
+    local target_uid
+    local target_gid
 
     if [[ -d "$postgres_data_dir/base" ]]; then
         # Data exists - detect current owner from base/ directory
-        target_uid=$(stat -c '%u' "$postgres_data_dir/base" 2>/dev/null || echo "999")
-        target_gid=$(stat -c '%g' "$postgres_data_dir/base" 2>/dev/null || echo "999")
-        info "Detected existing PostgreSQL UID from data: $target_uid:$target_gid"
+        target_uid=$(stat -c '%u' "$postgres_data_dir/base" 2>/dev/null)
+        target_gid=$(stat -c '%g' "$postgres_data_dir/base" 2>/dev/null)
+
+        if [[ -z "$target_uid" ]] || [[ -z "$target_gid" ]]; then
+            # stat failed - get from image
+            target_uid=$(get_postgres_uid_from_image "postgres:16-alpine")
+            target_gid="$target_uid"
+            info "Failed to detect UID from data, using image default: $target_uid:$target_gid"
+        else
+            info "Detected existing PostgreSQL UID from data: $target_uid:$target_gid"
+        fi
     else
-        info "No existing data - will use default UID: $target_uid:$target_gid (Alpine Linux)"
+        # No data - get UID from Docker image dynamically
+        target_uid=$(get_postgres_uid_from_image "postgres:16-alpine")
+        target_gid="$target_uid"
+        info "No existing data - using PostgreSQL UID from image: $target_uid:$target_gid (postgres:16-alpine)"
+    fi
+
+    # Remove stale postmaster.pid lock file (from failed startup attempts)
+    if [[ -f "$postgres_data_dir/postmaster.pid" ]]; then
+        warning "Found stale PostgreSQL lock file (postmaster.pid)"
+        info "Removing lock file from previous failed startup..."
+        if sudo rm -f "$postgres_data_dir/postmaster.pid"; then
+            success "Lock file removed"
+        else
+            warning "Failed to remove lock file (continuing anyway)"
+        fi
     fi
 
     # Create directory if doesn't exist


### PR DESCRIPTION
Проблема:
- initialize_postgres_directory() использовала hardcoded UID 999:999 по умолчанию
- Реальный postgres:16-alpine использует UID 70:70
- Это вызывало Permission Denied при запуске контейнера
- Stale lock файл postmaster.pid блокировал запуск после ошибок

Решение:
1. Добавлена функция get_postgres_uid_from_image() - динамически определяет
   UID из Docker образа (docker run + fallback на известные значения)

2. Исправлена логика в initialize_postgres_directory():
   - Приоритет 1: UID из существующих данных (data/postgres/base)
   - Приоритет 2: UID из Docker образа (динамически)
   - Fallback: 70 для Alpine, 999 для Debian

3. Добавлено автоматическое удаление stale lock файла postmaster.pid

Влияние:
- deploy.sh автоматически исправит ownership при следующем деплое
- Поддержка разных PostgreSQL образов (Alpine/Debian)
- Защита от lock файлов от failed startups

Файлы:
- scripts/lib/postgres.sh:18-42 (новая функция get_postgres_uid_from_image)
- scripts/lib/postgres.sh:59-92 (исправлена логика + удаление lock файла)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>