### PR TITLE
feat(users): add Google Sheets URL persistence for shopping list import

### DIFF
--- a/backend/app/api/v1/endpoints/users.py
+++ b/backend/app/api/v1/endpoints/users.py
@@ -232,7 +232,7 @@ async def get_google_sheets_url(
     """
     url = current_user.google_sheets_url
 
-    logger.info(
+    logger.debug(
         f"[GOOGLE_SHEETS_URL] User {current_user.id} fetching saved URL: "
         f"{url[:50] + '...' if url and len(url) > 50 else url}"
     )
@@ -296,7 +296,7 @@ async def update_google_sheets_url(
             )
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Invalid Google Sheets URL format: {e}"
+                detail=f"Неверный формат ссылки Google Sheets: {e}"
             )
 
     # Track if URL actually changed
@@ -305,12 +305,12 @@ async def update_google_sheets_url(
 
     # Update user
     current_user.google_sheets_url = new_url
-    current_user.updated_at = datetime.utcnow()
+    current_user.updated_at = datetime.now(timezone.utc)
 
     await session.commit()
     await session.refresh(current_user)
 
-    # Log update
+    # Log update (only when changed)
     if url_changed:
         if new_url is None:
             logger.info(
@@ -321,10 +321,6 @@ async def update_google_sheets_url(
                 f"[GOOGLE_SHEETS_URL] User {current_user.id} set URL: "
                 f"{new_url[:50] + '...' if len(new_url) > 50 else new_url}"
             )
-    else:
-        logger.info(
-            f"[GOOGLE_SHEETS_URL] User {current_user.id} URL unchanged"
-        )
 
     return GoogleSheetsUrlResponse(
         google_sheets_url=new_url,

--- a/backend/app/api/v1/endpoints/users.py
+++ b/backend/app/api/v1/endpoints/users.py
@@ -29,10 +29,16 @@ from backend.app.models.user import User
 from backend.app.schemas import get_common_responses
 from backend.app.schemas.auth import UserResponse
 from backend.app.schemas.user import (
+    GoogleSheetsUrlResponse,
+    GoogleSheetsUrlUpdate,
     UserCreate,
     UserDetailResponse,
     UserListResponse,
     UserUpdate,
+)
+from backend.app.services.google_sheets_parser import (
+    GoogleSheetsError,
+    parse_google_sheets_url,
 )
 from backend.app.services import create_new_version, has_changes
 
@@ -194,6 +200,136 @@ async def update_notification_preferences(
         )
 
     return current_user
+
+
+@router.get(
+    "/me/google-sheets-url",
+    response_model=GoogleSheetsUrlResponse,
+    responses=get_common_responses(),
+)
+async def get_google_sheets_url(
+    current_user: CurrentUser,
+) -> GoogleSheetsUrlResponse:
+    """
+    Get user's saved Google Sheets URL.
+
+    **Public:** Any authenticated user can access their saved URL.
+
+    **Returns:**
+    - 200 OK: GoogleSheetsUrlResponse with saved URL (or None if not set)
+    - 401 Unauthorized: Not authenticated
+
+    **Example Response:**
+    ```json
+    {
+        "google_sheets_url": "https://docs.google.com/spreadsheets/d/1ABC.../edit#gid=0",
+        "has_saved_url": true
+    }
+    ```
+
+    **Logging:**
+    All URL retrieval requests are logged with [GOOGLE_SHEETS_URL] prefix.
+    """
+    url = current_user.google_sheets_url
+
+    logger.info(
+        f"[GOOGLE_SHEETS_URL] User {current_user.id} fetching saved URL: "
+        f"{url[:50] + '...' if url and len(url) > 50 else url}"
+    )
+
+    return GoogleSheetsUrlResponse(
+        google_sheets_url=url,
+        has_saved_url=url is not None and len(url) > 0
+    )
+
+
+@router.patch(
+    "/me/google-sheets-url",
+    response_model=GoogleSheetsUrlResponse,
+    responses=get_common_responses(include_400=True),
+)
+async def update_google_sheets_url(
+    data: GoogleSheetsUrlUpdate,
+    current_user: CurrentUser,
+    session: AsyncSession = Depends(get_session),
+) -> GoogleSheetsUrlResponse:
+    """
+    Save or clear user's Google Sheets URL.
+
+    **Public:** Any authenticated user can update their saved URL.
+
+    **Parameters:**
+    - google_sheets_url: URL to save (set to null or empty string to clear)
+
+    **Validation:**
+    - URL must be a valid Google Sheets URL (docs.google.com/spreadsheets/d/...)
+    - URL is validated using parse_google_sheets_url()
+
+    **Returns:**
+    - 200 OK: Updated GoogleSheetsUrlResponse
+    - 400 Bad Request: Invalid URL format
+    - 401 Unauthorized: Not authenticated
+
+    **Example Request:**
+    ```json
+    {
+        "google_sheets_url": "https://docs.google.com/spreadsheets/d/1ABC.../edit#gid=0"
+    }
+    ```
+
+    **Logging:**
+    All URL updates are logged with [GOOGLE_SHEETS_URL] prefix.
+    """
+    new_url = data.google_sheets_url
+
+    # Clear URL if empty string or None
+    if new_url is not None and new_url.strip() == "":
+        new_url = None
+
+    # Validate URL format if provided
+    if new_url is not None:
+        try:
+            await parse_google_sheets_url(new_url)
+        except GoogleSheetsError as e:
+            logger.warning(
+                f"[GOOGLE_SHEETS_URL] User {current_user.id} invalid URL: {e}"
+            )
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Invalid Google Sheets URL format: {e}"
+            )
+
+    # Track if URL actually changed
+    old_url = current_user.google_sheets_url
+    url_changed = old_url != new_url
+
+    # Update user
+    current_user.google_sheets_url = new_url
+    current_user.updated_at = datetime.utcnow()
+
+    await session.commit()
+    await session.refresh(current_user)
+
+    # Log update
+    if url_changed:
+        if new_url is None:
+            logger.info(
+                f"[GOOGLE_SHEETS_URL] User {current_user.id} cleared URL"
+            )
+        else:
+            logger.info(
+                f"[GOOGLE_SHEETS_URL] User {current_user.id} set URL: "
+                f"{new_url[:50] + '...' if len(new_url) > 50 else new_url}"
+            )
+    else:
+        logger.info(
+            f"[GOOGLE_SHEETS_URL] User {current_user.id} URL unchanged"
+        )
+
+    return GoogleSheetsUrlResponse(
+        google_sheets_url=new_url,
+        has_saved_url=new_url is not None and len(new_url) > 0
+    )
 
 
 @router.get(

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -241,6 +241,16 @@ class User(SQLModel, table=True):
     )
 
     # =========================================================================
+    # Google Sheets Integration (v7.x+)
+    # =========================================================================
+
+    google_sheets_url: Optional[str] = Field(
+        default=None,
+        max_length=2048,
+        description="Saved Google Sheets URL for shopping list import (SCD1 - in-place update)"
+    )
+
+    # =========================================================================
     # Audit fields (SCD Type 1 - in-place updates)
     # =========================================================================
 

--- a/backend/app/models/user_history.py
+++ b/backend/app/models/user_history.py
@@ -218,6 +218,16 @@ class UserHistory(SQLModel, table=True):
         description="Last login timestamp at time of change (snapshot)"
     )
 
+    # =========================================================================
+    # Google Sheets Integration (v7.x+)
+    # =========================================================================
+
+    google_sheets_url: Optional[str] = Field(
+        default=None,
+        max_length=2048,
+        description="Google Sheets URL at time of change (snapshot)"
+    )
+
     # SCD Type 2 fields (temporal validity)
     valid_from: datetime = Field(
         sa_column=Column(DateTime(timezone=True), nullable=False, index=True),

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -176,6 +176,13 @@ class UserUpdate(BaseModel):
         examples=[True, False]
     )
 
+    google_sheets_url: Optional[str] = Field(
+        default=None,
+        max_length=2048,
+        description="Saved Google Sheets URL for shopping list import",
+        examples=["https://docs.google.com/spreadsheets/d/1ABC123/edit#gid=0", None]
+    )
+
 
 class UserResponse(BaseModel):
     """
@@ -269,6 +276,12 @@ class UserResponse(BaseModel):
         default=None,
         description="Target user ID if this account was merged into another",
         examples=[None, 2]
+    )
+
+    google_sheets_url: Optional[str] = Field(
+        default=None,
+        description="Saved Google Sheets URL for shopping list import",
+        examples=["https://docs.google.com/spreadsheets/d/1ABC123/edit#gid=0", None]
     )
 
     last_login_at: Optional[datetime] = Field(
@@ -616,3 +629,54 @@ class UserMergeResponse(BaseModel):
         description="Whether Telegram ID was transferred",
         examples=[True]
     )
