### PR TITLE
fix(deploy): add HTML templates checksum for Jinja2 cache invalidation

### DIFF
--- a/.claude/skills/deploy-prod/SKILL.md
+++ b/.claude/skills/deploy-prod/SKILL.md
@@ -66,6 +66,61 @@ user-invocable: true
 
 Этот skill выполняет следующие шаги автоматически:
 
+### Шаг 0: Интерактивный выбор опций деплоя
+
+⚠️ **ВНИМАНИЕ: Production среда!** Все изменения немедленно влияют на реальных пользователей.
+
+Перед началом деплоя Claude запрашивает параметры через AskUserQuestion.
+
+**Условие показа диалога:**
+- Показать диалог если пользователь НЕ указал явно параметры в запросе
+- Пропустить диалог если параметры указаны явно (например: "деплой с версией minor", "deploy --version patch --force-build")
+
+**Примеры явного указания параметров:**
+- "задеплой с версией patch" → версия=patch, показать только вопрос про доп. опции
+- "деплой --version minor --force-build" → версия=minor, force-build=да, пропустить диалог
+- "деплой на прод" → показать полный диалог
+- "обновить на budget-prod" → показать полный диалог
+
+**AskUserQuestion - Вопрос 1: Тип версии**
+```json
+{
+  "question": "⚠️ PRODUCTION: Какой тип версии использовать для деплоя?",
+  "header": "Version",
+  "options": [
+    {"label": "patch (Recommended)", "description": "Bug fixes: 6.6.0 → 6.6.1"},
+    {"label": "minor", "description": "New features: 6.6.0 → 6.7.0"},
+    {"label": "major", "description": "Breaking changes: 6.6.0 → 7.0.0"},
+    {"label": "none", "description": "Без изменения версии"}
+  ],
+  "multiSelect": false
+}
+```
+
+**AskUserQuestion - Вопрос 2: Дополнительные опции**
+```json
+{
+  "question": "Какие дополнительные опции применить?",
+  "header": "Options",
+  "options": [
+    {"label": "Стандартный деплой (Recommended)", "description": "Без дополнительных опций"},
+    {"label": "--force-build", "description": "Принудительная пересборка frontend"},
+    {"label": "--verbose", "description": "Детальный вывод всех операций"},
+    {"label": "--dry-run", "description": "Показать план без выполнения"}
+  ],
+  "multiSelect": true
+}
+```
+
+**Фиксированные опции (всегда применяются):**
+- `--sync-mode update` - только обновление/добавление файлов
+- `--cleanup-mode smart` - умная очистка старых образов
+
+**Формирование итоговой команды:**
+```bash
+ssh budget-prod "cd ~/familyBudget && sudo bash deploy.sh --sync-mode update --cleanup-mode smart [--version TYPE] [OPTIONS]"
+```
+
 ### Шаг 1: Проверка SSH подключения
 ```bash
 ssh budget-prod "echo 'Connection OK'"

--- a/.claude/skills/deploy-prod/templates/deploy-prod.sh
+++ b/.claude/skills/deploy-prod/templates/deploy-prod.sh
@@ -35,6 +35,7 @@ AUTO_FIX=false
 VERBOSE=false
 DRY_RUN=false
 VERSION_OPTION=""  # Version option to pass to deploy.sh
+FORCE_BUILD=""     # Force build option
 
 # Парсинг аргументов
 while [[ $# -gt 0 ]]; do
@@ -61,9 +62,13 @@ while [[ $# -gt 0 ]]; do
             VERSION_OPTION="--version $2"
             shift 2
             ;;
+        --force-build)
+            FORCE_BUILD="--force-build"
+            shift
+            ;;
         *)
             echo "Unknown option: $1"
-            echo "Usage: $0 [--auto-fix] [--verbose] [--dry-run] [--version TYPE]"
+            echo "Usage: $0 [--auto-fix] [--verbose] [--dry-run] [--version TYPE] [--force-build]"
             exit 1
             ;;
     esac
@@ -76,6 +81,11 @@ if [[ -n "$VERSION_OPTION" ]]; then
     echo -e "${BLUE}ℹ${NC} Version bump: ${VERSION_OPTION}"
 else
     echo -e "${BLUE}ℹ${NC} Version bump: none (version will not change)"
+fi
+
+if [[ -n "$FORCE_BUILD" ]]; then
+    DEPLOY_SCRIPT="${DEPLOY_SCRIPT} ${FORCE_BUILD}"
+    echo -e "${BLUE}ℹ${NC} Force build: enabled"
 fi
 
 # Создать директорию для логов

--- a/.claude/skills/deploy-test/SKILL.md
+++ b/.claude/skills/deploy-test/SKILL.md
@@ -66,6 +66,59 @@ user-invocable: true
 
 Этот skill выполняет следующие шаги автоматически:
 
+### Шаг 0: Интерактивный выбор опций деплоя
+
+Перед началом деплоя Claude запрашивает параметры через AskUserQuestion.
+
+**Условие показа диалога:**
+- Показать диалог если пользователь НЕ указал явно параметры в запросе
+- Пропустить диалог если параметры указаны явно (например: "деплой с версией minor", "deploy --version patch --force-build")
+
+**Примеры явного указания параметров:**
+- "задеплой с версией patch" → версия=patch, показать только вопрос про доп. опции
+- "деплой --version minor --force-build" → версия=minor, force-build=да, пропустить диалог
+- "деплой на тест" → показать полный диалог
+- "обновить на budget-test" → показать полный диалог
+
+**AskUserQuestion - Вопрос 1: Тип версии**
+```json
+{
+  "question": "Какой тип версии использовать для деплоя?",
+  "header": "Version",
+  "options": [
+    {"label": "patch (Recommended)", "description": "Bug fixes: 6.6.0 → 6.6.1"},
+    {"label": "minor", "description": "New features: 6.6.0 → 6.7.0"},
+    {"label": "major", "description": "Breaking changes: 6.6.0 → 7.0.0"},
+    {"label": "none", "description": "Без изменения версии"}
+  ],
+  "multiSelect": false
+}
+```
+
+**AskUserQuestion - Вопрос 2: Дополнительные опции**
+```json
+{
+  "question": "Какие дополнительные опции применить?",
+  "header": "Options",
+  "options": [
+    {"label": "Стандартный деплой (Recommended)", "description": "Без дополнительных опций"},
+    {"label": "--force-build", "description": "Принудительная пересборка frontend"},
+    {"label": "--verbose", "description": "Детальный вывод всех операций"},
+    {"label": "--dry-run", "description": "Показать план без выполнения"}
+  ],
+  "multiSelect": true
+}
+```
+
+**Фиксированные опции (всегда применяются):**
+- `--sync-mode update` - только обновление/добавление файлов
+- `--cleanup-mode smart` - умная очистка старых образов
+
+**Формирование итоговой команды:**
+```bash
+ssh budget-test "cd ~/familyBudget && sudo bash deploy.sh --sync-mode update --cleanup-mode smart [--version TYPE] [OPTIONS]"
+```
+
 ### Шаг 1: Проверка SSH подключения
 ```bash
 ssh budget-test "echo 'Connection OK'"

