### PR TITLE
fix(ui): FAB visibility, speed dial, delete icon

### DIFF
--- a/frontend/web/static/css/custom.css
+++ b/frontend/web/static/css/custom.css
@@ -950,14 +950,16 @@ html.offline-mode .save-btn:hover {
 .fab-wrapper {
     position: fixed;
     right: 1rem;
-    bottom: 1rem;
+    bottom: 5rem; /* Увеличено с 1rem для отступа от мобильной навигации */
     z-index: 998;
+    opacity: 1 !important; /* Гарантированная видимость */
+    visibility: visible;
 }
 
 @media (min-width: 1024px) {
     .fab-wrapper {
         right: 2rem;
-        bottom: 2rem;
+        bottom: 2rem; /* На desktop меньше отступ, т.к. нет нижней навигации */
     }
 }
 
@@ -982,5 +984,117 @@ html.offline-mode .save-btn:hover {
     .fab-button {
         width: 64px;
         height: 64px;
+    }
+}
+
+/* ============= Speed Dial Menu (для FAB wrapper) ============= */
+
+/* Контейнер меню */
+.fab-wrapper .mobile-fab-menu {
+    position: absolute;
+    bottom: 100%;
+    right: 0;
+    margin-bottom: 0.75rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    opacity: 0;
+    visibility: hidden;
+    transform: translateY(10px) scale(0.95);
+    transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
+    pointer-events: none;
+}
+
+/* Открытое состояние меню */
+.fab-wrapper.open .mobile-fab-menu {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(0) scale(1);
+    pointer-events: auto;
+}
+
+/* Элемент меню */
+.fab-wrapper .mobile-fab-item {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 0.75rem;
+    animation: slideInFab 0.3s cubic-bezier(0.4, 0, 0.2, 1) forwards;
+    opacity: 0;
+}
+
+/* Задержка анимации для каскадного эффекта */
+.fab-wrapper.open .mobile-fab-item:nth-child(1) {
+    animation-delay: 0.05s;
+}
+
+.fab-wrapper.open .mobile-fab-item:nth-child(2) {
+    animation-delay: 0.1s;
+}
+
+@keyframes slideInFab {
+    from {
+        opacity: 0;
+        transform: translateY(10px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+/* Лейбл (текстовая подсказка) */
+.fab-wrapper .mobile-fab-label {
+    background-color: rgba(0, 0, 0, 0.8);
+    color: white;
+    padding: 0.5rem 0.75rem;
+    border-radius: 0.5rem;
+    font-size: 0.875rem;
+    white-space: nowrap;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
+/* Кнопки в Speed Dial меню */
+.fab-wrapper .mobile-fab-item .btn-circle {
+    width: 48px;
+    height: 48px;
+}
+
+/* Вращение иконки + при открытии меню */
+.fab-wrapper.open .fab-icon-plus {
+    transform: rotate(45deg);
+    transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.fab-wrapper:not(.open) .fab-icon-plus {
+    transform: rotate(0deg);
+    transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* ============= Delete Button Mobile Fix ============= */
+
+/* Гарантированная видимость delete кнопки на мобильных */
+.modal-action button.btn-square.btn-error {
+    display: block !important; /* Показывать по умолчанию */
+}
+
+/* Скрыть на desktop (где есть чекбоксы) */
+@media (min-width: 768px) {
+    .modal-action button.btn-square.btn-error.md\:hidden {
+        display: none !important;
+    }
+}
+
+/* Увеличить размер кнопки на очень узких экранах */
+@media (max-width: 374px) {
+    .modal-action button.btn-square.btn-error {
+        min-width: 2.5rem !important; /* 40px вместо 32px */
+        min-height: 2.5rem !important;
+        padding: 0.5rem !important;
+    }
+
+    .modal-action button.btn-square.btn-error svg {
+        width: 1.25rem !important; /* 20px вместо 16px */
+        height: 1.25rem !important;
     }
 }

--- a/frontend/web/templates/components/fab_toolbar.html
+++ b/frontend/web/templates/components/fab_toolbar.html
@@ -71,15 +71,51 @@
         </div> <!-- .nav-container -->
     </div> <!-- .mobile-nav-wrapper -->
 
-    <!-- Simplified Universal FAB Button (shown on /, /facts, /plan) -->
+    <!-- Speed Dial FAB для главной страницы -->
     <div class="fab-wrapper" id="fab-wrapper">
+        <!-- Speed Dial меню (показывается только на /) -->
+        <div id="fab-speed-dial-menu" class="mobile-fab-menu" style="display: none;">
+            <!-- Опция 1: Добавить факт -->
+            <div class="mobile-fab-item">
+                <span class="mobile-fab-label">Добавить факт</span>
+                <button
+                    onclick="openModalFact(); closeFabMenu();"
+                    class="btn btn-circle btn-primary shadow-lg"
+                    aria-label="Добавить фактическую транзакцию"
+                    title="Добавить факт">
+                    <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <!-- Document icon -->
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                              d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
+                    </svg>
+                </button>
+            </div>
+
+            <!-- Опция 2: Добавить план -->
+            <div class="mobile-fab-item">
+                <span class="mobile-fab-label">Добавить план</span>
+                <button
+                    onclick="openModalPlan(); closeFabMenu();"
+                    class="btn btn-circle btn-primary shadow-lg"
+                    aria-label="Добавить плановую транзакцию"
+                    title="Добавить план">
+                    <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <!-- Calendar icon -->
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                              d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/>
+                    </svg>
+                </button>
+            </div>
+        </div>
+
+        <!-- Основная FAB кнопка -->
         <button
-            onclick="openContextModal()"
+            onclick="toggleFabMenu()"
             class="fab-button btn btn-circle btn-primary shadow-lg"
             id="fab-btn"
             aria-label="Добавить запись"
             title="Добавить запись">
-            <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg class="w-6 h-6 fab-icon-plus" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/>
             </svg>
         </button>
@@ -116,10 +152,19 @@ const FAB_PAGE_CONTEXT = {
 
         if (!context || context === 'lists') {
             // Hide FAB on /lists and unlisted pages (e.g., /analytics)
-            if (fabWrapper) fabWrapper.style.display = 'none';
+            if (fabWrapper) {
+                fabWrapper.style.display = 'none';
+                fabWrapper.style.visibility = 'hidden';
+                fabWrapper.style.pointerEvents = 'none';
+            }
         } else {
             // Show FAB on /, /facts, /plan
-            if (fabWrapper) fabWrapper.style.display = '';
+            if (fabWrapper) {
+                fabWrapper.style.display = '';
+                fabWrapper.style.visibility = 'visible';
+                fabWrapper.style.pointerEvents = 'auto';
+                fabWrapper.style.opacity = '1'; // Гарантия видимости
+            }
         }
 
         // Mobile navigation always visible (except offline mode adjustments)
@@ -197,4 +242,140 @@ const FAB_PAGE_CONTEXT = {
     });
 
 })();
+
+// ============= Speed Dial Controls =============
+
+/**
+ * Безопасный вызов openContextModal (защита от timing issues)
+ */
+function safeOpenContextModal() {
+    // Приоритет 1: Dashboard module
+    if (typeof window.Dashboard !== 'undefined' && window.Dashboard.openContextModal) {
+        try {
+            window.Dashboard.openContextModal();
+            return;
+        } catch (error) {
+            console.error('[FAB] Dashboard.openContextModal failed:', error);
+        }
+    }
+
+    // Приоритет 2: Global openContextModal
+    if (typeof window.openContextModal === 'function') {
+        try {
+            window.openContextModal();
+            return;
+        } catch (error) {
+            console.error('[FAB] window.openContextModal failed:', error);
+        }
+    }
+
+    // Fallback: Прямой вызов модальных окон
+    const currentPage = window.location.pathname;
+    if (currentPage === '/plan') {
+        if (typeof openModalPlan === 'function') {
+            openModalPlan();
+        } else {
+            console.error('[FAB] openModalPlan not available');
+            showFallbackError();
+        }
+    } else {
+        // По умолчанию - modal_fact (для / и /facts)
+        if (typeof openModalFact === 'function') {
+            openModalFact();
+        } else {
+            console.error('[FAB] openModalFact not available');
+            showFallbackError();
+        }
+    }
+}
+
+/**
+ * Показать ошибку если модальные функции недоступны
+ */
+function showFallbackError() {
+    if (typeof showToast === 'function') {
+        showToast('Функция временно недоступна. Попробуйте обновить страницу.', 'error');
+    } else {
+        alert('Функция временно недоступна. Попробуйте обновить страницу.');
+    }
+}
+
+/**
+ * Переключает Speed Dial меню (только на главной странице)
+ */
+function toggleFabMenu() {
+    const currentPage = window.location.pathname;
+    const wrapper = document.getElementById('fab-wrapper');
+    const menu = document.getElementById('fab-speed-dial-menu');
+
+    if (!wrapper || !menu) {
+        console.error('[FAB] Speed dial elements not found');
+        return;
+    }
+
+    // Speed dial только на главной странице
+    if (currentPage === '/') {
+        const isOpen = wrapper.classList.contains('open');
+
+        if (isOpen) {
+            // Закрыть меню
+            wrapper.classList.remove('open');
+            menu.style.display = 'none';
+        } else {
+            // Открыть меню
+            wrapper.classList.add('open');
+            menu.style.display = 'flex';
+        }
+    } else {
+        // На других страницах - прямой вызов модального окна
+        safeOpenContextModal();
+    }
+}
+
+/**
+ * Закрывает Speed Dial меню
+ */
+function closeFabMenu() {
+    const wrapper = document.getElementById('fab-wrapper');
+    const menu = document.getElementById('fab-speed-dial-menu');
+
+    if (wrapper && menu) {
+        wrapper.classList.remove('open');
+        menu.style.display = 'none';
+    }
+}
+
+/**
+ * Инициализация Speed Dial при загрузке страницы
+ */
+(function initSpeedDial() {
+    const currentPage = window.location.pathname;
+    const menu = document.getElementById('fab-speed-dial-menu');
+    const fabBtn = document.getElementById('fab-btn');
+
+    if (!menu || !fabBtn) return;
+
+    if (currentPage === '/') {
+        // Главная страница: Speed dial меню
+        menu.style.display = 'none'; // Изначально закрыто
+        fabBtn.setAttribute('onclick', 'toggleFabMenu()');
+    } else {
+        // /facts, /plan: прямое открытие модального окна
+        menu.style.display = 'none';
+        fabBtn.setAttribute('onclick', 'safeOpenContextModal()');
+    }
+})();
+
+// Закрытие меню при клике вне FAB
+document.addEventListener('click', function(event) {
+    const wrapper = document.getElementById('fab-wrapper');
+    const menu = document.getElementById('fab-speed-dial-menu');
+
+    if (!wrapper || !menu) return;
+
+    // Если клик вне FAB и меню открыто - закрыть
+    if (!wrapper.contains(event.target) && wrapper.classList.contains('open')) {
+        closeFabMenu();
+    }
+});
 </script>

--- a/frontend/web/templates/components/macros/delete_buttons.html
+++ b/frontend/web/templates/components/macros/delete_buttons.html
@@ -106,10 +106,11 @@
 #}
 {% macro delete_button_mobile(onclick_handler, title='Удалить', extra_classes='') %}
 <button type="button"
-        class="btn btn-sm sm:btn-md btn-error btn-square md:hidden {{ extra_classes }}"
+        class="btn btn-sm sm:btn-md btn-error btn-square md:hidden block {{ extra_classes }}"
         onclick="{{ onclick_handler }}"
         title="{{ title }}"
-        aria-label="{{ title }}">
+        aria-label="{{ title }}"
+        style="display: block !important;">
     {{ delete_icon_svg('h-5 w-5') }}
 </button>
 {% endmacro %}


### PR DESCRIPTION
## Проблемы

1. ✅ FAB кнопка невидима (opacity: 0)
2. ✅ FAB слишком близко к навигации
3. ✅ Нет выбора факт/план на главной
4. ✅ openContextModal не определена на /facts, /plan
5. ✅ Delete иконка пропадает на iPhone (<375px)

## Решения

### FAB Видимость и Позиционирование
- Установлена `opacity: 1 !important` для гарантированной видимости
- Увеличен `bottom: 5rem` (было 1rem) для отступа от мобильной навигации
- Добавлены явные visibility и pointerEvents управления в JS

### Speed Dial Меню
- Добавлено expandable меню с 2 опциями на главной странице (/)
- "Добавить факт" → открывает modal_fact
- "Добавить план" → открывает modal_plan
- Иконка + вращается на 45° при открытии
- Меню закрывается при клике вне FAB

### openContextModal Ошибки
- Добавлен `safeOpenContextModal()` wrapper с fallback chain
- Проверяет Dashboard.openContextModal → window.openContextModal → прямой вызов modals
- Устранены ошибки "not defined" на /facts и /plan

### Delete Icon на Узких Экранах
- Добавлен класс `block` + inline style `display: block !important`
- Увеличен размер кнопки на экранах <375px (40px вместо 32px)
- Увеличена иконка до 20px на узких экранах

## Изменённые Файлы

- `frontend/web/templates/components/fab_toolbar.html` - HTML структура + JS логика
- `frontend/web/static/css/custom.css` - Стили FAB + Speed Dial + Delete button
- `frontend/web/templates/components/macros/delete_buttons.html` - Макрос delete кнопки

## Manual Testing Checklist

### FAB Visibility
- [ ] Открыть `/` - FAB видима, opacity = 1
- [ ] Открыть `/facts` - FAB видима
- [ ] Открыть `/plan` - FAB видима
- [ ] Открыть `/analytics` - FAB скрыта

### Speed Dial Menu
- [ ] На `/` кликнуть FAB - меню раскрывается вверх
- [ ] Показываются 2 кнопки: "Добавить факт" и "Добавить план"
- [ ] Иконка + вращается на 45° при открытии
- [ ] Клик на "Добавить факт" открывает modal_fact
- [ ] Клик на "Добавить план" открывает modal_plan
- [ ] Клик вне FAB закрывает меню

### FAB Positioning
- [ ] На мобильном (<1024px) FAB НАД навигацией (bottom: 5rem)
- [ ] На desktop (>1024px) FAB в углу (bottom: 2rem)

### openContextModal
- [ ] На `/facts` кликнуть FAB - modal_fact открывается без ошибок
- [ ] На `/plan` кликнуть FAB - modal_plan открывается без ошибок

### Delete Icon
- [ ] Открыть edit modal на iPhone SE (<375px) - иконка видна
- [ ] Открыть edit modal на iPhone 12 (~390px) - иконка видна
- [ ] Открыть edit modal на iPad (768px) - иконка скрыта
- [ ] Открыть edit modal на desktop (>1024px) - иконка скрыта

## Backward Compatibility

✅ Все изменения backward compatible
✅ Никаких breaking changes
✅ TypeScript не требует rebuild (изменения только в HTML/CSS)

## Next Steps

1. Автоматический CI/CD build в GitHub Actions
2. Deploy на budget-test для manual testing
3. После подтверждения → deploy на production