### PR TITLE
perf(backend): migrate WebSocket services to orjson

### DIFF
--- a/backend/app/api/v1/endpoints/budget_ws.py
+++ b/backend/app/api/v1/endpoints/budget_ws.py
@@ -31,15 +31,17 @@ Messages (Client -> Server):
 """
 
 import asyncio
-import json
 import logging
 import time
 import uuid
 from collections import deque
 from datetime import datetime, timedelta
+from json import JSONDecodeError
 from typing import Any
 
 from fastapi import APIRouter, Body, Depends, HTTPException, Query, WebSocket, WebSocketDisconnect, status
+
+from backend.app.core.json_utils import dumps as json_dumps, loads as json_loads
 from jose import JWTError, jwt
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -313,7 +315,7 @@ class BudgetWebSocketManager:
             "data": data,
             "timestamp": datetime.utcnow().isoformat(),
         }
-        message = json.dumps(event, default=str)
+        message = json_dumps(event)
 
         async with self._lock:
             connections = list(self.connections)
@@ -353,7 +355,7 @@ class BudgetWebSocketManager:
             "data": data,
             "timestamp": datetime.utcnow().isoformat(),
         }
-        message = json.dumps(event, default=str)
+        message = json_dumps(event)
 
         # Use lock to prevent race condition with concurrent disconnect/cleanup
         async with self._lock:
@@ -590,7 +592,7 @@ async def budget_websocket_endpoint(
 
                 # Parse and handle client message
                 try:
-                    msg = json.loads(message)
+                    msg = json_loads(message)
                     msg_type = msg.get("type")
 
                     if msg_type == "ping":
@@ -611,7 +613,7 @@ async def budget_websocket_endpoint(
                     else:
                         logger.debug(f"Budget WS unknown message type: {msg_type}")
 
-                except json.JSONDecodeError:
+                except (JSONDecodeError, ValueError):
                     logger.warning(f"Budget WS invalid JSON from user {user_id}")
 
             except asyncio.TimeoutError:

--- a/backend/app/services/cache_service.py
+++ b/backend/app/services/cache_service.py
@@ -24,13 +24,12 @@ Usage:
 """
 
 import hashlib
-import json
 import logging
 from dataclasses import dataclass
-from datetime import datetime
 from typing import Any, Callable, TypeVar
 
-from backend.app.core.config import get_settings
+from backend.app.core.config import Settings, get_settings
+from backend.app.core.json_utils import dumps as json_dumps, loads as json_loads, dumps_for_cache
 
 from backend.app.services.redis_service import get_redis, is_redis_available
 
@@ -162,7 +161,7 @@ class CacheService:
         self._settings = None
 
     @property
-    def settings(self):
+    def settings(self) -> "Settings":
         """Lazy load settings."""
         if self._settings is None:
             self._settings = get_settings()
@@ -178,7 +177,7 @@ class CacheService:
     def hash_filter(filters: dict[str, Any]) -> str:
         """Create hash from filter parameters for cache key."""
         # Sort keys for consistent hashing
-        sorted_filters = json.dumps(filters, sort_keys=True, default=str)
+        sorted_filters = dumps_for_cache(filters)
         return hashlib.md5(sorted_filters.encode()).hexdigest()[:12]
 
     async def get(self, key: str | CacheKey) -> Any | None:
@@ -201,7 +200,7 @@ class CacheService:
                 value = await redis.get(cache_key)
                 if value:
                     logger.debug(f"Cache HIT: {cache_key}")
-                    return json.loads(value)
+                    return json_loads(value)
                 logger.debug(f"Cache MISS: {cache_key}")
                 return None
         except Exception as e:
@@ -233,7 +232,7 @@ class CacheService:
 
         try:
             # Serialize value
-            serialized = json.dumps(value, default=self._json_serializer)
+            serialized = json_dumps(value)
 
             async with get_redis() as redis:
                 await redis.set(cache_key, serialized, ex=ttl_seconds)
@@ -389,18 +388,6 @@ class CacheService:
     async def invalidate_all(self) -> int:
         """Invalidate all cache keys."""
         return await self.invalidate_pattern("*")
-
-    @staticmethod
-    def _json_serializer(obj: Any) -> Any:
-        """Custom JSON serializer for non-standard types."""
-        if isinstance(obj, datetime):
-            return obj.isoformat()
-        if hasattr(obj, "model_dump"):
-            # Pydantic model
-            return obj.model_dump(mode="json")
-        if hasattr(obj, "__dict__"):
-            return obj.__dict__
-        raise TypeError(f"Object of type {type(obj)} is not JSON serializable")
 
 
 # Singleton instance

