### PR TITLE
fix(frontend): исправлено раскрытие desktop FAB menu вверх

### DIFF
--- a/docs/architecture/frontend/responsive-design.md
+++ b/docs/architecture/frontend/responsive-design.md
@@ -56,6 +56,8 @@ Family Budget uses Tailwind CSS breakpoint system:
 - Speed Dial menu with 4 action items
 - Backdrop overlay when open
 - Z-index: 1000 (backdrop: 999)
+- **Menu expansion direction:** Upward (items appear ABOVE button)
+- **Main button position:** Fixed (doesn't move when menu opens)
 
 ### Page Context Visibility Matrix
 
@@ -93,6 +95,37 @@ Family Budget uses Tailwind CSS breakpoint system:
   breakpoint: 1024
 }
 ```
+
+### FAB Menu Expansion Direction (v11.3.0)
+
+**Desktop FAB (≥1024px):**
+- Speed Dial menu раскрывается **вверх** (items appear ABOVE button)
+- Главная кнопка остается fixed на месте (не сдвигается при раскрытии)
+- CSS Implementation:
+  ```css
+  .desktop-fab-wrapper {
+      flex-direction: column;  /* Not column-reverse */
+  }
+
+  /* Items positioned above button */
+  .desktop-fab-wrapper .fab-menu-item {
+      order: -1;
+  }
+
+  .desktop-fab-wrapper .fab-button {
+      order: 999;
+  }
+
+  /* Collapse animation slides down */
+  .desktop-fab-wrapper.closed .fab-menu-item {
+      transform: scale(0.5) translateY(20px);  /* +20px = slide down */
+  }
+  ```
+
+**Mobile FAB (<1024px):**
+- Speed Dial menu раскрывается **вверх** (items appear ABOVE button)
+- Используется отдельная структура `.mobile-fab-menu`
+- Positioning: `bottom: calc(100% + 0.5rem)`
 
 ### Critical CSS Requirements
 

--- a/frontend/web/static/css/custom.css
+++ b/frontend/web/static/css/custom.css
@@ -414,11 +414,20 @@ html.offline-mode .save-btn:hover {
 
     .desktop-fab-wrapper {
         display: flex !important;
-        flex-direction: column-reverse;
+        flex-direction: column;
         align-items: flex-end;
         gap: 0.75rem;
         z-index: var(--z-fab-desktop);  /* 1000 - above backdrop (999) */
         position: relative;
+    }
+
+    /* FAB menu items ordering - items appear ABOVE button */
+    .desktop-fab-wrapper .fab-menu-item {
+        order: -1;
+    }
+
+    .desktop-fab-wrapper .fab-button {
+        order: 999;
     }
 
     /* Fallback для браузеров без gap support (Safari < 14.1, IE11) */
@@ -672,7 +681,7 @@ html.offline-mode .save-btn:hover {
     display: none;  /* Force hide - like Main FAB in lists */
     opacity: 0;
     visibility: hidden;  /* iOS Safari protection */
-    transform: scale(0.5) translateY(-20px);
+    transform: scale(0.5) translateY(20px);
     pointer-events: none;
     transition: opacity 0.3s, visibility 0s 0.3s, transform 0.3s;
 }


### PR DESCRIPTION
## Описание

Исправлено поведение desktop FAB menu - теперь раскрывается вверх, а не вниз.

## Проблема

- Desktop FAB menu раскрывался **вниз**, сдвигая главную кнопку **вверх**
- Использовался `flex-direction: column-reverse`, который инвертировал порядок элементов
- При раскрытии menu items появлялись снизу, заставляя button перемещаться

## Решение

### CSS изменения (`frontend/web/static/css/custom.css`)

1. **Изменен flex-direction:**
   - Было: `flex-direction: column-reverse`
   - Стало: `flex-direction: column`

2. **Добавлены order rules:**
   ```css
   .desktop-fab-wrapper .fab-menu-item {
       order: -1;  /* Items appear before button */
   }
   
   .desktop-fab-wrapper .fab-button {
       order: 999;  /* Button stays at bottom */
   }
   ```

3. **Исправлена animation direction:**
   - Было: `transform: scale(0.5) translateY(-20px)`
   - Стало: `transform: scale(0.5) translateY(20px)` (slide down when closing)

## Визуальный результат

- ✅ Desktop FAB menu раскрывается **вверх**
- ✅ Menu items появляются **выше** главной кнопки
- ✅ Главная кнопка **остается на месте** (fixed position)
- ✅ Animation соответствует направлению раскрытия

## Затронутые файлы

- `frontend/web/static/css/custom.css` (lines 417, 425-431, 684)
- `docs/architecture/frontend/responsive-design.md` (добавлена документация)

## Тестирование

- ✅ Frontend build успешен (`npm run build`)
- ✅ TypeScript type check passed
- ✅ Pre-commit hooks passed

## Checklist

- [x] CSS изменения применены
- [x] Build успешно завершен
- [x] Документация обновлена
- [x] Коммиты содержат Co-Authored-By

## Связанные материалы

- Complexity: **MINIMAL** (CSS-only fix)
- Breaking changes: **No**
- Requires manual testing: **Yes** (visual regression on desktop viewport ≥1024px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)