+
+
+class GoogleSheetsUrlUpdate(BaseModel):
+    """
+    Schema for updating user's Google Sheets URL.
+
+    Used by PATCH /users/me/google-sheets-url endpoint.
+
+    Attributes:
+        google_sheets_url: URL to save (None to clear)
+    """
+
+    google_sheets_url: Optional[str] = Field(
+        default=None,
+        max_length=2048,
+        description="Google Sheets URL to save. Set to null to clear saved URL.",
+        examples=["https://docs.google.com/spreadsheets/d/1ABC123/edit#gid=0", None]
+    )
+
+
+class GoogleSheetsUrlResponse(BaseModel):
+    """
+    Schema for Google Sheets URL response.
+
+    Used by GET /users/me/google-sheets-url endpoint.
+
+    Attributes:
+        google_sheets_url: Saved URL or None if not set
+        has_saved_url: Convenience flag for frontend
+    """
+
+    google_sheets_url: Optional[str] = Field(
+        default=None,
+        description="Saved Google Sheets URL (None if not set)",
+        examples=["https://docs.google.com/spreadsheets/d/1ABC123/edit#gid=0", None]
+    )
+
+    has_saved_url: bool = Field(
+        default=False,
+        description="True if user has a saved Google Sheets URL",
+        examples=[True, False]
+    )
+
+    model_config = {
+        "json_schema_extra": {
+            "example": {
+                "google_sheets_url": "https://docs.google.com/spreadsheets/d/1ABC123/edit#gid=0",
+                "has_saved_url": True
+            }
+        }
+    }

