### PR TITLE
fix(ui): improve progress bar and page transition timings

### DIFF
--- a/frontend/web/static/js/navigationProgress.js
+++ b/frontend/web/static/js/navigationProgress.js
@@ -33,8 +33,8 @@
         // Configuration
         config: {
             timeout: 30000,           // 30 seconds max
-            minDisplayTime: 1000,     // Minimum 1 second for better UX
-            fadeOutDelay: 500,        // Longer delay to show 100% completion before smooth fade-out
+            minDisplayTime: 1200,     // Minimum 1.2 seconds for visible progress
+            fadeOutDelay: 600,        // Extended delay to clearly show 100% completion
             animatedFallbackSpeed: 30 // Fake progress increment per 100ms
         },
 
@@ -236,8 +236,8 @@
                 // Complete progress with smooth fade-out
                 this.setProgress(100);
 
-                // Longer delay to show 100% completion (smoother UX)
-                await this.delay(500);
+                // Extended delay to clearly show 100% completion
+                await this.delay(this.config.fadeOutDelay);
 
                 // Start fade-out animation
                 this.fadeOutProgress();
@@ -455,7 +455,7 @@
             setTimeout(() => {
                 this.progressBar.classList.remove('active', 'complete');
                 this.progressBar.style.width = '0%';
-            }, 400);
+            }, 600);  // Sync with CSS opacity transition
         },
 
         /**

--- a/frontend/web/templates/base.html
+++ b/frontend/web/templates/base.html
@@ -279,8 +279,8 @@
             background: #36d399; /* DaisyUI success green fallback */
             background: oklch(var(--su)); /* DaisyUI success color (green) */
             z-index: 39; /* под navbar (z-40) */
-            transition: width 0.15s ease-out;
-            -webkit-transition: width 0.15s ease-out;
+            transition: width 0.35s ease-out;
+            -webkit-transition: width 0.35s ease-out;
             opacity: 0;
             pointer-events: none;
             box-shadow: 0 0 8px rgba(54, 211, 153, 0.5); /* Fallback */
@@ -302,7 +302,7 @@
 
         .navigation-progress.complete {
             width: 100%;
-            transition: width 0.1s ease-out, opacity 0.6s ease-out 0.2s;
+            transition: width 0.25s ease-out, opacity 0.8s ease-out 0.3s;
             opacity: 0;
         }
 
@@ -393,8 +393,8 @@
             background: oklch(var(--b1)); /* DaisyUI base background (light/dark aware) */
             opacity: 0;
             visibility: hidden;
-            transition: opacity 0.15s ease-out, visibility 0.15s ease-out;
-            -webkit-transition: opacity 0.15s ease-out, visibility 0.15s ease-out;
+            transition: opacity 0.3s ease-out, visibility 0.3s ease-out;
+            -webkit-transition: opacity 0.3s ease-out, visibility 0.3s ease-out;
             pointer-events: none;
             display: -webkit-flex;
             display: flex;
@@ -436,11 +436,11 @@
 
             /* Smooth fade transition for page content */
             ::view-transition-old(root) {
-                animation: view-fade-out 0.3s ease-out;
+                animation: view-fade-out 0.5s ease-out;
             }
 
             ::view-transition-new(root) {
-                animation: view-fade-in 0.3s ease-in;
+                animation: view-fade-in 0.5s ease-in;
             }
 
             /* Fade out animation */


### PR DESCRIPTION
## Summary
- Увеличены CSS/JS тайминги анимаций для устранения эффекта мерцания
- Плавные переходы между страницами вместо резких "скачков"

## Changes
| Параметр | Было | Стало |
|----------|------|-------|
| Progress width transition | 0.15s | 0.35s |
| Progress complete width | 0.1s | 0.25s |
| Progress opacity fade | 0.6s (delay 0.2s) | 0.8s (delay 0.3s) |
| Overlay transition | 0.15s | 0.3s |
| View transition fade | 0.3s | 0.5s |
| JS minDisplayTime | 1000ms | 1200ms |
| JS fadeOutDelay | 500ms | 600ms |
| JS hideProgress timeout | 400ms | 600ms |

## Test plan
- [ ] Desktop: проверить плавность прогресс бара при переходах
- [ ] Mobile: убедиться в отсутствии мерцания
- [ ] prefers-reduced-motion: анимации отключены

🤖 Generated with [Claude Code](https://claude.ai/code)