--- a/.claude/skills/deploy-test/templates/deploy-test.sh
+++ b/.claude/skills/deploy-test/templates/deploy-test.sh
@@ -35,6 +35,7 @@ AUTO_FIX=false
 VERBOSE=false
 DRY_RUN=false
 VERSION_OPTION=""  # Version option to pass to deploy.sh
+FORCE_BUILD=""     # Force build option
 
 # Парсинг аргументов
 while [[ $# -gt 0 ]]; do
@@ -61,9 +62,13 @@ while [[ $# -gt 0 ]]; do
             VERSION_OPTION="--version $2"
             shift 2
             ;;
+        --force-build)
+            FORCE_BUILD="--force-build"
+            shift
+            ;;
         *)
             echo "Unknown option: $1"
-            echo "Usage: $0 [--auto-fix] [--verbose] [--dry-run] [--version TYPE]"
+            echo "Usage: $0 [--auto-fix] [--verbose] [--dry-run] [--version TYPE] [--force-build]"
             exit 1
             ;;
     esac
@@ -76,6 +81,11 @@ if [[ -n "$VERSION_OPTION" ]]; then
     echo -e "${BLUE}ℹ${NC} Version bump: ${VERSION_OPTION}"
 else
     echo -e "${BLUE}ℹ${NC} Version bump: none (version will not change)"
+fi
+
+if [[ -n "$FORCE_BUILD" ]]; then
+    DEPLOY_SCRIPT="${DEPLOY_SCRIPT} ${FORCE_BUILD}"
+    echo -e "${BLUE}ℹ${NC} Force build: enabled"
 fi
 
 # Создать директорию для логов

--- a/scripts/lib/services.sh
+++ b/scripts/lib/services.sh
@@ -776,6 +776,15 @@ start_application_services() {
             return 1
         fi
         success "Services recreated successfully"
+
+        # Save HTML templates checksum if backend was recreated
+        # This enables future detection of template changes for Jinja2 cache invalidation
+        if [[ " ${services_to_recreate[*]} " =~ " backend " ]]; then
+            info "Saving HTML templates checksum (backend recreated)..."
+            if save_html_templates_checksum "$SCRIPT_DIR"; then
+                success "HTML templates checksum saved"
+            fi
+        fi
     else
         info "No services need recreation (code unchanged)"
         start_result=0

--- a/scripts/lib/sync.sh
+++ b/scripts/lib/sync.sh
@@ -726,6 +726,22 @@ analyze_sync_changes() {
     if [[ -z "${SYNC_CHANGED_FILES:-}" ]]; then
         info "No file changes detected in sync - containers may not need recreation"
         info "This is normal if code is up-to-date or sync was skipped"
+
+        # CRITICAL: Check HTML templates checksum for Jinja2 cache invalidation
+        # Even when rsync detects no changes (files already synced), the backend
+        # container may have stale Jinja2 cached templates from a previous deploy.
+        # This happens when:
+        #   1. First deploy syncs files and starts backend (Jinja2 caches templates)
+        #   2. Code change is committed (e.g., CSS removed from base.html)
+        #   3. Second deploy - rsync sees files already identical → SYNC_CHANGED_FILES empty
+        #   4. Without checksum check, backend keeps running with OLD cached templates
+        #
+        # Fix: Compare templates checksum with last backend recreation
+        if needs_backend_restart_for_templates "$SCRIPT_DIR"; then
+            export NEEDS_BACKEND_RECREATE=true
+            info "✓ Backend will be recreated (HTML templates changed since last restart)"
+        fi
+
         return 0
     fi
 

--- a/scripts/lib/version.sh
+++ b/scripts/lib/version.sh
@@ -464,6 +464,73 @@ save_frontend_build_checksums() {
     info "Saved frontend build checksums"
 }
 
+# =============================================================================
+# HTML TEMPLATES CHECKSUM FUNCTIONS
+# =============================================================================
+# Jinja2 templates are cached in memory by the backend container.
+# When templates change but rsync detects no file changes (files already synced),
+# the backend must still be restarted to clear Jinja2 cache.
+#
+# These functions track HTML templates checksum separately from frontend_build_checksums
+# to detect template changes that require backend restart for Jinja2 cache invalidation.
+
+# File to store checksum of HTML templates from last backend recreation
+HTML_TEMPLATES_CHECKSUM_FILE="${DEPLOY_DIR}/.html_templates_checksum"
+
+# Save HTML templates checksum after backend container recreation
+# Call this AFTER backend container is successfully recreated
+# Args: repo_dir (optional, defaults to SCRIPT_DIR)
+save_html_templates_checksum() {
+    local repo_dir="${1:-$SCRIPT_DIR}"
+    local checksum_file="$HTML_TEMPLATES_CHECKSUM_FILE"
+
+    local checksum
+    checksum=$(find "$repo_dir/frontend/web/templates" -type f -name "*.html" 2>/dev/null | sort | xargs md5sum 2>/dev/null | md5sum | cut -d' ' -f1)
+
+    if [[ -z "$checksum" ]]; then
+        warning "No HTML templates found to save checksum"
+        return 1
+    fi
+
+    echo "$checksum" > "$checksum_file"
+    info "Saved HTML templates checksum: ${checksum:0:12}..."
+    return 0
+}
+
+# Check if HTML templates changed since last backend recreation
+# This catches cases where rsync didn't detect changes but Jinja2 cache is stale
+# Returns: 0 if changed (restart needed), 1 if unchanged
+# Args: repo_dir (optional, defaults to SCRIPT_DIR)
+needs_backend_restart_for_templates() {
+    local repo_dir="${1:-$SCRIPT_DIR}"
+    local checksum_file="$HTML_TEMPLATES_CHECKSUM_FILE"
+
+    # Always restart if no previous checksum (first deploy or checksum file deleted)
+    if [[ ! -f "$checksum_file" ]]; then
+        info "No previous HTML templates checksum - backend restart needed"
+        return 0
+    fi
+
+    local previous_checksum
+    previous_checksum=$(cat "$checksum_file")
+
+    local current_checksum
+    current_checksum=$(find "$repo_dir/frontend/web/templates" -type f -name "*.html" 2>/dev/null | sort | xargs md5sum 2>/dev/null | md5sum | cut -d' ' -f1)
+
+    if [[ -z "$current_checksum" ]]; then
+        warning "No HTML templates found to calculate checksum"
+        return 1
+    fi
+
+    if [[ "$previous_checksum" != "$current_checksum" ]]; then
+        info "HTML templates changed: ${previous_checksum:0:12}... → ${current_checksum:0:12}..."
+        return 0
+    fi
+
+    info "HTML templates unchanged (checksum: ${current_checksum:0:12}...)"
+    return 1
+}
+
 # Check if Docker images need to be rebuilt
 # Compares current trigger files against checksums from LAST SUCCESSFUL BUILD
 # (not against deploy directory, which may have been synced without rebuild)


### PR DESCRIPTION
## Summary
- Adds HTML templates checksum tracking to detect Jinja2 cache staleness
- Fixes issue where template changes weren't applied after repeat deployments
- Backend now restarts when templates change, even if rsync sees no file differences

## Problem
After deploying changes that removed CSS from `base.html` (PR #332), the old styles were still visible because:
1. First deploy synced files and started backend (Jinja2 cached templates)
2. Second deploy - rsync saw files already identical → `SYNC_CHANGED_FILES` empty
3. Backend kept running with OLD cached templates in memory

## Solution
Track HTML templates checksum separately from rsync file comparison:
- `save_html_templates_checksum()` - saves MD5 after backend recreation
- `needs_backend_restart_for_templates()` - checks if templates changed
- Integration in `analyze_sync_changes()` sets `NEEDS_BACKEND_RECREATE` flag
- Integration in `start_application_services()` saves checksum after recreate

## Test plan
- [ ] Deploy twice with template change to verify backend restarts on second deploy
- [ ] Verify `.html_templates_checksum` file is created in `/opt/budget/`
- [ ] Check deploy logs show "HTML templates changed" message when applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)