### PR TITLE
feat(ui): add responsive font scaling and improve mobile edit modal layout

### DIFF
--- a/backend/app/api/v1/analytics.py
+++ b/backend/app/api/v1/analytics.py
@@ -458,26 +458,31 @@ async def get_quick_stats_html(
             #desktop-stats {{ display: none !important; }}
             #mobile-stats {{ display: grid !important; }}
         }}
+        /* Responsive font sizing */
+        .stat-title {{ font-size: clamp(0.625rem, 2vw, 0.875rem); }}
+        .stat-label {{ font-size: clamp(0.5rem, 1.5vw, 0.75rem); }}
+        .stat-value {{ font-size: clamp(0.5rem, 1.5vw, 0.75rem); }}
+        .stat-pct {{ font-size: clamp(0.5rem, 1.3vw, 0.625rem); }}
     </style>
     <!-- Desktop version: horizontal flex layout -->
     <div id="desktop-stats" class="flex flex-row gap-4 w-full">
         <!-- Доходы -->
         <div class="bg-base-200 rounded-lg p-3 shadow flex-1">
             <div class="mb-1">
-                <span class="font-semibold text-[10px]">💰 Доходы</span>
+                <span class="font-semibold stat-title">💰 Доходы</span>
             </div>
             <div class="space-y-0.5">
                 <div class="flex justify-between items-baseline">
-                    <div class="text-[8px] opacity-60">План</div>
-                    <div class="font-semibold text-[8px]">{format_money(month_plan_income)}</div>
+                    <div class="stat-label opacity-60">План</div>
+                    <div class="font-semibold stat-value">{format_money(month_plan_income)}</div>
                 </div>
                 <div class="flex justify-between items-baseline">
-                    <div class="text-[8px] opacity-60">Факт</div>
-                    <div class="font-bold text-success text-[8px]">{format_money(month_income)}</div>
+                    <div class="stat-label opacity-60">Факт</div>
+                    <div class="font-bold text-success stat-value">{format_money(month_income)}</div>
                 </div>
                 <div class="flex justify-between items-baseline">
-                    <div class="text-[8px] opacity-60">Исп., %</div>
-                    <div class="font-bold {get_pct_color(plan_execution_income_pct)} text-[6px]">{format_pct(plan_execution_income_pct)}</div>
+                    <div class="stat-label opacity-60">Исп., %</div>
+                    <div class="font-bold {get_pct_color(plan_execution_income_pct)} stat-pct">{format_pct(plan_execution_income_pct)}</div>
                 </div>
             </div>
         </div>
