### PR TITLE
fix(ui): reduce import collapse vertical size by half

### DIFF
--- a/frontend/web/templates/lists.html
+++ b/frontend/web/templates/lists.html
@@ -79,10 +79,10 @@
         </div>
 
         <!-- Import Accordion (CSV or Google Sheets) - hidden on mobile -->
-        <div class="collapse bg-base-100 shadow-sm sm:shadow-md mb-4 sm:mb-6 hidden sm:block rounded-lg">
+        <div class="collapse bg-base-100 shadow-sm sm:shadow-md mb-2 sm:mb-3 hidden sm:block rounded-lg">
             <input type="checkbox" id="import-toggle"
                    onchange="handleImportToggle(this.checked)" />
-            <label for="import-toggle" class="collapse-title text-base sm:text-lg font-medium cursor-pointer py-1 sm:py-1.5 min-h-0 flex items-center">
+            <label for="import-toggle" class="collapse-title text-base sm:text-lg font-medium cursor-pointer !py-1 !min-h-0 flex items-center">
                 📥 Импорт <span class="text-xs text-base-content/50 font-normal ml-2">(нажмите чтобы раскрыть)</span>
             </label>
             <div class="collapse-content px-2 sm:px-4">


### PR DESCRIPTION
- mb-4/mb-6 → mb-2/mb-3 (halve bottom margin)
- Add !py-1 !min-h-0 to override DaisyUI defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>