### PR TITLE
fix(api): use timezone-aware datetime for SCD2 valid_to field

### DIFF
--- a/backend/app/api/v1/admin.py
+++ b/backend/app/api/v1/admin.py
@@ -6,7 +6,7 @@ All endpoints require admin privileges (is_admin=True).
 """
 
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Annotated, List
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -47,7 +47,8 @@ from backend.app.services.user_service import (
 )
 from backend.app.services.article_service import (
     update_article_profile as update_article_scd1,
-    create_initial_history as create_article_initial_history
+    create_initial_history as create_article_initial_history,
+    FAR_FUTURE_DATETIME,
 )
 from backend.app.services import (
     archive_recursive,
@@ -1690,7 +1691,7 @@ async def delete_article(
         code=article.code,
         is_active=article.is_active,
         valid_from=now,
-        valid_to=datetime(9999, 12, 31),
+        valid_to=FAR_FUTURE_DATETIME,
         is_current=False,  # Deleted records are never current
         change_type="DELETE",
         changed_fields=None,  # Full deletion
@@ -1732,7 +1733,7 @@ async def delete_article(
                 record_type=fact.record_type,
                 transfer_id=fact.transfer_id,
                 valid_from=now,
-                valid_to=datetime(9999, 12, 31),
+                valid_to=FAR_FUTURE_DATETIME,
                 is_current=False,
                 change_type="DELETE",
                 changed_fields=None,  # Full deletion

--- a/backend/app/api/v1/endpoints/cost_centers.py
+++ b/backend/app/api/v1/endpoints/cost_centers.py
@@ -13,7 +13,7 @@ Endpoints:
 """
 
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 
 logger = logging.getLogger(__name__)