--- a/backend/app/services/user_service.py
+++ b/backend/app/services/user_service.py
@@ -120,6 +120,7 @@ async def update_user_profile(
         is_active=user.is_active,
         two_factor_enabled=user.two_factor_enabled,  # Include 2FA status
         last_login_at=user.last_login_at,
+        google_sheets_url=user.google_sheets_url,  # Include Google Sheets URL
         valid_from=now,
         valid_to=FAR_FUTURE_DATETIME,
         is_current=True,
@@ -270,6 +271,7 @@ async def create_initial_history(
         is_active=user.is_active,
         two_factor_enabled=user.two_factor_enabled,  # Include 2FA status
         last_login_at=user.last_login_at,
+        google_sheets_url=user.google_sheets_url,  # Include Google Sheets URL
         valid_from=now,
         valid_to=FAR_FUTURE_DATETIME,
         is_current=True,

--- a/backend/db/migrations/versions/20260118_4c87e46b1cd8_add_google_sheets_url_to_user.py
+++ b/backend/db/migrations/versions/20260118_4c87e46b1cd8_add_google_sheets_url_to_user.py
@@ -1,0 +1,71 @@
+"""add_google_sheets_url_to_user
+
+Revision ID: 4c87e46b1cd8
+Revises: 28cb68876eaf
+Create Date: 2026-01-18 12:00:00.000000
+
+This migration adds google_sheets_url field to t_d_user table
+for persistent Google Sheets URL storage per user.
+
+Changes:
+1. Add google_sheets_url VARCHAR(2048) NULL to t_d_user
+2. Add google_sheets_url VARCHAR(2048) NULL to t_d_user_history
+
+Use Case:
+- Users can save their Google Sheets URL for shopping list import
+- URL is stored on user level for reuse in future imports
+- Frontend auto-fills saved URL when opening Google Sheets import wizard
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '4c87e46b1cd8'
+down_revision: Union[str, None] = '28cb68876eaf'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add google_sheets_url field to user tables."""
+
+    # Step 1: Add column to main User table (t_d_user)
+    print("[MIGRATION] Adding google_sheets_url to t_d_user...")
+    op.add_column(
+        't_d_user',
+        sa.Column(
+            'google_sheets_url',
+            sa.String(2048),
+            nullable=True,
+            comment='Saved Google Sheets URL for shopping list import (v7.x+)'
+        )
+    )
+
+    # Step 2: Add column to User History table (t_d_user_history)
+    print("[MIGRATION] Adding google_sheets_url to t_d_user_history...")
+    op.add_column(
+        't_d_user_history',
+        sa.Column(
+            'google_sheets_url',
+            sa.String(2048),
+            nullable=True,
+            comment='Historical snapshot of Google Sheets URL preference'
+        )
+    )
+
+    print("[MIGRATION] google_sheets_url migration completed successfully")
+
+
+def downgrade() -> None:
+    """Remove google_sheets_url field from user tables."""
+
+    print("[MIGRATION] Removing google_sheets_url from t_d_user_history...")
+    op.drop_column('t_d_user_history', 'google_sheets_url')
+
+    print("[MIGRATION] Removing google_sheets_url from t_d_user...")
+    op.drop_column('t_d_user', 'google_sheets_url')
+
+    print("[MIGRATION] google_sheets_url rollback completed")

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -27,6 +27,31 @@ Use these files to understand component relationships when planning changes or o
 
 ## Recent Changes
 
+### 2026-01-18: Google Sheets URL Persistence (v7.x)
+- **Change:** Added ability to save Google Sheets URL per user for reuse in shopping list import
+- **Backend:**
+  - Added `google_sheets_url` field to `t_d_user` and `t_d_user_history` tables
+  - New endpoints: `GET/PATCH /api/v1/users/me/google-sheets-url`
+  - URL validation via existing `parse_google_sheets_url()` function
+  - SCD Type 2 history tracking for URL changes
+- **Frontend:**
+  - Auto-fill saved URL when opening Google Sheets import wizard
+  - "Найдена сохранённая ссылка" alert with clear button
+  - Checkbox "Сохранить ссылку для будущего использования" (default: checked)
+  - URL saved after successful data fetch
+- **Files Modified:**
+  - `backend/db/migrations/versions/20260118_4c87e46b1cd8_add_google_sheets_url_to_user.py` (new)
+  - `backend/app/models/user.py`, `backend/app/models/user_history.py`
+  - `backend/app/schemas/user.py` (+GoogleSheetsUrlUpdate, GoogleSheetsUrlResponse)
+  - `backend/app/api/v1/endpoints/users.py` (+2 endpoints)
+  - `backend/app/services/user_service.py` (+google_sheets_url in history snapshot)
+  - `frontend/web/static/js/lists/googleSheetsImporter.js`
+- **Logging:** `[GOOGLE_SHEETS_URL]` prefix for all URL operations
+- **Impact:**
+  - ✅ Users don't need to re-enter Google Sheets URL for each import
+  - ✅ URL auto-filled from previous successful import
+  - ✅ Easy clear saved URL functionality
+
 ### 2026-01-16: Fix FAB on /lists Page (v6.6.1)
 - **Change:** Fixed FAB (Floating Action Button) issues on `/lists` page
 - **Problems Fixed:**

--- a/frontend/web/static/js/lists/googleSheetsImporter.js
+++ b/frontend/web/static/js/lists/googleSheetsImporter.js
@@ -19,6 +19,11 @@ class GoogleSheetsImporter {
         this.spreadsheetId = null;
         this.sheetGid = null;
 
+        // Saved URL data
+        this.savedUrl = null;
+        this.hasSavedUrl = false;
+        this.shouldSaveUrl = true;  // Default: save URL after successful import
+
         // CSV data (after fetch)
         this.fileContent = null;  // Base64 CSV from backend
 
@@ -32,7 +37,7 @@ class GoogleSheetsImporter {
     /**
      * Initialize Google Sheets importer
      */
-    init() {
+    async init() {
         // Container should be set by ImportManager
         if (!this.container) {
             this.container = document.getElementById('import-wizard');
@@ -43,8 +48,99 @@ class GoogleSheetsImporter {
             return;
         }
 
+        // Load saved URL from backend
+        await this.fetchSavedGoogleSheetsUrl();
+
         this.renderStep1();
         debugLog('[GoogleSheetsImporter] Initialized');
+    }
+
+    /**
+     * Fetch saved Google Sheets URL from backend
+     */
+    async fetchSavedGoogleSheetsUrl() {
+        try {
+            const response = await fetch('/api/v1/users/me/google-sheets-url', {
+                method: 'GET',
+                credentials: 'same-origin',
+            });
+
+            if (!response.ok) {
+                debugLog('[GoogleSheetsImporter] Failed to fetch saved URL:', response.status);
+                return;
+            }
+
+            const data = await response.json();
+            this.savedUrl = data.google_sheets_url;
+            this.hasSavedUrl = data.has_saved_url;
+
+            debugLog('[GoogleSheetsImporter] Fetched saved URL:', {
+                hasSavedUrl: this.hasSavedUrl,
+                url: this.savedUrl ? this.savedUrl.substring(0, 50) + '...' : null
+            });
+        } catch (error) {
+            console.error('[GoogleSheetsImporter] Error fetching saved URL:', error);
+        }
+    }
+
+    /**
+     * Save Google Sheets URL to backend
+     * @param {string|null} url - URL to save (null to clear)
+     */
+    async saveGoogleSheetsUrl(url) {
+        try {
+            const response = await fetch('/api/v1/users/me/google-sheets-url', {
+                method: 'PATCH',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                credentials: 'same-origin',
+                body: JSON.stringify({
+                    google_sheets_url: url
+                })
+            });
+
+            if (!response.ok) {
+                const error = await response.json();
+                throw new Error(error.detail || `HTTP ${response.status}`);
+            }
+
+            const data = await response.json();
+            this.savedUrl = data.google_sheets_url;
+            this.hasSavedUrl = data.has_saved_url;
+
+            debugLog('[GoogleSheetsImporter] Saved URL:', {
+                hasSavedUrl: this.hasSavedUrl,
+                url: this.savedUrl ? this.savedUrl.substring(0, 50) + '...' : null
+            });
+
+            return true;
+        } catch (error) {
+            console.error('[GoogleSheetsImporter] Error saving URL:', error);
+            return false;
+        }
+    }
+
+    /**
+     * Clear saved URL
+     */
+    async clearSavedUrl() {
+        const success = await this.saveGoogleSheetsUrl(null);
+        if (success) {
+            showToast('Сохранённая ссылка удалена', 'success');
+            this.renderStep1();
+        } else {
+            showToast('Ошибка при удалении ссылки', 'error');
+        }
+    }
+
+    /**
+     * Handle save URL checkbox change
+     * @param {Event} event - Change event
+     */
+    handleSaveUrlCheckboxChange(event) {
+        this.shouldSaveUrl = event.target.checked;
+        debugLog('[GoogleSheetsImporter] Save URL checkbox:', this.shouldSaveUrl);
     }
 
     /**
@@ -52,6 +148,39 @@ class GoogleSheetsImporter {
      */
     renderStep1() {
         this.currentStep = 1;
+
+        // Build saved URL alert HTML
+        const savedUrlAlert = this.hasSavedUrl ? `
+            <div class="alert alert-success mb-4">
+                <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                </svg>
+                <div class="flex-1">
+                    <p class="font-bold">Найдена сохранённая ссылка</p>
+                    <p class="text-sm opacity-80 truncate max-w-md">${this.escapeHtml(this.savedUrl)}</p>
+                </div>
+                <button type="button"
+                        class="btn btn-sm btn-ghost"
+                        onclick="window.googleSheetsImporter.clearSavedUrl()"
+                        title="Удалить сохранённую ссылку">
+                    ✕
+                </button>
+            </div>
+        ` : '';
+
+        // Build save URL checkbox HTML
+        const saveUrlCheckbox = `
+            <div class="form-control mb-4">
+                <label class="label cursor-pointer justify-start gap-3">
+                    <input type="checkbox"
+                           id="save-url-checkbox"
+                           class="checkbox checkbox-primary checkbox-sm"
+                           ${this.shouldSaveUrl ? 'checked' : ''}
+                           onchange="window.googleSheetsImporter.handleSaveUrlCheckboxChange(event)">
+                    <span class="label-text">Сохранить ссылку для будущего использования</span>
+                </label>
+            </div>
+        `;
 
         this.container.innerHTML = `
             <div class="google-sheets-wizard-step">
@@ -66,6 +195,8 @@ class GoogleSheetsImporter {
                         </ul>
                     </div>
                 </div>
+
+                ${savedUrlAlert}
 
                 <div class="alert alert-info mb-4">
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -86,12 +217,15 @@ class GoogleSheetsImporter {
                                id="google-sheets-url-input"
                                class="input input-bordered w-full"
                                placeholder="https://docs.google.com/spreadsheets/d/1ABC.../edit#gid=0"
+                               value="${this.hasSavedUrl ? this.escapeHtml(this.savedUrl) : ''}"
                                required
                                pattern=".*docs\\.google\\.com/spreadsheets.*">
                         <label class="label">
                             <span class="label-text-alt">Вставьте ссылку из адресной строки браузера</span>
                         </label>
                     </div>
+
+                    ${saveUrlCheckbox}
 
                     <div class="flex gap-2">
                         <button type="button"
@@ -224,7 +358,17 @@ class GoogleSheetsImporter {
                 size: this.fileContent.length
             });
 
-            showToast('✅ Данные загружены из Google Sheets', 'success');
+            // Save URL if checkbox is checked
+            if (this.shouldSaveUrl) {
+                const saved = await this.saveGoogleSheetsUrl(this.googleSheetsUrl);
+                if (saved) {
+                    showToast('✅ Данные загружены, ссылка сохранена', 'success');
+                } else {
+                    showToast('✅ Данные загружены (ссылка не сохранена)', 'warning');
+                }
+            } else {
+                showToast('✅ Данные загружены из Google Sheets', 'success');
+            }
 
             // Now delegate to CSVImporter for Steps 2-5
             this.delegateToCSVImporter();

--- a/frontend/web/static/js/lists/googleSheetsImporter.js
+++ b/frontend/web/static/js/lists/googleSheetsImporter.js
@@ -161,7 +161,7 @@ class GoogleSheetsImporter {
                 </div>
                 <button type="button"
                         class="btn btn-sm btn-ghost"
-                        onclick="window.googleSheetsImporter.clearSavedUrl()"
+                        onclick="window.googleSheetsImporter.clearSavedUrl().catch(e => console.error('[GoogleSheetsImporter] Clear URL error:', e))"
                         title="Удалить сохранённую ссылку">
                     ✕
                 </button>


### PR DESCRIPTION
## Summary
- Allow users to save their Google Sheets URL for reuse when importing shopping lists
- URL is stored per-user and auto-filled when opening the import wizard
- Checkbox to control whether to save URL (default: enabled)

## Changes

### Backend
- Database migration adding `google_sheets_url` field to `t_d_user` and `t_d_user_history`
- New endpoints: `GET/PATCH /api/v1/users/me/google-sheets-url`
- URL validation via existing `parse_google_sheets_url()`
- SCD Type 2 history tracking for URL changes

### Frontend
- Auto-fill saved URL when opening Google Sheets import wizard
- Alert "Найдена сохранённая ссылка" with clear button
- Checkbox "Сохранить ссылку для будущего использования"
- URL saved after successful data fetch

## Test plan
- [ ] Run migration: `alembic upgrade head`
- [ ] Verify new endpoints in Swagger `/docs`
- [ ] Test UI: new user → empty input
- [ ] Test UI: enter URL + checkbox → URL saved
- [ ] Test UI: next import → URL auto-filled
- [ ] Test UI: clear button → URL removed

## Files changed
- `backend/db/migrations/versions/20260118_4c87e46b1cd8_add_google_sheets_url_to_user.py` (new)
- `backend/app/models/user.py`, `backend/app/models/user_history.py`
- `backend/app/schemas/user.py` (+GoogleSheetsUrlUpdate, GoogleSheetsUrlResponse)
- `backend/app/api/v1/endpoints/users.py` (+2 endpoints)
- `backend/app/services/user_service.py`
- `frontend/web/static/js/lists/googleSheetsImporter.js`
- `docs/architecture/README.md`

🤖 Generated with [Claude Code](https://claude.ai/code)