### PR TITLE
fix(ui): reduce font scaling and prevent text wrapping in quick-stats and balances

### DIFF
--- a/backend/app/api/v1/analytics.py
+++ b/backend/app/api/v1/analytics.py
@@ -465,11 +465,13 @@ async def get_quick_stats_html(
             #desktop-stats {{ display: none !important; }}
             #mobile-stats {{ display: grid !important; }}
         }}
-        /* Responsive font sizing - increased vw for better mobile scaling */
-        .stat-title {{ font-size: clamp(0.75rem, 3.5vw, 1rem); }}
-        .stat-label {{ font-size: clamp(0.625rem, 3vw, 0.875rem); }}
-        .stat-value {{ font-size: clamp(0.625rem, 3vw, 0.875rem); }}
-        .stat-pct {{ font-size: clamp(0.625rem, 2.8vw, 0.75rem); }}
+        /* Responsive font sizing - balanced for no wrapping */
+        .stat-title {{ font-size: clamp(0.625rem, 2.5vw, 0.875rem); }}
+        .stat-label {{ font-size: clamp(0.5rem, 2vw, 0.75rem); }}
+        .stat-value {{ font-size: clamp(0.5rem, 2vw, 0.75rem); }}
+        .stat-pct {{ font-size: clamp(0.5rem, 1.8vw, 0.625rem); }}
+        /* Prevent text wrapping */
+        .stat-row {{ white-space: nowrap; }}
     </style>
     <!-- Desktop version: horizontal flex layout -->
     <div id="desktop-stats" class="flex flex-row gap-3 w-full">
