### PR TITLE
fix(frontend): correct API endpoint paths causing 404 errors

### DIFF
--- a/frontend/web/static/js/dashboard/features/modalFact/index.ts
+++ b/frontend/web/static/js/dashboard/features/modalFact/index.ts
@@ -279,7 +279,7 @@ async function loadFactTransferHints(direction: 'from' | 'to'): Promise<void> {
     }
 
     const articleType = direction === 'from' ? 'expense' : 'income';
-    const url = `/api/v1/hints/fact-hints?fact_date=${factDate}&article_id=${categoryId}&article_type=${articleType}&financial_center_id=${fcId}`;
+    const url = `/api/v1/analytics/fact-hints?fact_date=${factDate}&article_id=${categoryId}&article_type=${articleType}&financial_center_id=${fcId}`;
 
     const response = await fetch(url);
 

--- a/frontend/web/static/js/dashboard/features/modalFact/saveTransfer.ts
+++ b/frontend/web/static/js/dashboard/features/modalFact/saveTransfer.ts
@@ -34,8 +34,8 @@ export async function saveFactTransfer(form: HTMLFormElement): Promise<void> {
     description: formData.get('description') || null
   };
 
-  // POST /api/v1/admin/transfers
-  await postAPI('/api/v1/admin/transfers', data, 'SaveFactModal');
+  // POST /api/v1/transfers
+  await postAPI('/api/v1/transfers', data, 'SaveFactModal');
 
   // Update UI
   await refreshUIAfterFactSave();

--- a/frontend/web/static/js/dashboard/features/modalPlan/index.ts
+++ b/frontend/web/static/js/dashboard/features/modalPlan/index.ts
@@ -286,7 +286,7 @@ async function loadPlanTransferHints(direction: 'from' | 'to'): Promise<void> {
     }
 
     const articleType = direction === 'from' ? 'expense' : 'income';
-    const url = `/api/v1/hints/plan-hints?period=${period}&article_id=${categoryId}&article_type=${articleType}&financial_center_id=${fcId}`;
+    const url = `/api/v1/analytics/plan-hints?period=${period}&article_id=${categoryId}&article_type=${articleType}&financial_center_id=${fcId}`;
 
     const response = await fetch(url);
 

--- a/frontend/web/static/js/dashboard/features/modalPlan/saveTransfer.ts
+++ b/frontend/web/static/js/dashboard/features/modalPlan/saveTransfer.ts
@@ -26,8 +26,8 @@ export async function savePlanTransfer(form: HTMLFormElement): Promise<void> {
     description: formData.get('description') || null
   };
 
-  // POST /api/v1/admin/transfers
-  await postAPI('/api/v1/admin/transfers', data, 'SavePlanModal');
+  // POST /api/v1/transfers
+  await postAPI('/api/v1/transfers', data, 'SavePlanModal');
 
   // Update UI
   await refreshUIAfterPlanSave();


### PR DESCRIPTION
## 🔴 Critical Hotfix - API Endpoint 404 Errors

### Problem
After deploying **v11.4.31** (PR #413 - legacy modal cleanup), multiple API endpoints started returning 404 errors:

```
GET /api/v1/hints/fact-hints → 404 (should be /api/v1/analytics/fact-hints)
GET /api/v1/hints/plan-hints → 404 (should be /api/v1/analytics/plan-hints)
POST /api/v1/admin/transfers → 404 (should be /api/v1/transfers)
```

### Root Cause
New modal modules (modalFact, modalPlan) introduced in v10.x-v11.x used **incorrect API paths**. Legacy code (removed in PR #413) was using **correct paths** from analyticsAPI.ts.

The regression was **hidden** until PR #413 removed the working legacy code, exposing the bug in the new modules.

### Impact
- ❌ Modal fact/plan hints not loading (period plan/fact amounts)
- ❌ Transfer operations failing
- ❌ Affects both desktop and mobile views
- ⚠️ User-facing errors in production

### Solution
Fixed API paths in 4 files:

| File | Line | Old Path | New Path |
|------|------|----------|----------|
| modalFact/index.ts | 282 | /api/v1/hints/fact-hints | /api/v1/analytics/fact-hints |
| modalFact/saveTransfer.ts | 38 | /api/v1/admin/transfers | /api/v1/transfers |
| modalPlan/index.ts | 289 | /api/v1/hints/plan-hints | /api/v1/analytics/plan-hints |
| modalPlan/saveTransfer.ts | 30 | /api/v1/admin/transfers | /api/v1/transfers |

### Testing
- ✅ TypeScript compilation: PASSED
- ✅ Pre-commit hooks: PASSED
- 📋 Expected behavior after merge: hints display correctly, transfers work

### Priority
**CRITICAL** - Production regression affecting user-facing features.

### Related
- Caused by: PR #413 (legacy modal cleanup)
- Regression: v11.4.31
- Fix: v11.4.32

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>