### PR TITLE
fix(ui): add debit/credit category type buttons to edit modals

### DIFF
--- a/frontend/web/templates/components/modal_edit_fact.html
+++ b/frontend/web/templates/components/modal_edit_fact.html
@@ -25,7 +25,7 @@
                        placeholder="ДД.ММ.ГГГГ" autocomplete="off" />
             </div>
 
-            <!-- Тип категории (expense/income) -->
+            <!-- Тип категории (expense/income/debit/credit) -->
             <div class="form-control">
                 <label class="label py-1">
                     <span class="label-text font-semibold">Тип категории *</span>
@@ -38,6 +38,14 @@
                     <label class="btn btn-sm btn-outline btn-success edit-category-type-btn" data-type="income">
                         <input type="radio" name="edit_category_type" value="income" class="hidden" />
                         Доход
+                    </label>
+                    <label class="btn btn-sm btn-outline btn-info edit-category-type-btn" data-type="debit">
+                        <input type="radio" name="edit_category_type" value="debit" class="hidden" />
+                        Списание
+                    </label>
+                    <label class="btn btn-sm btn-outline btn-warning edit-category-type-btn" data-type="credit">
+                        <input type="radio" name="edit_category_type" value="credit" class="hidden" />
+                        Пополнение
                     </label>
                 </div>
             </div>

--- a/frontend/web/templates/components/modal_edit_plan.html
+++ b/frontend/web/templates/components/modal_edit_plan.html
@@ -25,7 +25,7 @@
                        placeholder="ДД.ММ.ГГГГ" autocomplete="off" />
             </div>
 
-            <!-- Тип категории (expense/income) -->
+            <!-- Тип категории (expense/income/debit/credit) -->
             <div class="form-control">
                 <label class="label py-1">
                     <span class="label-text font-semibold">Тип категории *</span>
@@ -38,6 +38,14 @@
                     <label class="btn btn-sm btn-outline btn-success edit-category-type-btn" data-type="income">
                         <input type="radio" name="edit_category_type" value="income" class="hidden" />
                         Доход
+                    </label>
+                    <label class="btn btn-sm btn-outline btn-info edit-category-type-btn" data-type="debit">
+                        <input type="radio" name="edit_category_type" value="debit" class="hidden" />
+                        Списание
+                    </label>
+                    <label class="btn btn-sm btn-outline btn-warning edit-category-type-btn" data-type="credit">
+                        <input type="radio" name="edit_category_type" value="credit" class="hidden" />
+                        Пополнение
                     </label>
                 </div>
             </div>


### PR DESCRIPTION
Add missing "Списание" (debit) and "Пополнение" (credit) buttons
to category type selector in edit modals for facts and plan pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>