@@ -479,15 +481,15 @@ async def get_quick_stats_html(
                 <span class="font-semibold stat-title">💰 Доходы</span>
             </div>
             <div class="space-y-0.5">
-                <div class="flex justify-between items-baseline gap-2">
+                <div class="stat-row flex justify-between items-baseline gap-2">
                     <span class="stat-label opacity-60">План</span>
                     <span class="font-semibold stat-value">{format_money_desktop(month_plan_income)}</span>
                 </div>
-                <div class="flex justify-between items-baseline gap-2">
+                <div class="stat-row flex justify-between items-baseline gap-2">
                     <span class="stat-label opacity-60">Факт</span>
                     <span class="font-bold text-success stat-value">{format_money_desktop(month_income)}</span>
                 </div>
-                <div class="flex justify-between items-baseline gap-2">
+                <div class="stat-row flex justify-between items-baseline gap-2">
                     <span class="stat-label opacity-60">Исп., %</span>
                     <span class="font-bold {get_pct_color(plan_execution_income_pct)} stat-pct">{format_pct(plan_execution_income_pct)}</span>
                 </div>
@@ -500,15 +502,15 @@ async def get_quick_stats_html(
                 <span class="font-semibold stat-title">💸 Расходы</span>
             </div>
             <div class="space-y-0.5">
-                <div class="flex justify-between items-baseline gap-2">
+                <div class="stat-row flex justify-between items-baseline gap-2">
                     <span class="stat-label opacity-60">План</span>
                     <span class="font-semibold stat-value">{format_money_desktop(month_plan_expense)}</span>
                 </div>
-                <div class="flex justify-between items-baseline gap-2">
+                <div class="stat-row flex justify-between items-baseline gap-2">
                     <span class="stat-label opacity-60">Факт</span>
                     <span class="font-bold text-error stat-value">{format_money_desktop(month_expense)}</span>
                 </div>
-                <div class="flex justify-between items-baseline gap-2">
+                <div class="stat-row flex justify-between items-baseline gap-2">
                     <span class="stat-label opacity-60">Исп., %</span>
                     <span class="font-bold {get_pct_color(plan_execution_expense_pct)} stat-pct">{format_pct(plan_execution_expense_pct)}</span>
                 </div>
@@ -521,15 +523,15 @@ async def get_quick_stats_html(
                 <span class="font-semibold stat-title">➕ Пополнение</span>
             </div>
             <div class="space-y-0.5">
-                <div class="flex justify-between items-baseline gap-2">
+                <div class="stat-row flex justify-between items-baseline gap-2">
                     <span class="stat-label opacity-60">План</span>
                     <span class="font-semibold stat-value">{format_money_desktop(month_plan_credit)}</span>
                 </div>
-                <div class="flex justify-between items-baseline gap-2">
+                <div class="stat-row flex justify-between items-baseline gap-2">
                     <span class="stat-label opacity-60">Факт</span>
                     <span class="font-bold text-info stat-value">{format_money_desktop(month_credit)}</span>
                 </div>
-                <div class="flex justify-between items-baseline gap-2">
+                <div class="stat-row flex justify-between items-baseline gap-2">
                     <span class="stat-label opacity-60">Исп., %</span>
                     <span class="font-bold {get_pct_color(plan_execution_credit_pct)} stat-pct">{format_pct(plan_execution_credit_pct)}</span>
                 </div>
@@ -542,15 +544,15 @@ async def get_quick_stats_html(
                 <span class="font-semibold stat-title">➖ Списание</span>
             </div>
             <div class="space-y-0.5">
-                <div class="flex justify-between items-baseline gap-2">
+                <div class="stat-row flex justify-between items-baseline gap-2">
                     <span class="stat-label opacity-60">План</span>
                     <span class="font-semibold stat-value">{format_money_desktop(month_plan_debit)}</span>
                 </div>
-                <div class="flex justify-between items-baseline gap-2">
+                <div class="stat-row flex justify-between items-baseline gap-2">
                     <span class="stat-label opacity-60">Факт</span>
                     <span class="font-bold text-warning stat-value">{format_money_desktop(month_debit)}</span>
                 </div>
-                <div class="flex justify-between items-baseline gap-2">
+                <div class="stat-row flex justify-between items-baseline gap-2">
                     <span class="stat-label opacity-60">Исп., %</span>
                     <span class="font-bold {get_pct_color(plan_execution_debit_pct)} stat-pct">{format_pct(plan_execution_debit_pct)}</span>
                 </div>
@@ -566,15 +568,15 @@ async def get_quick_stats_html(
                 <span class="font-semibold stat-title">💰 Доходы</span>
             </div>
             <div class="space-y-0.5">
-                <div class="flex justify-between items-baseline gap-1">
+                <div class="stat-row flex justify-between items-baseline gap-1">
                     <span class="stat-label opacity-60">План</span>
                     <span class="font-semibold stat-value">{format_money_mobile(month_plan_income)}</span>
                 </div>
-                <div class="flex justify-between items-baseline gap-1">
+                <div class="stat-row flex justify-between items-baseline gap-1">
                     <span class="stat-label opacity-60">Факт</span>
                     <span class="font-bold text-success stat-value">{format_money_mobile(month_income)}</span>
                 </div>
-                <div class="flex justify-between items-baseline gap-1">
+                <div class="stat-row flex justify-between items-baseline gap-1">
                     <span class="stat-label opacity-60">Исп., %</span>
                     <span class="font-bold {get_pct_color(plan_execution_income_pct)} stat-pct">{format_pct(plan_execution_income_pct)}</span>
                 </div>
@@ -587,15 +589,15 @@ async def get_quick_stats_html(
                 <span class="font-semibold stat-title">💸 Расходы</span>
             </div>
             <div class="space-y-0.5">
-                <div class="flex justify-between items-baseline gap-1">
+                <div class="stat-row flex justify-between items-baseline gap-1">
                     <span class="stat-label opacity-60">План</span>
                     <span class="font-semibold stat-value">{format_money_mobile(month_plan_expense)}</span>
                 </div>
-                <div class="flex justify-between items-baseline gap-1">
+                <div class="stat-row flex justify-between items-baseline gap-1">
                     <span class="stat-label opacity-60">Факт</span>
                     <span class="font-bold text-error stat-value">{format_money_mobile(month_expense)}</span>
                 </div>
-                <div class="flex justify-between items-baseline gap-1">
+                <div class="stat-row flex justify-between items-baseline gap-1">
                     <span class="stat-label opacity-60">Исп., %</span>
                     <span class="font-bold {get_pct_color(plan_execution_expense_pct)} stat-pct">{format_pct(plan_execution_expense_pct)}</span>
                 </div>
@@ -608,15 +610,15 @@ async def get_quick_stats_html(
                 <span class="font-semibold stat-title">➕ Пополнение</span>
             </div>
             <div class="space-y-0.5">
-                <div class="flex justify-between items-baseline gap-1">
+                <div class="stat-row flex justify-between items-baseline gap-1">
                     <span class="stat-label opacity-60">План</span>
                     <span class="font-semibold stat-value">{format_money_mobile(month_plan_credit)}</span>
                 </div>
-                <div class="flex justify-between items-baseline gap-1">
+                <div class="stat-row flex justify-between items-baseline gap-1">
                     <span class="stat-label opacity-60">Факт</span>
                     <span class="font-bold text-info stat-value">{format_money_mobile(month_credit)}</span>
                 </div>
-                <div class="flex justify-between items-baseline gap-1">
+                <div class="stat-row flex justify-between items-baseline gap-1">
                     <span class="stat-label opacity-60">Исп., %</span>
                     <span class="font-bold {get_pct_color(plan_execution_credit_pct)} stat-pct">{format_pct(plan_execution_credit_pct)}</span>
                 </div>
@@ -629,15 +631,15 @@ async def get_quick_stats_html(
                 <span class="font-semibold stat-title">➖ Списание</span>
             </div>
             <div class="space-y-0.5">
-                <div class="flex justify-between items-baseline gap-1">
+                <div class="stat-row flex justify-between items-baseline gap-1">
                     <span class="stat-label opacity-60">План</span>
                     <span class="font-semibold stat-value">{format_money_mobile(month_plan_debit)}</span>
                 </div>
-                <div class="flex justify-between items-baseline gap-1">
+                <div class="stat-row flex justify-between items-baseline gap-1">
                     <span class="stat-label opacity-60">Факт</span>
                     <span class="font-bold text-warning stat-value">{format_money_mobile(month_debit)}</span>
                 </div>
-                <div class="flex justify-between items-baseline gap-1">
+                <div class="stat-row flex justify-between items-baseline gap-1">
                     <span class="stat-label opacity-60">Исп., %</span>
                     <span class="font-bold {get_pct_color(plan_execution_debit_pct)} stat-pct">{format_pct(plan_execution_debit_pct)}</span>
                 </div>
@@ -796,11 +798,11 @@ async def get_account_balances_html(
         <div class="bg-base-200 rounded-lg p-2 hover:bg-base-300 transition-colors">
             <div class="font-semibold balance-title mb-1 truncate" title="{bal['name']}">{bal['name']}</div>
             <div class="space-y-1">
-                <div class="flex justify-between items-baseline gap-2">
+                <div class="balance-row flex justify-between items-baseline gap-2">
                     <span class="balance-label opacity-60">Начало</span>
                     <span class="balance-value font-medium {get_balance_color(bal['opening_balance'])}">{format_money_desktop(bal['opening_balance'])}</span>
                 </div>
-                <div class="flex justify-between items-baseline gap-2 pt-1 border-t border-base-300">
+                <div class="balance-row flex justify-between items-baseline gap-2 pt-1 border-t border-base-300">
                     <span class="balance-label opacity-60">Текущий</span>
                     <span class="balance-value font-bold {get_balance_color(bal['current_balance'])}">{format_money_desktop(bal['current_balance'])}</span>
                 </div>
@@ -814,11 +816,11 @@ async def get_account_balances_html(
         <div class="bg-base-200 rounded-lg p-2">
             <div class="font-semibold balance-title mb-1 truncate" title="{bal['name']}">{bal['name']}</div>
             <div class="space-y-1">
-                <div class="flex justify-between items-baseline gap-1">
+                <div class="balance-row flex justify-between items-baseline gap-1">
                     <span class="balance-label opacity-60">Начало</span>
                     <span class="balance-value {get_balance_color(bal['opening_balance'])}">{format_money_mobile(bal['opening_balance'])}</span>
                 </div>
-                <div class="flex justify-between items-baseline gap-1">
+                <div class="balance-row flex justify-between items-baseline gap-1">
                     <span class="balance-label opacity-60">Текущий</span>
                     <span class="balance-value font-bold {get_balance_color(bal['current_balance'])}">{format_money_mobile(bal['current_balance'])}</span>
                 </div>
@@ -835,10 +837,12 @@ async def get_account_balances_html(
             #desktop-balances {{ display: none !important; }}
             #mobile-balances {{ display: grid !important; }}
         }}
-        /* Responsive font sizing for balances - increased vw for better mobile scaling */
-        .balance-title {{ font-size: clamp(0.75rem, 3.5vw, 1rem); }}
-        .balance-label {{ font-size: clamp(0.625rem, 3vw, 0.875rem); }}
-        .balance-value {{ font-size: clamp(0.75rem, 3.2vw, 1rem); }}
+        /* Responsive font sizing for balances - balanced for no wrapping */
+        .balance-title {{ font-size: clamp(0.625rem, 2.5vw, 0.875rem); }}
+        .balance-label {{ font-size: clamp(0.5rem, 2vw, 0.75rem); }}
+        .balance-value {{ font-size: clamp(0.5rem, 2vw, 0.75rem); }}
+        /* Prevent text wrapping */
+        .balance-row {{ white-space: nowrap; }}
     </style>
 
     <!-- Desktop: Adaptive grid layout (1-4 columns) -->


### PR DESCRIPTION
Reduced vw values for responsive font sizing to prevent text overflow:
- stat-title: 3.5vw → 2.5vw
- stat-label: 3vw → 2vw
- stat-value: 3.2vw → 2vw
- balance-title: 3.5vw → 2.5vw
- balance-label: 3vw → 2vw
- balance-value: 3.2vw → 2vw

Added .stat-row and .balance-row classes with white-space: nowrap
to force labels and values on same horizontal line.

Separate format functions for desktop (full amounts with spaces)
vs mobile (abbreviated with k/M suffixes).

Fixes vertical stretching issue on both mobile and desktop versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>