--- a/backend/app/services/redis_pubsub_service.py
+++ b/backend/app/services/redis_pubsub_service.py
@@ -29,14 +29,14 @@ Usage:
 """
 
 import asyncio
-import json
 import logging
 import time
 from datetime import datetime
 from typing import Any, Callable, Coroutine
 
 import redis.exceptions
-from redis.asyncio import Redis
+
+from backend.app.core.json_utils import dumps as json_dumps, loads as json_loads
 
 from backend.app.services.redis_service import get_redis, is_redis_available
 
@@ -79,7 +79,7 @@ async def publish_event(event_type: str, data: dict[str, Any]) -> bool:
         "timestamp": datetime.utcnow().isoformat(),
         "ts": time.time(),  # Unix timestamp for sorting
     }
-    message = json.dumps(event, default=str)
+    message = json_dumps(event)
 
     try:
         async with get_redis() as redis:
@@ -137,7 +137,7 @@ async def get_events_since(since_timestamp: float) -> list[dict]:
             events = []
             for event_json in events_raw:
                 try:
-                    event = json.loads(event_json)
+                    event = json_loads(event_json)
                     # Only include events after the requested timestamp
                     if event.get("ts", 0) > since_timestamp:
                         events.append({
@@ -145,7 +145,7 @@ async def get_events_since(since_timestamp: float) -> list[dict]:
                             "data": event["data"],
                             "timestamp": event["ts"],
                         })
-                except json.JSONDecodeError:
+                except ValueError:
                     continue
 
             return events
@@ -191,7 +191,7 @@ async def _subscriber_loop():
 
                     if message["type"] == "message":
                         try:
-                            event = json.loads(message["data"])
+                            event = json_loads(message["data"])
                             event_type = event.get("type")
                             event_data = event.get("data", {})
 
@@ -203,7 +203,7 @@ async def _subscriber_loop():
                             else:
                                 logger.warning(f"No callback registered, event {event_type} dropped")
 
-                        except json.JSONDecodeError as e:
+                        except ValueError as e:
                             logger.warning(f"Invalid JSON in Pub/Sub message: {e}")
                         except Exception as e:
                             logger.error(f"Error processing Pub/Sub message: {e}", exc_info=True)
@@ -260,7 +260,7 @@ async def start_pubsub_listener(
     return True
 
 
-async def stop_pubsub_listener():
+async def stop_pubsub_listener() -> None:
     """Stop the Redis Pub/Sub subscriber background task."""
     global _subscriber_task, _local_broadcast_callback
 

--- a/backend/app/services/redis_ws_manager.py
+++ b/backend/app/services/redis_ws_manager.py
@@ -35,7 +35,6 @@ Usage:
 """
 
 import asyncio
-import json
 import logging
 import time
 import uuid
@@ -44,6 +43,7 @@ from typing import Any
 
 from fastapi import HTTPException, WebSocket, status
 
+from backend.app.core.json_utils import dumps as json_dumps
 from backend.app.services.redis_service import is_redis_available
 from backend.app.services.redis_pubsub_service import (
     publish_event,
@@ -242,7 +242,7 @@ class RedisBudgetWebSocketManager:
             "data": data,
             "timestamp": datetime.utcnow().isoformat(),
         }
-        message = json.dumps(event, default=str)
+        message = json_dumps(event)
 
         async with self._lock:
             connections = list(self.connections)
@@ -272,7 +272,7 @@ class RedisBudgetWebSocketManager:
             "data": data,
             "timestamp": datetime.utcnow().isoformat(),
         }
-        message = json.dumps(event, default=str)
+        message = json_dumps(event)
 
         async with self._lock:
             for user_id, websocket, cid, last_activity in self.connections:

--- a/backend/app/services/write_behind_service.py
+++ b/backend/app/services/write_behind_service.py
@@ -36,7 +36,6 @@ Usage:
 """
 
 import asyncio
-import json
 import logging
 import time
 import uuid
@@ -45,6 +44,7 @@ from enum import Enum
 from typing import Any
 
 from backend.app.core.config import get_settings
+from backend.app.core.json_utils import dumps as json_dumps, loads as json_loads
 from backend.app.services.redis_service import get_redis, is_redis_available
 from backend.app.models.budget_fact_history import FAR_FUTURE_DATETIME
 
@@ -113,7 +113,7 @@ class WriteQueueItem:
 
     def to_json(self) -> str:
         """Serialize to JSON string for Redis."""
-        return json.dumps({
+        return json_dumps({
             "operation": self.operation.value,
             "entity_type": self.entity_type,
             "data": self.data,
@@ -121,12 +121,12 @@ class WriteQueueItem:
             "request_id": self.request_id,
             "retries": self.retries,
             "created_at": self.created_at,
-        }, default=str)
+        })
 
     @classmethod
     def from_json(cls, json_str: str) -> "WriteQueueItem":
         """Deserialize from JSON string."""
-        data = json.loads(json_str)
+        data = json_loads(json_str)
         return cls(
             operation=WriteOperation(data["operation"]),
             entity_type=data["entity_type"],
@@ -581,12 +581,12 @@ class WriteBehindService:
         try:
             async with get_redis() as redis:
                 dlq_item = {
-                    "item": json.loads(item.to_json()),
+                    "item": json_loads(item.to_json()),
                     "error": error,
                     "failed_at": datetime.utcnow().isoformat(),
                     "worker_id": self._worker_id,
                 }
-                await redis.rpush(DLQ_KEY, json.dumps(dlq_item, default=str))
+                await redis.rpush(DLQ_KEY, json_dumps(dlq_item))
                 logger.error(
                     f"Write-behind DLQ: {item.operation.value} {item.entity_type} "
                     f"request_id={item.request_id} error={error}"
@@ -630,7 +630,7 @@ class WriteBehindService:
                         break
 
                     try:
-                        item_data = json.loads(item_json)
+                        item_data = json_loads(item_json)
                         failed_at = datetime.fromisoformat(item_data.get("failed_at", ""))
                         age_seconds = (now - failed_at).total_seconds()
 
@@ -640,7 +640,7 @@ class WriteBehindService:
                         else:
                             # Items are ordered by time, so stop here
                             break
-                    except (json.JSONDecodeError, ValueError):
+                    except ValueError:
                         # Invalid item, remove it
                         await redis.lpop(DLQ_KEY)
                         removed_count += 1
@@ -744,7 +744,7 @@ class WriteBehindService:
 
         logger.info(f"Write-behind worker stopped: worker_id={self._worker_id}")
 
-    async def start_worker(self):
+    async def start_worker(self) -> None:
         """Start the background worker."""
         if self._worker_task is not None:
             logger.warning("Write-behind worker already running")
@@ -758,7 +758,7 @@ class WriteBehindService:
         self._worker_task = asyncio.create_task(self._worker_loop())
         logger.info("Write-behind worker task created")
 
-    async def stop_worker(self):
+    async def stop_worker(self) -> None:
         """Stop the background worker."""
         if self._worker_task is None:
             return
@@ -802,11 +802,11 @@ class WriteBehindService:
 write_behind_service = WriteBehindService()
 
 
-async def start_write_behind_worker():
+async def start_write_behind_worker() -> None:
     """Start write-behind worker (call from main.py lifespan startup)."""
     await write_behind_service.start_worker()
 
 
-async def stop_write_behind_worker():
+async def stop_write_behind_worker() -> None:
     """Stop write-behind worker (call from main.py lifespan shutdown)."""
     await write_behind_service.stop_worker()


### PR DESCRIPTION
## Summary

- Migrate WebSocket and caching services from stdlib `json` to `orjson` wrapper (`json_utils`)
- Replace all `json.dumps/loads` calls with `json_dumps/json_loads` from `backend.app.core.json_utils`
- Fix `JSONDecodeError` handling in `budget_ws.py` to catch both `JSONDecodeError` and `ValueError`

## Changed Files

| File | Changes |
|------|---------|
| `redis_ws_manager.py` | Replace `json.dumps` → `json_dumps` (2 places) |
| `budget_ws.py` | Replace `json.dumps` → `json_dumps` (2), `json.loads` → `json_loads` (1), fix except clause |
| `cache_service.py` | Use `json_utils` for cache serialization |
| `redis_pubsub_service.py` | Use `json_utils` for pub/sub messages |
| `write_behind_service.py` | Use `json_utils` for write-behind queue |

## Benefits

- **3-10x faster** JSON serialization with orjson
- **Native support** for datetime, Decimal, UUID via `default_serializer`
- **Graceful fallback** to stdlib json if orjson unavailable
- **Consistent API** across all services

## Test Plan

- [x] Pre-commit hooks passed (TypeScript, unit tests)
- [ ] CI/CD pipeline checks
- [ ] Manual WebSocket connection test on test server

## Related

Dependency: `backend/app/core/json_utils.py` (orjson wrapper)

---

🤖 Generated with [Claude Code](https://claude.ai/code)