### PR TITLE
fix(scripts): correct alembic command path and revision pattern

### DIFF
--- a/logs.sh
+++ b/logs.sh
@@ -554,8 +554,8 @@ check_database_details() {
 
     if [ -n "$backend_container" ]; then
         # Get current Alembic version
-        local current_version=$(docker exec "$backend_container" bash -c "cd /app/backend/db/migrations && alembic current 2>/dev/null" | grep -oP '[a-f0-9]{12}' | head -1 || echo "unknown")
-        local head_version=$(docker exec "$backend_container" bash -c "cd /app/backend/db/migrations && alembic heads 2>/dev/null" | grep -oP '[a-f0-9]{12}' | head -1 || echo "unknown")
+        local current_version=$(docker exec "$backend_container" bash -c "cd /app && alembic -c backend/db/migrations/alembic.ini current 2>/dev/null" | tail -1 | grep -oP '^[a-zA-Z0-9]{12}' || echo "unknown")
+        local head_version=$(docker exec "$backend_container" bash -c "cd /app && alembic -c backend/db/migrations/alembic.ini heads 2>/dev/null" | tail -1 | grep -oP '^[a-zA-Z0-9]{12}' || echo "unknown")
 
         if [ "$current_version" != "unknown" ]; then
             print_status "  Current Version:" "$current_version" "$WHITE"

--- a/scripts/lib/alembic.sh
+++ b/scripts/lib/alembic.sh
@@ -21,9 +21,10 @@
 # =============================================================================
 
 # Alembic command wrapper (runs inside backend container)
+# Must specify config file path and run from /app directory
 alembic_cmd() {
     local alembic_args="$*"
-    compose_cmd exec -T backend alembic $alembic_args
+    compose_cmd exec -T backend bash -c "cd /app && alembic -c backend/db/migrations/alembic.ini $alembic_args"
 }
 
 # =============================================================================

--- a/scripts/lib/migrations.sh
+++ b/scripts/lib/migrations.sh
@@ -54,7 +54,7 @@ run_alembic_migrations() {
     # Check current Alembic revision
     info "Checking current migration status..."
     local current_revision
-    current_revision=$(compose_cmd exec -T backend bash -c "cd /app && alembic -c backend/db/migrations/alembic.ini current 2>/dev/null | head -1 | grep -oP '^[a-f0-9]{12}'" || echo "none")
+    current_revision=$(compose_cmd exec -T backend bash -c "cd /app && alembic -c backend/db/migrations/alembic.ini current 2>/dev/null | tail -1 | grep -oP '^[a-zA-Z0-9]{12}'" || echo "none")
 
     if [[ "$current_revision" == "none" ]]; then
         info "No migrations applied yet - fresh database detected"
@@ -91,7 +91,7 @@ run_alembic_migrations() {
 
         # Show new current revision
         local new_revision
-        new_revision=$(compose_cmd exec -T backend bash -c "cd /app && alembic -c backend/db/migrations/alembic.ini current 2>/dev/null | head -1 | grep -oP '^[a-f0-9]{12}'" || echo "unknown")
+        new_revision=$(compose_cmd exec -T backend bash -c "cd /app && alembic -c backend/db/migrations/alembic.ini current 2>/dev/null | tail -1 | grep -oP '^[a-zA-Z0-9]{12}'" || echo "unknown")
         if [[ "$new_revision" != "unknown" && "$new_revision" != "$current_revision" ]]; then
             info "Database updated: $current_revision → $new_revision"
         elif [[ "$new_revision" == "$current_revision" ]]; then
@@ -127,7 +127,7 @@ verify_database_schema() {
     # Check Alembic migration status
     info "Checking Alembic migration status..."
     local current_revision
-    current_revision=$(compose_cmd exec -T backend bash -c "cd /app && alembic -c backend/db/migrations/alembic.ini current 2>/dev/null | head -1 | grep -oP '^[a-f0-9]{12}'" || echo "none")
+    current_revision=$(compose_cmd exec -T backend bash -c "cd /app && alembic -c backend/db/migrations/alembic.ini current 2>/dev/null | tail -1 | grep -oP '^[a-zA-Z0-9]{12}'" || echo "none")
 
     if [[ "$current_revision" == "none" ]]; then
         warning "No Alembic migrations applied - database may be empty"


### PR DESCRIPTION
- Fix alembic_cmd() to use correct config path: cd /app && alembic -c backend/db/migrations/alembic.ini
- Change regex from [a-f0-9]{12} to [a-zA-Z0-9]{12} to match alphanumeric revisions like r3d4e5f6g7h8
- Use tail -1 instead of head -1 to get last line (revision) instead of first INFO line
- Fixes false warning "No Alembic migrations applied" during deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>