@@ -485,20 +490,20 @@ async def get_quick_stats_html(
         <!-- Расходы -->
         <div class="bg-base-200 rounded-lg p-3 shadow flex-1">
             <div class="mb-1">
-                <span class="font-semibold text-[10px]">💸 Расходы</span>
+                <span class="font-semibold stat-title">💸 Расходы</span>
             </div>
             <div class="space-y-0.5">
                 <div class="flex justify-between items-baseline">
-                    <div class="text-[8px] opacity-60">План</div>
-                    <div class="font-semibold text-[8px]">{format_money(month_plan_expense)}</div>
+                    <div class="stat-label opacity-60">План</div>
+                    <div class="font-semibold stat-value">{format_money(month_plan_expense)}</div>
                 </div>
                 <div class="flex justify-between items-baseline">
-                    <div class="text-[8px] opacity-60">Факт</div>
-                    <div class="font-bold text-error text-[8px]">{format_money(month_expense)}</div>
+                    <div class="stat-label opacity-60">Факт</div>
+                    <div class="font-bold text-error stat-value">{format_money(month_expense)}</div>
                 </div>
                 <div class="flex justify-between items-baseline">
-                    <div class="text-[8px] opacity-60">Исп., %</div>
-                    <div class="font-bold {get_pct_color(plan_execution_expense_pct)} text-[6px]">{format_pct(plan_execution_expense_pct)}</div>
+                    <div class="stat-label opacity-60">Исп., %</div>
+                    <div class="font-bold {get_pct_color(plan_execution_expense_pct)} stat-pct">{format_pct(plan_execution_expense_pct)}</div>
                 </div>
             </div>
         </div>
@@ -506,20 +511,20 @@ async def get_quick_stats_html(
         <!-- Пополнение -->
         <div class="bg-base-200 rounded-lg p-3 shadow flex-1">
             <div class="mb-1">
-                <span class="font-semibold text-[10px]">➕ Пополнение</span>
+                <span class="font-semibold stat-title">➕ Пополнение</span>
             </div>
             <div class="space-y-0.5">
                 <div class="flex justify-between items-baseline">
-                    <div class="text-[8px] opacity-60">План</div>
-                    <div class="font-semibold text-[8px]">{format_money(month_plan_credit)}</div>
+                    <div class="stat-label opacity-60">План</div>
+                    <div class="font-semibold stat-value">{format_money(month_plan_credit)}</div>
                 </div>
                 <div class="flex justify-between items-baseline">
-                    <div class="text-[8px] opacity-60">Факт</div>
-                    <div class="font-bold text-info text-[8px]">{format_money(month_credit)}</div>
+                    <div class="stat-label opacity-60">Факт</div>
+                    <div class="font-bold text-info stat-value">{format_money(month_credit)}</div>
                 </div>
                 <div class="flex justify-between items-baseline">
-                    <div class="text-[8px] opacity-60">Исп., %</div>
-                    <div class="font-bold {get_pct_color(plan_execution_credit_pct)} text-[6px]">{format_pct(plan_execution_credit_pct)}</div>
+                    <div class="stat-label opacity-60">Исп., %</div>
+                    <div class="font-bold {get_pct_color(plan_execution_credit_pct)} stat-pct">{format_pct(plan_execution_credit_pct)}</div>
                 </div>
             </div>
         </div>
@@ -527,44 +532,44 @@ async def get_quick_stats_html(
         <!-- Списание -->
         <div class="bg-base-200 rounded-lg p-3 shadow flex-1">
             <div class="mb-1">
-                <span class="font-semibold text-[10px]">➖ Списание</span>
+                <span class="font-semibold stat-title">➖ Списание</span>
             </div>
             <div class="space-y-0.5">
                 <div class="flex justify-between items-baseline">
-                    <div class="text-[8px] opacity-60">План</div>
-                    <div class="font-semibold text-[8px]">{format_money(month_plan_debit)}</div>
+                    <div class="stat-label opacity-60">План</div>
+                    <div class="font-semibold stat-value">{format_money(month_plan_debit)}</div>
                 </div>
                 <div class="flex justify-between items-baseline">
-                    <div class="text-[8px] opacity-60">Факт</div>
-                    <div class="font-bold text-warning text-[8px]">{format_money(month_debit)}</div>
+                    <div class="stat-label opacity-60">Факт</div>
+                    <div class="font-bold text-warning stat-value">{format_money(month_debit)}</div>
                 </div>
                 <div class="flex justify-between items-baseline">
-                    <div class="text-[8px] opacity-60">Исп., %</div>
-                    <div class="font-bold {get_pct_color(plan_execution_debit_pct)} text-[6px]">{format_pct(plan_execution_debit_pct)}</div>
+                    <div class="stat-label opacity-60">Исп., %</div>
+                    <div class="font-bold {get_pct_color(plan_execution_debit_pct)} stat-pct">{format_pct(plan_execution_debit_pct)}</div>
                 </div>
             </div>
         </div>
     </div>
 
-    <!-- Mobile version: 2x2 grid (font reduced by 4px for mobile) -->
+    <!-- Mobile version: 2x2 grid with responsive font sizing -->
     <div id="mobile-stats" class="grid grid-cols-2 gap-3">
         <!-- Доходы -->
         <div class="bg-base-200 rounded-lg p-2 shadow">
             <div class="mb-0.5">
-                <span class="font-semibold text-[4px]">💰 Доходы</span>
+                <span class="font-semibold stat-title">💰 Доходы</span>
             </div>
             <div class="space-y-0.5">
                 <div class="flex justify-between items-baseline">
-                    <div class="text-[3px] opacity-60">План</div>
-                    <div class="font-semibold text-[4px]">{format_money(month_plan_income)}</div>
+                    <div class="stat-label opacity-60">План</div>
+                    <div class="font-semibold stat-value">{format_money(month_plan_income)}</div>
                 </div>
                 <div class="flex justify-between items-baseline">
-                    <div class="text-[3px] opacity-60">Факт</div>
-                    <div class="font-bold text-success text-[4px]">{format_money(month_income)}</div>
+                    <div class="stat-label opacity-60">Факт</div>
+                    <div class="font-bold text-success stat-value">{format_money(month_income)}</div>
                 </div>
                 <div class="flex justify-between items-baseline">
-                    <div class="text-[3px] opacity-60">Исп., %</div>
-                    <div class="font-bold {get_pct_color(plan_execution_income_pct)} text-[3px]">{format_pct(plan_execution_income_pct)}</div>
+                    <div class="stat-label opacity-60">Исп., %</div>
+                    <div class="font-bold {get_pct_color(plan_execution_income_pct)} stat-pct">{format_pct(plan_execution_income_pct)}</div>
                 </div>
             </div>
         </div>
@@ -572,20 +577,20 @@ async def get_quick_stats_html(
         <!-- Расходы -->
         <div class="bg-base-200 rounded-lg p-2 shadow">
             <div class="mb-0.5">
-                <span class="font-semibold text-[4px]">💸 Расходы</span>
+                <span class="font-semibold stat-title">💸 Расходы</span>
             </div>
             <div class="space-y-0.5">
                 <div class="flex justify-between items-baseline">
-                    <div class="text-[3px] opacity-60">План</div>
-                    <div class="font-semibold text-[4px]">{format_money(month_plan_expense)}</div>
+                    <div class="stat-label opacity-60">План</div>
+                    <div class="font-semibold stat-value">{format_money(month_plan_expense)}</div>
                 </div>
                 <div class="flex justify-between items-baseline">
-                    <div class="text-[3px] opacity-60">Факт</div>
-                    <div class="font-bold text-error text-[4px]">{format_money(month_expense)}</div>
+                    <div class="stat-label opacity-60">Факт</div>
+                    <div class="font-bold text-error stat-value">{format_money(month_expense)}</div>
                 </div>
                 <div class="flex justify-between items-baseline">
-                    <div class="text-[3px] opacity-60">Исп., %</div>
-                    <div class="font-bold {get_pct_color(plan_execution_expense_pct)} text-[3px]">{format_pct(plan_execution_expense_pct)}</div>
+                    <div class="stat-label opacity-60">Исп., %</div>
+                    <div class="font-bold {get_pct_color(plan_execution_expense_pct)} stat-pct">{format_pct(plan_execution_expense_pct)}</div>
                 </div>
             </div>
         </div>
@@ -593,20 +598,20 @@ async def get_quick_stats_html(
         <!-- Пополнение -->
         <div class="bg-base-200 rounded-lg p-2 shadow">
             <div class="mb-0.5">
-                <span class="font-semibold text-[4px]">➕ Пополнение</span>
+                <span class="font-semibold stat-title">➕ Пополнение</span>
             </div>
             <div class="space-y-0.5">
                 <div class="flex justify-between items-baseline">
-                    <div class="text-[3px] opacity-60">План</div>
-                    <div class="font-semibold text-[4px]">{format_money(month_plan_credit)}</div>
+                    <div class="stat-label opacity-60">План</div>
+                    <div class="font-semibold stat-value">{format_money(month_plan_credit)}</div>
                 </div>
                 <div class="flex justify-between items-baseline">
-                    <div class="text-[3px] opacity-60">Факт</div>
-                    <div class="font-bold text-info text-[4px]">{format_money(month_credit)}</div>
+                    <div class="stat-label opacity-60">Факт</div>
+                    <div class="font-bold text-info stat-value">{format_money(month_credit)}</div>
                 </div>
                 <div class="flex justify-between items-baseline">
-                    <div class="text-[3px] opacity-60">Исп., %</div>
-                    <div class="font-bold {get_pct_color(plan_execution_credit_pct)} text-[3px]">{format_pct(plan_execution_credit_pct)}</div>
+                    <div class="stat-label opacity-60">Исп., %</div>
+                    <div class="font-bold {get_pct_color(plan_execution_credit_pct)} stat-pct">{format_pct(plan_execution_credit_pct)}</div>
                 </div>
             </div>
         </div>
@@ -614,20 +619,20 @@ async def get_quick_stats_html(
         <!-- Списание -->
         <div class="bg-base-200 rounded-lg p-2 shadow">
             <div class="mb-0.5">
-                <span class="font-semibold text-[4px]">➖ Списание</span>
+                <span class="font-semibold stat-title">➖ Списание</span>
             </div>
             <div class="space-y-0.5">
                 <div class="flex justify-between items-baseline">
-                    <div class="text-[3px] opacity-60">План</div>
-                    <div class="font-semibold text-[4px]">{format_money(month_plan_debit)}</div>
+                    <div class="stat-label opacity-60">План</div>
+                    <div class="font-semibold stat-value">{format_money(month_plan_debit)}</div>
                 </div>
                 <div class="flex justify-between items-baseline">
-                    <div class="text-[3px] opacity-60">Факт</div>
-                    <div class="font-bold text-warning text-[4px]">{format_money(month_debit)}</div>
+                    <div class="stat-label opacity-60">Факт</div>
+                    <div class="font-bold text-warning stat-value">{format_money(month_debit)}</div>
                 </div>
                 <div class="flex justify-between items-baseline">
-                    <div class="text-[3px] opacity-60">Исп., %</div>
-                    <div class="font-bold {get_pct_color(plan_execution_debit_pct)} text-[3px]">{format_pct(plan_execution_debit_pct)}</div>
+                    <div class="stat-label opacity-60">Исп., %</div>
+                    <div class="font-bold {get_pct_color(plan_execution_debit_pct)} stat-pct">{format_pct(plan_execution_debit_pct)}</div>
                 </div>
             </div>
         </div>
@@ -793,15 +798,15 @@ async def get_account_balances_html(
     for bal in balances:
         mobile_cards += f"""
         <div class="bg-base-200 rounded-lg p-2">
-            <div class="font-semibold text-xs mb-1 truncate" title="{bal['name']}">{bal['name']}</div>
+            <div class="font-semibold balance-title mb-1 truncate" title="{bal['name']}">{bal['name']}</div>
             <div class="space-y-1">
                 <div class="flex justify-between items-center gap-2">
-                    <span class="text-[10px] opacity-60">Начало</span>
-                    <span class="text-xs {get_balance_color(bal['opening_balance'])}">{format_money(bal['opening_balance'])}</span>
+                    <span class="balance-label opacity-60">Начало</span>
+                    <span class="balance-value {get_balance_color(bal['opening_balance'])}">{format_money(bal['opening_balance'])}</span>
                 </div>
                 <div class="flex justify-between items-center gap-2">
-                    <span class="text-[10px] opacity-60">Текущий</span>
-                    <span class="text-xs font-bold {get_balance_color(bal['current_balance'])}">{format_money(bal['current_balance'])}</span>
+                    <span class="balance-label opacity-60">Текущий</span>
+                    <span class="balance-value font-bold {get_balance_color(bal['current_balance'])}">{format_money(bal['current_balance'])}</span>
                 </div>
             </div>
         </div>"""
@@ -816,6 +821,10 @@ async def get_account_balances_html(
             #desktop-balances {{ display: none !important; }}
             #mobile-balances {{ display: grid !important; }}
         }}
+        /* Responsive font sizing for balances */
+        .balance-title {{ font-size: clamp(0.625rem, 2vw, 0.875rem); }}
+        .balance-label {{ font-size: clamp(0.5rem, 1.5vw, 0.75rem); }}
+        .balance-value {{ font-size: clamp(0.625rem, 1.8vw, 0.875rem); }}
     </style>
 
     <!-- Desktop: Adaptive grid layout (1-4 columns) -->

--- a/frontend/web/templates/components/modal_edit_fact.html
+++ b/frontend/web/templates/components/modal_edit_fact.html
@@ -92,20 +92,21 @@
 
             <!-- Кнопки -->
             <div class="modal-action mt-3 flex flex-row gap-2">
-                <!-- Кнопка удаления - видна только на мобильных (где нет чекбоксов) -->
-                <button type="button" class="btn btn-sm btn-error flex-1 md:hidden" onclick="deleteFromEditModal()">
+                <!-- Кнопка удаления - только иконка, видна только на мобильных (где нет чекбоксов) -->
+                <button type="button" class="btn btn-sm btn-error btn-square md:hidden" onclick="deleteFromEditModal()" title="Удалить">
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
                     </svg>
-                    Удалить
                 </button>
-                <button type="button" class="btn btn-sm btn-ghost flex-1 md:flex-none" onclick="closeEditModal()">
+                <!-- Разделитель (пустое пространство) -->
+                <div class="flex-1 md:hidden"></div>
+                <button type="button" class="btn btn-sm btn-ghost flex-none" onclick="closeEditModal()">
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
                     </svg>
                     Отмена
                 </button>
-                <button type="submit" class="btn btn-sm save-btn flex-1 md:flex-none">
+                <button type="submit" class="btn btn-sm save-btn flex-1">
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
                     </svg>

--- a/frontend/web/templates/components/modal_edit_plan.html
+++ b/frontend/web/templates/components/modal_edit_plan.html
@@ -137,20 +137,21 @@
 
             <!-- Кнопки -->
             <div class="modal-action mt-3 flex flex-row gap-2">
-                <!-- Кнопка удаления - видна только на мобильных (где нет чекбоксов) -->
-                <button type="button" class="btn btn-sm btn-error flex-1 md:hidden" onclick="deleteFromEditModal()">
+                <!-- Кнопка удаления - только иконка, видна только на мобильных (где нет чекбоксов) -->
+                <button type="button" class="btn btn-sm btn-error btn-square md:hidden" onclick="deleteFromEditModal()" title="Удалить">
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
                     </svg>
-                    Удалить
                 </button>
-                <button type="button" class="btn btn-sm btn-ghost flex-1 md:flex-none" onclick="closeEditModal()">
+                <!-- Разделитель (пустое пространство) -->
+                <div class="flex-1 md:hidden"></div>
+                <button type="button" class="btn btn-sm btn-ghost flex-none" onclick="closeEditModal()">
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
                     </svg>
                     Отмена
                 </button>
-                <button type="submit" class="btn btn-sm save-btn flex-1 md:flex-none">
+                <button type="submit" class="btn btn-sm save-btn flex-1">
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
                     </svg>


### PR DESCRIPTION
- Add CSS clamp() for adaptive font sizing in quick-stats and mobile-balances
  * stat-title: clamp(0.625rem, 2vw, 0.875rem) - 10-14px range
  * stat-label/value: clamp(0.5rem, 1.5vw, 0.75rem) - 8-12px range
  * Prevents text wrapping on narrow screens (320px-1920px)

- Improve mobile edit modal buttons layout
  * Delete button: icon-only with btn-square (compact)
  * Add flex-1 spacer between delete and cancel buttons
  * Expand save button to flex-1 for better mobile UX
  * Apply to both modal_edit_fact.html and modal_edit_plan.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>