### PR TITLE
fix(analytics): use date_trunc('week') for quarter period aggregation

### DIFF
--- a/backend/app/api/v1/analytics.py
+++ b/backend/app/api/v1/analytics.py
@@ -1704,7 +1704,7 @@ async def get_waterfall_data(
             elif period == "quarter":
                 # Current calendar quarter (from Q start to today)
                 start_date, end_date = get_current_calendar_quarter(today)
-                group_by_expr = Fact.fact_date
+                group_by_expr = func.date_trunc("week", Fact.fact_date)
                 label_format = "week"  # Group by weeks with ISO numbers
             else:  # year
                 # Current calendar year (from Jan 1 to today)
@@ -1862,29 +1862,19 @@ async def get_waterfall_data(
 
         elif label_format == "week":
             # Для period='quarter': агрегация по календарным неделям с ISO номерами
+            # With date_trunc("week"), period_data keys are Mondays (week start dates)
+            # SQL already aggregated data by week, so we just look up by week_start
             # Generate ALL weeks in quarter range, even if no data exists
             # Find Monday of the week containing start_date
             week_start = start_date - timedelta(days=start_date.weekday())
 
             while week_start <= end_date:
-                week_end = week_start + timedelta(days=6)
-                # Don't go beyond the quarter range
-                actual_week_end = min(week_end, end_date)
-                actual_week_start = max(week_start, start_date)
-
-                # Aggregate data for this week from period_data (which is keyed by date)
-                week_income = 0.0
-                week_expense = 0.0
-                week_articles = []
-
-                # Aggregate all days in this week
-                current_date = actual_week_start
-                while current_date <= actual_week_end:
-                    day_data = period_data.get(current_date, {"income": 0.0, "expense": 0.0, "articles": []})
-                    week_income += day_data["income"]
-                    week_expense += day_data["expense"]
-                    week_articles.extend(day_data.get("articles", []))
-                    current_date += timedelta(days=1)
+                # With date_trunc("week"), data is already aggregated by week in SQL
+                # period_data keys are Mondays (week start dates)
+                week_data = period_data.get(week_start, {"income": 0.0, "expense": 0.0, "articles": []})
+                week_income = week_data["income"]
+                week_expense = week_data["expense"]
+                week_articles = week_data.get("articles", [])
 
                 week_balance = week_income - week_expense
                 cumulative_balance += week_balance

--- a/docs/architecture/endpoints/analytics.yaml
+++ b/docs/architecture/endpoints/analytics.yaml
@@ -253,15 +253,19 @@ routes:
     notes: |
       Aggregation depends on period or date range:
       - period=month: Groups by days (from 1st of month to today)
-      - period=quarter: Groups by weeks with ISO week numbers (from Q start to today)
+      - period=quarter: Groups by weeks using date_trunc('week') (from Q start to today)
       - period=year: Groups by months using date_trunc('month') (from Jan 1 to today)
       - Custom date range ≤31 days: Groups by days
-      - Custom date range 32-91 days: Groups by weeks
-      - Custom date range >91 days: Groups by months
+      - Custom date range 32-91 days: Groups by weeks using date_trunc('week')
+      - Custom date range >91 days: Groups by months using date_trunc('month')
 
       FIX (2025-12-21): Changed period='year' to use date_trunc('month') for correct
       monthly aggregation. Previously used Fact.fact_date which only counted
       transactions on the 1st of each month.
+
+      FIX (2025-12-21): Changed period='quarter' to use date_trunc('week') for
+      consistency with custom date range 32-91 days. Updated week rendering to look
+      up data by week_start (Monday) directly instead of iterating through days.
 
 # Frontend
 frontend:


### PR DESCRIPTION
- Changed period='quarter' to use func.date_trunc('week') for SQL-level
  week aggregation, consistent with custom date range 32-91 days
- Simplified week rendering logic to look up data by week_start (Monday)
  directly instead of iterating through each day
- This is more efficient (SQL aggregation vs Python) and consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>