@@ -36,6 +36,7 @@ from backend.app.services.scd2_service import has_changes
 from backend.app.services.cost_center_service import (
     create_initial_history,
     update_cost_center_profile,
+    FAR_FUTURE_DATETIME,
 )
 
 router = APIRouter(
@@ -396,7 +397,7 @@ async def delete_cost_center(
         code=cost_center.code,
         is_active=cost_center.is_active,
         valid_from=now,
-        valid_to=datetime(9999, 12, 31),
+        valid_to=FAR_FUTURE_DATETIME,
         is_current=False,  # Deleted records are never current
         change_type="DELETE",
         changed_fields=None,  # Full deletion
@@ -435,7 +436,7 @@ async def delete_cost_center(
                 record_type=fact.record_type,
                 transfer_id=fact.transfer_id,
                 valid_from=now,
-                valid_to=datetime(9999, 12, 31),
+                valid_to=FAR_FUTURE_DATETIME,
                 is_current=False,  # Deleted records are never current
                 change_type="DELETE",
                 changed_fields=None,  # Full deletion

--- a/backend/app/api/v1/endpoints/facts.py
+++ b/backend/app/api/v1/endpoints/facts.py
@@ -13,7 +13,7 @@ Features:
 """
 
 import logging
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from decimal import Decimal
 from typing import Annotated, Optional
 
@@ -43,6 +43,10 @@ from backend.app.schemas.fact import (
     FactSummary,
     FactUpdate,
 )
+
+
+# Far future datetime constant for SCD Type 2 valid_to field
+FAR_FUTURE_DATETIME = datetime(9999, 12, 31, 23, 59, 59, tzinfo=timezone.utc)
 
 logger = logging.getLogger(__name__)
 
@@ -876,7 +880,7 @@ async def delete_fact(
         record_type=fact.record_type,
         transfer_id=fact.transfer_id,
         valid_from=now,
-        valid_to=datetime(9999, 12, 31),
+        valid_to=FAR_FUTURE_DATETIME,
         is_current=False,  # Deleted records are never current
         change_type="DELETE",
         changed_fields=None,  # Full deletion
@@ -970,7 +974,7 @@ async def batch_delete_facts(
             record_type=fact.record_type,
             transfer_id=fact.transfer_id,
             valid_from=now,
-            valid_to=datetime(9999, 12, 31),
+            valid_to=FAR_FUTURE_DATETIME,
             is_current=False,  # Deleted records are never current
             change_type="DELETE",
             changed_fields=None,  # Full deletion

--- a/backend/app/api/v1/endpoints/financial_centers.py
+++ b/backend/app/api/v1/endpoints/financial_centers.py
@@ -13,7 +13,7 @@ Endpoints:
 """
 
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 
 logger = logging.getLogger(__name__)
@@ -36,6 +36,7 @@ from backend.app.services.scd2_service import has_changes
 from backend.app.services.financial_center_service import (
     create_initial_history,
     update_financial_center_profile,
+    FAR_FUTURE_DATETIME,
 )
 
 router = APIRouter(
@@ -396,7 +397,7 @@ async def delete_financial_center(
         code=financial_center.code,
         is_active=financial_center.is_active,
         valid_from=now,
-        valid_to=datetime(9999, 12, 31),
+        valid_to=FAR_FUTURE_DATETIME,
         is_current=False,  # Deleted records are never current
         change_type="DELETE",
         changed_fields=None,  # Full deletion
@@ -435,7 +436,7 @@ async def delete_financial_center(
                 record_type=fact.record_type,
                 transfer_id=fact.transfer_id,
                 valid_from=now,
-                valid_to=datetime(9999, 12, 31),
+                valid_to=FAR_FUTURE_DATETIME,
                 is_current=False,  # Deleted records are never current
                 change_type="DELETE",
                 changed_fields=None,  # Full deletion

--- a/backend/app/api/v1/endpoints/users.py
+++ b/backend/app/api/v1/endpoints/users.py
@@ -11,7 +11,7 @@ Features:
     - Update user role with SCD Type 2 (admin only)
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
@@ -34,6 +34,10 @@ from backend.app.schemas.user import (
     UserUpdate,
 )
 from backend.app.services import create_new_version, has_changes
+
+
+# Far future datetime constant for SCD Type 2 valid_to field
+FAR_FUTURE_DATETIME = datetime(9999, 12, 31, 23, 59, 59, tzinfo=timezone.utc)
 
 router = APIRouter(prefix="/users", tags=["Users"])
 
@@ -207,7 +211,7 @@ async def create_user(
         last_name=user_data.last_name,
         is_admin=user_data.is_admin,
         valid_from=now,
-        valid_to=datetime(9999, 12, 31, 23, 59, 59),
+        valid_to=FAR_FUTURE_DATETIME,
         is_current=True,
         created_at=now,
         updated_at=now,

--- a/backend/app/models/article_history.py
+++ b/backend/app/models/article_history.py
@@ -15,6 +15,11 @@ from sqlalchemy import ARRAY, DateTime, String
 from sqlmodel import Column, Field, SQLModel
 
 
+# Far future datetime constant for SCD Type 2 valid_to field
+# Uses timezone-aware UTC to prevent asyncpg year overflow issues
+FAR_FUTURE_DATETIME = datetime(9999, 12, 31, 23, 59, 59, tzinfo=timezone.utc)
+
+
 class ArticleHistory(SQLModel, table=True):
     """
     Article history table (SCD Type 2 - full change history).
@@ -198,7 +203,7 @@ class ArticleHistory(SQLModel, table=True):
     )
     valid_to: datetime = Field(
         sa_column=Column(DateTime(timezone=True), nullable=False),
-        default=datetime(9999, 12, 31, 23, 59, 59),
+        default_factory=lambda: FAR_FUTURE_DATETIME,
         description="End of validity period (9999-12-31 23:59:59 for current version)"
     )
     is_current: bool = Field(

--- a/backend/app/models/budget_fact_history.py
+++ b/backend/app/models/budget_fact_history.py
@@ -17,6 +17,10 @@ from sqlalchemy import DateTime, ARRAY, String
 from sqlmodel import Column, Field, SQLModel
 
 
+# Far future datetime constant for SCD Type 2 valid_to field
+FAR_FUTURE_DATETIME = datetime(9999, 12, 31, 23, 59, 59, tzinfo=timezone.utc)
+
+
 class BudgetFactHistory(SQLModel, table=True):
     """
     Budget Fact history table (SCD Type 2 - full change history).
@@ -224,7 +228,7 @@ class BudgetFactHistory(SQLModel, table=True):
 
     valid_to: datetime = Field(
         sa_column=Column(DateTime(timezone=True), nullable=False),
-        default=datetime(9999, 12, 31),
+        default_factory=lambda: FAR_FUTURE_DATETIME,
         description="End of validity period (9999-12-31 for current version)"
     )
 

--- a/backend/app/models/cost_center_history.py
+++ b/backend/app/models/cost_center_history.py
@@ -15,6 +15,10 @@ from sqlalchemy import DateTime, ARRAY, String
 from sqlmodel import Column, Field, SQLModel
 
 
+# Far future datetime constant for SCD Type 2 valid_to field
+FAR_FUTURE_DATETIME = datetime(9999, 12, 31, 23, 59, 59, tzinfo=timezone.utc)
+
+
 class CostCenterHistory(SQLModel, table=True):
     """
     Cost Center history table (SCD Type 2 - full change history).
@@ -165,7 +169,7 @@ class CostCenterHistory(SQLModel, table=True):
     )
     valid_to: datetime = Field(
         sa_column=Column(DateTime(timezone=True), nullable=False),
-        default=datetime(9999, 12, 31, 23, 59, 59),
+        default_factory=lambda: FAR_FUTURE_DATETIME,
         description="End of validity period (9999-12-31 23:59:59 for current version)"
     )
     is_current: bool = Field(

--- a/backend/app/models/financial_center_history.py
+++ b/backend/app/models/financial_center_history.py
@@ -15,6 +15,10 @@ from sqlalchemy import DateTime, ARRAY, String
 from sqlmodel import Column, Field, SQLModel
 
 
+# Far future datetime constant for SCD Type 2 valid_to field
+FAR_FUTURE_DATETIME = datetime(9999, 12, 31, 23, 59, 59, tzinfo=timezone.utc)
+
+
 class FinancialCenterHistory(SQLModel, table=True):
     """
     Financial Center history table (SCD Type 2 - full change history).
@@ -165,7 +169,7 @@ class FinancialCenterHistory(SQLModel, table=True):
     )
     valid_to: datetime = Field(
         sa_column=Column(DateTime(timezone=True), nullable=False),
-        default=datetime(9999, 12, 31, 23, 59, 59),
+        default_factory=lambda: FAR_FUTURE_DATETIME,
         description="End of validity period (9999-12-31 23:59:59 for current version)"
     )
     is_current: bool = Field(

--- a/backend/app/models/user_history.py
+++ b/backend/app/models/user_history.py
@@ -23,6 +23,10 @@ from sqlalchemy import DateTime, ARRAY, BigInteger, Column, String
 from sqlmodel import Field, SQLModel
 
 
+# Far future datetime constant for SCD Type 2 valid_to field
+FAR_FUTURE_DATETIME = datetime(9999, 12, 31, 23, 59, 59, tzinfo=timezone.utc)
+
+
 class UserHistory(SQLModel, table=True):
     """
     User history table (SCD Type 2 - full change history).
@@ -221,7 +225,7 @@ class UserHistory(SQLModel, table=True):
     )
     valid_to: datetime = Field(
         sa_column=Column(DateTime(timezone=True), nullable=False),
-        default=datetime(9999, 12, 31, 23, 59, 59),
+        default_factory=lambda: FAR_FUTURE_DATETIME,
         description="End of validity period (9999-12-31 23:59:59 for current version)"
     )
     is_current: bool = Field(

--- a/backend/app/services/article_service.py
+++ b/backend/app/services/article_service.py
@@ -17,7 +17,7 @@ Key Functions:
     - create_initial_history(): Create initial history record for new article
 """
 
-from datetime import datetime, date
+from datetime import datetime, date, timezone
 from typing import Any, Dict, List, Optional
 
 from sqlmodel import select
@@ -25,6 +25,11 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from backend.app.models.article import Article
 from backend.app.models.article_history import ArticleHistory
+
+
+# Far future datetime constant for SCD Type 2 valid_to field
+# Uses timezone-aware UTC to prevent asyncpg year overflow issues
+FAR_FUTURE_DATETIME = datetime(9999, 12, 31, 23, 59, 59, tzinfo=timezone.utc)
 
 
 async def update_article_profile(
@@ -118,7 +123,7 @@ async def update_article_profile(
         code=article.code,
         is_active=article.is_active,
         valid_from=now,
-        valid_to=datetime(9999, 12, 31, 23, 59, 59),  # Far future
+        valid_to=FAR_FUTURE_DATETIME,
         is_current=True,
         change_type=change_type,
         changed_fields=changed_fields,
@@ -266,7 +271,7 @@ async def create_initial_history(
         code=article.code,
         is_active=article.is_active,
         valid_from=now,
-        valid_to=datetime(9999, 12, 31, 23, 59, 59),
+        valid_to=FAR_FUTURE_DATETIME,
         is_current=True,
         change_type=change_type,
         changed_fields=None,  # Initial creation - no previous version

--- a/backend/app/services/cost_center_service.py
+++ b/backend/app/services/cost_center_service.py
@@ -17,7 +17,7 @@ Key Functions:
     - create_initial_history(): Create initial history record for new cost center
 """
 
-from datetime import datetime, date
+from datetime import datetime, date, timezone
 from typing import Any, Dict, List, Optional
 
 from sqlmodel import select
@@ -25,6 +25,11 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from backend.app.models.cost_center import CostCenter
 from backend.app.models.cost_center_history import CostCenterHistory
+
+
+# Far future datetime constant for SCD Type 2 valid_to field
+# Uses timezone-aware UTC to prevent asyncpg year overflow issues
+FAR_FUTURE_DATETIME = datetime(9999, 12, 31, 23, 59, 59, tzinfo=timezone.utc)
 
 
 async def update_cost_center_profile(
@@ -112,7 +117,7 @@ async def update_cost_center_profile(
         code=cost_center.code,
         is_active=cost_center.is_active,
         valid_from=now,
-        valid_to=datetime(9999, 12, 31, 23, 59, 59),  # Far future
+        valid_to=FAR_FUTURE_DATETIME,
         is_current=True,
         change_type=change_type,
         changed_fields=changed_fields,
@@ -257,7 +262,7 @@ async def create_initial_history(
         code=cost_center.code,
         is_active=cost_center.is_active,
         valid_from=now,
-        valid_to=datetime(9999, 12, 31, 23, 59, 59),
+        valid_to=FAR_FUTURE_DATETIME,
         is_current=True,
         change_type=change_type,
         changed_fields=None,  # Initial creation - no previous version

--- a/backend/app/services/financial_center_service.py
+++ b/backend/app/services/financial_center_service.py
@@ -17,7 +17,7 @@ Key Functions:
     - create_initial_history(): Create initial history record for new financial center
 """
 
-from datetime import datetime, date
+from datetime import datetime, date, timezone
 from typing import Any, Dict, List, Optional
 
 from sqlmodel import select
@@ -25,6 +25,11 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from backend.app.models.financial_center import FinancialCenter
 from backend.app.models.financial_center_history import FinancialCenterHistory
+
+
+# Far future datetime constant for SCD Type 2 valid_to field
+# Uses timezone-aware UTC to prevent asyncpg year overflow issues
+FAR_FUTURE_DATETIME = datetime(9999, 12, 31, 23, 59, 59, tzinfo=timezone.utc)
 
 
 async def update_financial_center_profile(
@@ -112,7 +117,7 @@ async def update_financial_center_profile(
         code=financial_center.code,
         is_active=financial_center.is_active,
         valid_from=now,
-        valid_to=datetime(9999, 12, 31, 23, 59, 59),  # Far future
+        valid_to=FAR_FUTURE_DATETIME,
         is_current=True,
         change_type=change_type,
         changed_fields=changed_fields,
@@ -257,7 +262,7 @@ async def create_initial_history(
         code=financial_center.code,
         is_active=financial_center.is_active,
         valid_from=now,
-        valid_to=datetime(9999, 12, 31, 23, 59, 59),
+        valid_to=FAR_FUTURE_DATETIME,
         is_current=True,
         change_type=change_type,
         changed_fields=None,  # Initial creation - no previous version

--- a/backend/app/services/scd2_service.py
+++ b/backend/app/services/scd2_service.py
@@ -17,7 +17,7 @@ Key Functions:
     - get_history(): Get all versions ordered by valid_from
 """
 
-from datetime import datetime, date
+from datetime import datetime, date, timezone
 from typing import Any, Dict, Optional, Type, TypeVar
 
 from sqlalchemy.exc import IntegrityError
@@ -26,6 +26,11 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from backend.app.models.article import Article
 from backend.app.models.user import User
+
+
+# Far future datetime constant for SCD Type 2 valid_to field
+# Uses timezone-aware UTC to prevent asyncpg year overflow issues
+FAR_FUTURE_DATETIME = datetime(9999, 12, 31, 23, 59, 59, tzinfo=timezone.utc)
 
 # Generic type for SCD2 models
 T = TypeVar("T", Article, User)
@@ -113,7 +118,7 @@ async def create_new_version(
     # Set SCD Type 2 fields
     new_data["is_current"] = True
     new_data["valid_from"] = now
-    new_data["valid_to"] = datetime(9999, 12, 31, 23, 59, 59)
+    new_data["valid_to"] = FAR_FUTURE_DATETIME
     new_data["updated_at"] = now
 
     # Preserve original creation timestamp

--- a/backend/app/services/user_service.py
+++ b/backend/app/services/user_service.py
@@ -16,7 +16,7 @@ Key Functions:
     - get_user_version_at_date(): Time-travel query to UserHistory
 """
 
-from datetime import datetime, date
+from datetime import datetime, date, timezone
 from typing import Any, Dict, List, Optional
 
 from sqlmodel import select
@@ -24,6 +24,11 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from backend.app.models.user import User
 from backend.app.models.user_history import UserHistory
+
+
+# Far future datetime constant for SCD Type 2 valid_to field
+# Uses timezone-aware UTC to prevent asyncpg year overflow issues
+FAR_FUTURE_DATETIME = datetime(9999, 12, 31, 23, 59, 59, tzinfo=timezone.utc)
 
 
 async def update_user_profile(
@@ -116,7 +121,7 @@ async def update_user_profile(
         two_factor_enabled=user.two_factor_enabled,  # Include 2FA status
         last_login_at=user.last_login_at,
         valid_from=now,
-        valid_to=datetime(9999, 12, 31, 23, 59, 59),  # Far future
+        valid_to=FAR_FUTURE_DATETIME,
         is_current=True,
         change_type=change_type,
         changed_fields=changed_fields,
@@ -266,7 +271,7 @@ async def create_initial_history(
         two_factor_enabled=user.two_factor_enabled,  # Include 2FA status
         last_login_at=user.last_login_at,
         valid_from=now,
-        valid_to=datetime(9999, 12, 31, 23, 59, 59),
+        valid_to=FAR_FUTURE_DATETIME,
         is_current=True,
         change_type=change_type,
         changed_fields=None,  # Initial creation - no previous version


### PR DESCRIPTION
Fixes 500 error when updating article category type. The issue was
caused by naive datetime(9999, 12, 31, 23, 59, 59) being inserted
into TIMESTAMP WITH TIME ZONE columns - asyncpg/PostgreSQL cannot
convert naive datetime for year 9999 when timezone offset is applied.

Solution: Use timezone-aware FAR_FUTURE_DATETIME constant with
explicit UTC timezone across all history models and services.

Changes:
- Add FAR_FUTURE_DATETIME constant to all services and models
- Replace datetime(9999, 12, 31, ...) with FAR_FUTURE_DATETIME
- Use default_factory instead of default for Field definitions

Affected: article_service, user_service, cost_center_service,
financial_center_service, scd2_service, and all *_history models

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>