### PR TITLE
fix(deploy,setup,logs): fix critical issues from budget-prod deployment analysis

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1268,6 +1268,17 @@ main() {
         ls -la "$DATA_DIR/postgres/" | head -20 || true
     fi
 
+    # CRITICAL FIX: Stop PostgreSQL before repair to ensure ALL directories (persistent + runtime) are created
+    # repair_postgres_directories_atomic() creates only persistent_dirs when PostgreSQL is running,
+    # but skips runtime_dirs (pg_notify, pg_dynshmem, pg_stat) to avoid race conditions.
+    # However, if PostgreSQL restarts after repair without runtime_dirs, it fails with FATAL errors.
+    # Solution: Stop PostgreSQL BEFORE repair so that repair creates ALL directories atomically.
+    if docker ps --filter "name=$PROJECT_NAME-postgres" --filter "status=running" -q 2>/dev/null | grep -q .; then
+        info "Stopping PostgreSQL before atomic repair (ensures runtime dirs creation)"
+        cd "$DEPLOY_DIR" && docker compose stop postgres || true
+        sleep 2
+    fi
+
     repair_postgres_directories_atomic
     echo ""
 

--- a/logs.sh
+++ b/logs.sh
@@ -881,7 +881,9 @@ check_ssl_security() {
                 local proto_name="${protocol_names[$i]}"
 
                 # Use SNI (-servername) for proper testing
-                if echo | openssl s_client -connect "$test_host:443" -servername "$test_host" -"$proto" 2>/dev/null | grep -q "Cipher"; then
+                # FIXED: Check for actual cipher (not "Cipher is (NONE)") to avoid false positives
+                local ssl_output=$(echo | openssl s_client -connect "$test_host:443" -servername "$test_host" -"$proto" 2>&1)
+                if echo "$ssl_output" | grep "Cipher" | grep -q -v "(NONE)"; then
                     # Insecure protocols
                     if [[ "$proto" == "ssl3" ]] || [[ "$proto" == "tls1" ]] || [[ "$proto" == "tls1_1" ]]; then
                         print_status "    $proto_name:" "✗ Enabled (insecure!)" "$RED"

--- a/setup.sh
+++ b/setup.sh
@@ -135,18 +135,20 @@ calculate_cpu_limits() {
 
     if [[ $cpu_count -eq 1 ]]; then
         # Single CPU server - conservative limits
-        CONFIG[BACKEND_CPU_LIMIT]="0.8"
-        CONFIG[BACKEND_CPU_RESERVATION]="0.3"
+        # IMPORTANT: Total must be < 1.0 (not = 1.0) on single-CPU systems
+        # Docker enforces: "range of CPUs is from 0.01 to 1.00" (exclusive upper bound)
+        CONFIG[BACKEND_CPU_LIMIT]="0.75"
+        CONFIG[BACKEND_CPU_RESERVATION]="0.25"
         CONFIG[BOT_CPU_LIMIT]="0.15"
         CONFIG[BOT_CPU_RESERVATION]="0.05"
         CONFIG[NGINX_CPU_LIMIT]="0.05"
         CONFIG[NGINX_CPU_RESERVATION]="0.01"
 
         info "Single-CPU configuration:"
-        info "  Backend: 0.8 CPU (80%)"
-        info "  Bot: 0.15 CPU (15%)"
+        info "  Backend: 0.75 CPU (79%)"
+        info "  Bot: 0.15 CPU (16%)"
         info "  Nginx: 0.05 CPU (5%)"
-        info "  Total: 1.0 CPU"
+        info "  Total: 0.95 CPU (< 1.0 required)"
 
     elif [[ $cpu_count -eq 2 ]]; then
         # Dual CPU server - balanced limits


### PR DESCRIPTION
### PostgreSQL pg_notify Missing (CRITICAL)
- **Problem**: repair_postgres_directories_atomic() creates only persistent_dirs when PostgreSQL is running,
  skipping runtime_dirs (pg_notify, pg_dynshmem, pg_stat). On PostgreSQL restart, this causes 18+ FATAL errors.
- **Solution**: Stop PostgreSQL BEFORE repair to ensure ALL directories (persistent + runtime) are created atomically.
- **File**: deploy.sh:1271-1280

### CPU Limits Exceed Single-CPU Max (HIGH)
- **Problem**: Single-CPU systems had sum of limits = 1.0 (0.8+0.15+0.05), causing Docker error:
  "range of CPUs is from 0.01 to 1.00" (exclusive upper bound).
- **Solution**: Reduced BACKEND_CPU_LIMIT from 0.8 to 0.75, total now 0.95 < 1.0.
- **File**: setup.sh:140-151

### logs.sh SSL Protocol Check False Positive (MEDIUM)
- **Problem**: logs.sh reported TLSv1.0/1.1 as "Enabled" despite nginx correctly blocking them.
  Cause: grep "Cipher" matched "Cipher is (NONE)" in failed connections.
- **Solution**: Check for actual cipher (not "(NONE)") to avoid false positives.
- **File**: logs.sh:884-900

### Testing
- [x] Bash syntax checks passed (deploy.sh, setup.sh, logs.sh)
- [x] TLSv1.0 manually tested: connection refused (correct behavior)
- [x] TLSv1.2 manually tested: connection successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>