### PR TITLE
fix(deploy): save Docker build checksums for reliable rebuild detection

### DIFF
--- a/scripts/lib/services.sh
+++ b/scripts/lib/services.sh
@@ -121,6 +121,17 @@ start_services() {
             warning "Services started but some containers are unhealthy. Check logs above."
         else
             success "Services started successfully"
+
+            # Save Docker build checksums ONLY after successful start with rebuild
+            # This ensures next deploy will correctly detect if trigger files changed
+            if [[ "$build_flag" == "--build" ]]; then
+                info "Saving Docker build checksums for future rebuild detection..."
+                if save_docker_build_checksums "$SCRIPT_DIR"; then
+                    success "Docker build checksums saved"
+                else
+                    warning "Failed to save Docker build checksums"
+                fi
+            fi
         fi
     else
         error "Failed to start services. Check $LOG_FILE for details."

--- a/scripts/lib/sync.sh
+++ b/scripts/lib/sync.sh
@@ -230,6 +230,7 @@ check_code_changes() {
         --exclude='*.pyc' \
         --exclude='.npm-isolated/' \
         --exclude='.migration_checksums' \
+        --exclude='.docker_build_checksums' \
         "$repo_dir/" "$DEPLOY_DIR/" 2>/dev/null | grep -v "/$" | grep -v "^sending\|^sent\|^total" | wc -l)
 
     if [[ $changes -gt 0 ]]; then
@@ -271,6 +272,7 @@ sync_mirror() {
     rsync -avnc \
         --filter='protect .npm-isolated/' \
         --filter='protect .migration_checksums' \
+        --filter='protect .docker_build_checksums' \
         --exclude='.env' \
         --exclude='node_modules/' \
         --exclude='data/' \
@@ -282,6 +284,7 @@ sync_mirror() {
         --exclude='*.pyc' \
         --exclude='.npm-isolated/' \
         --exclude='.migration_checksums' \
+        --exclude='.docker_build_checksums' \
         --exclude='docs/' \
         --exclude='setup.sh' \
         --exclude='install.sh' \
@@ -306,9 +309,11 @@ sync_mirror() {
     # Protected files live ONLY in production (/opt/budget), NOT in repository:
     #   - .npm-isolated/ (233 npm packages for build)
     #   - .migration_checksums (MD5 checksums for migration change detection)
+    #   - .docker_build_checksums (MD5 checksums for Docker rebuild detection)
     if rsync -avc --delete \
         --filter='protect .npm-isolated/' \
         --filter='protect .migration_checksums' \
+        --filter='protect .docker_build_checksums' \
         --exclude='.env' \
         --exclude='node_modules/' \
         --exclude='data/' \
@@ -320,6 +325,7 @@ sync_mirror() {
         --exclude='*.pyc' \
         --exclude='.npm-isolated/' \
         --exclude='.migration_checksums' \
+        --exclude='.docker_build_checksums' \
         --exclude='docs/' \
         --exclude='setup.sh' \
         --exclude='install.sh' \
@@ -387,6 +393,7 @@ sync_update() {
         --exclude='*.pyc' \
         --exclude='.npm-isolated/' \
         --exclude='.migration_checksums' \
+        --exclude='.docker_build_checksums' \
         --exclude='docs/' \
         --exclude='setup.sh' \
         --exclude='install.sh' \
@@ -418,6 +425,7 @@ sync_update() {
         --exclude='*.pyc' \
         --exclude='.npm-isolated/' \
         --exclude='.migration_checksums' \
+        --exclude='.docker_build_checksums' \
         --exclude='docs/' \
         --exclude='setup.sh' \
         --exclude='install.sh' \
@@ -453,6 +461,7 @@ sync_update() {
         ! -path "./__pycache__/*" \
         ! -path "./.npm-isolated/*" \
         ! -name ".migration_checksums" \
+        ! -name ".docker_build_checksums" \
         ! -path "./docs/*" \
         ! -name "setup.sh" \
         ! -name "install.sh" \
@@ -480,6 +489,7 @@ sync_update() {
         ! -path "./__pycache__/*" \
         ! -path "./.npm-isolated/*" \
         ! -name ".migration_checksums" \
+        ! -name ".docker_build_checksums" \
         ! -path "./docs/*" \
         ! -name "setup.sh" \
         ! -name "install.sh" \
@@ -541,6 +551,7 @@ sync_clean() {
     warning "  - .env file"
     warning "  - .npm-isolated/ (production npm environment)"
     warning "  - .migration_checksums (migration change detection)"
+    warning "  - .docker_build_checksums (Docker rebuild detection)"
     warning "  - logs/ and data/ directories (contents cleared)"
     warning "  - Current deploy.log (for troubleshooting)"
     echo ""
@@ -640,6 +651,7 @@ sync_clean() {
         --exclude='*.pyc' \
         --exclude='.npm-isolated/' \
         --exclude='.migration_checksums' \
+        --exclude='.docker_build_checksums' \
         "$repo_dir/" "$DEPLOY_DIR/" >> "$LOG_FILE" 2>&1; then
 
         # Ensure logs/, data/, and backups/ directories exist
@@ -714,7 +726,7 @@ sync_code_to_deploy() {
             echo "Select sync mode:"
             echo "  [1] Mirror (rsync --delete) - RECOMMENDED"
             echo "      Removes files from /opt/budget not in repository"
-            echo "      Protected: .env, .npm-isolated/, .migration_checksums, backups/, data/, logs/"
+            echo "      Protected: .env, .npm-isolated/, .migration_checksums, .docker_build_checksums, backups/, data/, logs/"
             echo ""
             echo "  [2] Update only (rsync)"
             echo "      Updates existing + adds new files"
@@ -723,7 +735,7 @@ sync_code_to_deploy() {
             echo "  [3] Clean + copy (DANGEROUS!)"
             echo "      Deletes EVERYTHING (code, data/*, logs/*, backups, Docker volumes)"
             echo "      ⚠️  DELETES PostgreSQL database and ALL data!"
-            echo "      Protected: .env, .npm-isolated/, .migration_checksums, logs/ and data/ directories (contents cleared)"
+            echo "      Protected: .env, .npm-isolated/, .migration_checksums, .docker_build_checksums, logs/ and data/ directories (contents cleared)"
             echo ""
             echo "  [4] Skip synchronization"
             echo "      Deploy without updating code"
@@ -763,6 +775,7 @@ sync_code_to_deploy() {
     # Production-only files live in /opt/budget (NOT synchronized from repository):
     #   1. .npm-isolated/ - npm packages (233 packages, ~100-200MB)
     #   2. .migration_checksums - MD5 checksums for migration change detection
+    #   3. .docker_build_checksums - MD5 checksums for Docker rebuild detection
     #
     # These are excluded in all rsync commands above. This provides:
     #   - Faster deploys (~100-200MB not copied)

--- a/scripts/lib/version.sh
+++ b/scripts/lib/version.sh
@@ -220,52 +220,104 @@ update_all_version_files() {
 # REBUILD DETECTION FUNCTIONS
 # =============================================================================
 
+# File to store checksums of trigger files used in last successful Docker build
+# This prevents the bug where:
+#   1. Sync copies new files to /opt/budget
+#   2. Build fails or is skipped
+#   3. Next deploy compares repo vs deploy (now identical) → "no rebuild needed"
+#   4. But Docker image still has OLD dependencies!
+DOCKER_BUILD_CHECKSUMS_FILE="${DEPLOY_DIR}/.docker_build_checksums"
+
+# Calculate checksums for all rebuild trigger files
+# Args: repo_dir
+# Returns: sorted list of "checksum filename" pairs
+calculate_trigger_checksums() {
+    local repo_dir="${1:-$SCRIPT_DIR}"
+    local checksums=""
+
+    for trigger_file in "${REBUILD_TRIGGER_FILES[@]}"; do
+        local full_path="${repo_dir}/${trigger_file}"
+        if [[ -f "$full_path" ]]; then
+            local checksum
+            checksum=$(md5sum "$full_path" 2>/dev/null | cut -d' ' -f1)
+            checksums+="${checksum}  ${trigger_file}"$'\n'
+        fi
+    done
+
+    echo "$checksums" | sort
+}
+
+# Save checksums after successful Docker build
+# Call this AFTER Docker images are successfully built
+save_docker_build_checksums() {
+    local repo_dir="${1:-$SCRIPT_DIR}"
+    local checksums
+
+    checksums=$(calculate_trigger_checksums "$repo_dir")
+
+    if [[ -z "$checksums" ]]; then
+        warning "No trigger files found to save checksums"
+        return 1
+    fi
+
+    echo "$checksums" > "$DOCKER_BUILD_CHECKSUMS_FILE"
+    info "Saved Docker build checksums for $(echo "$checksums" | grep -c .) trigger files"
+    return 0
+}
+
+# Load checksums from last successful build
+load_docker_build_checksums() {
+    if [[ -f "$DOCKER_BUILD_CHECKSUMS_FILE" ]]; then
+        cat "$DOCKER_BUILD_CHECKSUMS_FILE"
+    else
+        echo ""  # No previous build checksums
+    fi
+}
+
 # Check if Docker images need to be rebuilt
+# Compares current trigger files against checksums from LAST SUCCESSFUL BUILD
+# (not against deploy directory, which may have been synced without rebuild)
 # Args: repo_dir
 # Returns: 0 if rebuild needed, 1 if not needed
 needs_docker_rebuild() {
     local repo_dir="${1:-$SCRIPT_DIR}"
 
-    # If no previous deployment, always rebuild
-    if [[ ! -f "$DEPLOY_DIR/.last_deployed_version" ]]; then
-        info "First deployment - Docker rebuild required"
+    # If no previous build checksums, always rebuild
+    if [[ ! -f "$DOCKER_BUILD_CHECKSUMS_FILE" ]]; then
+        info "No previous Docker build checksums found - rebuild required"
         return 0
     fi
 
-    # Get list of changed files since last deployment
-    local last_version
-    last_version=$(cat "$DEPLOY_DIR/.last_deployed_version" 2>/dev/null || echo "")
+    # Load previous build checksums
+    local previous_checksums
+    previous_checksums=$(load_docker_build_checksums)
 
-    if [[ -z "$last_version" ]]; then
-        info "No previous version found - Docker rebuild required"
+    if [[ -z "$previous_checksums" ]]; then
+        info "Empty Docker build checksums - rebuild required"
         return 0
     fi
 
-    # Check if any rebuild trigger files changed
-    for trigger_file in "${REBUILD_TRIGGER_FILES[@]}"; do
-        local full_path="${repo_dir}/${trigger_file}"
-        local deploy_path="${DEPLOY_DIR}/${trigger_file}"
+    # Calculate current checksums
+    local current_checksums
+    current_checksums=$(calculate_trigger_checksums "$repo_dir")
 
-        if [[ -f "$full_path" ]]; then
-            # Compare with deployed version
-            if [[ ! -f "$deploy_path" ]]; then
-                info "New file detected: $trigger_file - Docker rebuild required"
-                return 0
-            fi
+    # Compare checksums
+    if [[ "$previous_checksums" != "$current_checksums" ]]; then
+        # Find which files changed
+        local changed_files
+        changed_files=$(diff <(echo "$previous_checksums") <(echo "$current_checksums") 2>/dev/null | grep "^[<>]" | sed 's/^[<>] //' | awk '{print $2}' | sort -u)
 
-            # Compare checksums
-            local repo_checksum deploy_checksum
-            repo_checksum=$(md5sum "$full_path" 2>/dev/null | cut -d' ' -f1)
-            deploy_checksum=$(md5sum "$deploy_path" 2>/dev/null | cut -d' ' -f1)
-
-            if [[ "$repo_checksum" != "$deploy_checksum" ]]; then
-                info "Changed: $trigger_file - Docker rebuild required"
-                return 0
-            fi
+        if [[ -n "$changed_files" ]]; then
+            info "Trigger files changed since last build:"
+            echo "$changed_files" | while read -r file; do
+                info "  - $file"
+            done
         fi
-    done
+        info "Docker rebuild required"
+        return 0
+    fi
 
-    info "No rebuild trigger files changed - Docker rebuild not required"
+    info "No rebuild trigger files changed since last successful build"
     return 1
 }
 


### PR DESCRIPTION
Previously, the rebuild detection compared trigger file checksums between
the repository and the deploy directory. This caused a bug where:
1. Sync copies new files (e.g., requirements.txt with new deps) to /opt/budget
2. Docker build fails or is skipped (e.g., due to unhealthy container)
3. Next deploy compares repo vs deploy → identical checksums → "no rebuild"
4. Docker image still has OLD dependencies → runtime crash

The fix introduces .docker_build_checksums which:
- Saves checksums ONLY after successful Docker build + healthy containers
- Compares against saved checksums, not deploy directory
- Ensures rebuild is triggered if dependencies changed since last SUCCESSFUL build

Changes:
- version.sh: Add calculate_trigger_checksums(), save_docker_build_checksums(),
  load_docker_build_checksums() functions; update needs_docker_rebuild() to
  compare against saved checksums instead of deploy directory
- services.sh: Call save_docker_build_checksums() after successful service start
  with --build flag
- sync.sh: Exclude .docker_build_checksums from rsync (production-only file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>