### PR TITLE
Fix admin pages bugs (6 issues)

### DIFF
--- a/backend/app/api/v1/endpoints/articles.py
+++ b/backend/app/api/v1/endpoints/articles.py
@@ -436,6 +436,10 @@ async def update_article(
             detail="At least one field must be provided for update"
         )
 
+    # Extract financial_center_ids BEFORE has_changes check (M2M field)
+    financial_center_ids = update_data.pop('financial_center_ids', None)
+    logger.info(f"[UPDATE_ARTICLE] Extracted financial_center_ids: {financial_center_ids}")
+
     # Load article
     statement = select(Article).where(
         Article.id == article_id
@@ -477,8 +481,8 @@ async def update_article(
     logger = logging.getLogger(__name__)
     logger.info(f"[ARTICLE UPDATE] article_id={article_id}, changed={changed}, changed_fields={changed_fields}, update_data={update_data}")
 
-    if not changed:
-        # No changes, return existing article
+    if not changed and financial_center_ids is None:
+        # No changes (neither scalar fields nor M2M), return existing article
         logger.info("[ARTICLE UPDATE] No changes detected, returning old article")
         return old_article
 
@@ -526,15 +530,44 @@ async def update_article(
             change_type="UPDATE",
         )
         logger.info(f"[ARTICLE UPDATE] Updated article (SCD1+History): id={article_id}")
-        # Invalidate articles cache
-        await cache_service.invalidate_articles()
-        return updated_article
+        result_article = updated_article
     else:
-        # Only is_active was changed, return updated article (no history record needed - already done by archive/restore)
-        logger.info("[ARTICLE UPDATE] Only is_active changed, returning updated article")
-        # Invalidate articles cache (is_active change affects listing)
-        await cache_service.invalidate_articles()
-        return old_article
+        # Only is_active was changed (or only financial_center_ids), return updated article
+        logger.info("[ARTICLE UPDATE] Only is_active changed (or only M2M fields)")
+        result_article = old_article
+
+    # Handle financial_center_ids (Many-to-Many relationship)
+    if financial_center_ids is not None:
+        from sqlalchemy import delete
+        from backend.app.models.article_financial_center import ArticleFinancialCenter
+
+        logger.info(f"[UPDATE_ARTICLE] Updating financial center links for article_id={article_id}")
+
+        # Delete existing links
+        delete_stmt = delete(ArticleFinancialCenter).where(
+            ArticleFinancialCenter.article_id == article_id
+        )
+        await session.execute(delete_stmt)
+        logger.info(f"[UPDATE_ARTICLE] Deleted existing FC links")
+
+        # Insert new links (if list is not empty)
+        if financial_center_ids:
+            for fc_id in financial_center_ids:
+                link = ArticleFinancialCenter(
+                    article_id=article_id,
+                    financial_center_id=fc_id
+                )
+                session.add(link)
+            logger.info(f"[UPDATE_ARTICLE] Created {len(financial_center_ids)} new FC links")
+        else:
+            logger.info("[UPDATE_ARTICLE] Cleared all FC links (available for all FCs)")
+
+        await session.commit()
+        await session.refresh(result_article)
+
+    # Invalidate cache AFTER updating M2M relationships
+    await cache_service.invalidate_articles()
+    return result_article
 
 
 @router.delete(

--- a/frontend/web/templates/admin_articles.html
+++ b/frontend/web/templates/admin_articles.html
@@ -171,7 +171,7 @@
                 <!-- Кнопка удаления - только иконка, видна только на мобильных (где нет чекбоксов) -->
                 {{ delete_button_mobile('deleteArticleFromEditModal()') }}
                 <!-- Разделитель (пустое пространство) -->
-                <div class="flex-1 md:hidden"></div>
+                <div class="flex-1"></div>
                 <button type="button" class="btn btn-sm sm:btn-md flex-1 sm:flex-initial" onclick="closeEditModal()">❌ Отмена</button>
                 <button type="submit" class="btn btn-sm sm:btn-md btn-primary flex-1 sm:flex-initial">💾 Сохранить</button>
             </div>
@@ -753,10 +753,36 @@ function closeEditModal() {
 }
 
 // Delete article from edit modal (mobile only)
-function deleteArticleFromEditModal() {
+async function deleteArticleFromEditModal() {
     const articleId = document.getElementById('edit-id').value;
-    closeEditModal();
-    deactivateArticle(articleId);
+    const modal = document.getElementById('edit-modal');
+
+    // ✅ Create overlay loader
+    const overlay = document.createElement('div');
+    overlay.className = 'absolute inset-0 bg-base-300/80 flex items-center justify-center z-50 rounded-lg';
+    overlay.innerHTML = `
+        <div class="flex flex-col items-center gap-4">
+            <span class="loading loading-spinner loading-lg text-primary"></span>
+            <p class="text-lg font-semibold">Удаление категории...</p>
+        </div>
+    `;
+
+    // Add overlay to modal
+    const modalBox = modal.querySelector('.modal-box');
+    modalBox.style.position = 'relative';
+    modalBox.appendChild(overlay);
+
+    try {
+        // ✅ Wait for deletion to complete
+        await deactivateArticle(articleId);
+
+        // ✅ Close modal AFTER successful deletion
+        closeEditModal();
+    } catch (error) {
+        // Error already handled in deactivateArticle()
+        // Remove overlay to allow retry
+        overlay.remove();
+    }
 }
 
 // Update article
@@ -839,6 +865,19 @@ async function updateArticle(event) {
 
 // Deactivate article
 async function deactivateArticle(articleId) {
+    // ✅ Normalize ID to integer for correct comparison
+    const articleIdInt = typeof articleId === 'string' ? parseInt(articleId, 10) : articleId;
+
+    // ✅ Find article with normalized ID
+    const article = articlesData.find(a => a.id === articleIdInt);
+
+    // ✅ Check for undefined BEFORE using article
+    if (!article) {
+        console.error(`Article with ID ${articleId} not found in articlesData`);
+        showNotification('❌ Категория не найдена', 'error');
+        return;
+    }
+
     // First confirmation - warning about physical deletion
     const firstConfirm = await showConfirmDialog(
         '⚠️ ВНИМАНИЕ: Физическое удаление категории!\n\n' +
@@ -873,7 +912,7 @@ async function deactivateArticle(articleId) {
     }
 
     try {
-        const response = await fetch(`/api/v1/admin/articles/${articleId}`, {
+        const response = await fetch(`/api/v1/admin/articles/${articleIdInt}`, {
             method: 'DELETE',
             credentials: 'include',
         });

--- a/frontend/web/templates/admin_cost_centers.html
+++ b/frontend/web/templates/admin_cost_centers.html
@@ -115,7 +115,7 @@
                 <!-- Кнопка удаления - только иконка, видна только на мобильных (где нет чекбоксов) -->
                 {{ delete_button_mobile('deleteCenterFromEditModal()') }}
                 <!-- Разделитель (пустое пространство) -->
-                <div class="flex-1 md:hidden"></div>
+                <div class="flex-1"></div>
                 <button type="button" class="btn btn-sm sm:btn-md flex-1 sm:flex-initial" onclick="closeEditModal()">❌ Отмена</button>
                 <button type="submit" class="btn btn-sm sm:btn-md btn-primary flex-1 sm:flex-initial">💾 Сохранить</button>
             </div>
@@ -392,10 +392,36 @@ function closeEditModal() {
 }
 
 // Delete center from edit modal (mobile only)
-function deleteCenterFromEditModal() {
+async function deleteCenterFromEditModal() {
     const centerId = document.getElementById('edit-id').value;
-    closeEditModal();
-    deleteCenter(centerId);
+    const modal = document.getElementById('edit-modal');
+
+    // ✅ Create overlay loader
+    const overlay = document.createElement('div');
+    overlay.className = 'absolute inset-0 bg-base-300/80 flex items-center justify-center z-50 rounded-lg';
+    overlay.innerHTML = `
+        <div class="flex flex-col items-center gap-4">
+            <span class="loading loading-spinner loading-lg text-primary"></span>
+            <p class="text-lg font-semibold">Удаление МЗ...</p>
+        </div>
+    `;
+
+    // Add overlay to modal
+    const modalBox = modal.querySelector('.modal-box');
+    modalBox.style.position = 'relative';
+    modalBox.appendChild(overlay);
+
+    try {
+        // ✅ Wait for deletion to complete
+        await deleteCenter(centerId);
+
+        // ✅ Close modal AFTER successful deletion
+        closeEditModal();
+    } catch (error) {
+        // Error already handled in deleteCenter()
+        // Remove overlay to allow retry
+        overlay.remove();
+    }
 }
 
 // Update cost center
@@ -442,6 +468,19 @@ async function updateCenter(event) {
 
 // Delete cost center
 async function deleteCenter(centerId) {
+    // ✅ Normalize ID to integer for correct comparison
+    const centerIdInt = typeof centerId === 'string' ? parseInt(centerId, 10) : centerId;
+
+    // ✅ Find center with normalized ID
+    const center = centersData.find(c => c.id === centerIdInt);
+
+    // ✅ Check for undefined BEFORE using center
+    if (!center) {
+        console.error(`Cost center with ID ${centerId} not found in centersData`);
+        showNotification('❌ МЗ не найдено', 'error');
+        return;
+    }
+
     // First confirmation - warning about cascade deletion
     const firstConfirm = await showConfirmDialog(
         '⚠️ ВНИМАНИЕ: Удаление МЗ приведёт к каскадному удалению!\n\n' +
@@ -474,7 +513,7 @@ async function deleteCenter(centerId) {
     }
 
     try {
-        const response = await fetch(`/api/v1/cost-centers/${centerId}`, {
+        const response = await fetch(`/api/v1/cost-centers/${centerIdInt}`, {
             method: 'DELETE',
             credentials: 'include',
         });

--- a/frontend/web/templates/admin_financial_centers.html
+++ b/frontend/web/templates/admin_financial_centers.html
@@ -93,7 +93,7 @@
                 <!-- Кнопка удаления - только иконка, видна только на мобильных (где нет чекбоксов) -->
                 {{ delete_button_mobile('deleteCenterFromEditModal()') }}
                 <!-- Разделитель (пустое пространство) -->
-                <div class="flex-1 md:hidden"></div>
+                <div class="flex-1"></div>
                 <button type="button" class="btn btn-sm sm:btn-md flex-1 sm:flex-initial" onclick="closeEditModal()">❌ Отмена</button>
                 <button type="submit" class="btn btn-sm sm:btn-md btn-primary flex-1 sm:flex-initial">💾 Сохранить</button>
             </div>
@@ -309,10 +309,36 @@ function closeEditModal() {
 }
 
 // Delete center from edit modal (mobile only)
-function deleteCenterFromEditModal() {
+async function deleteCenterFromEditModal() {
     const centerId = document.getElementById('edit-id').value;
-    closeEditModal();
-    deleteCenter(centerId);
+    const modal = document.getElementById('edit-modal');
+
+    // ✅ Create overlay loader
+    const overlay = document.createElement('div');
+    overlay.className = 'absolute inset-0 bg-base-300/80 flex items-center justify-center z-50 rounded-lg';
+    overlay.innerHTML = `
+        <div class="flex flex-col items-center gap-4">
+            <span class="loading loading-spinner loading-lg text-primary"></span>
+            <p class="text-lg font-semibold">Удаление счета...</p>
+        </div>
+    `;
+
+    // Add overlay to modal
+    const modalBox = modal.querySelector('.modal-box');
+    modalBox.style.position = 'relative';
+    modalBox.appendChild(overlay);
+
+    try {
+        // ✅ Wait for deletion to complete
+        await deleteCenter(centerId);
+
+        // ✅ Close modal AFTER successful deletion
+        closeEditModal();
+    } catch (error) {
+        // Error already handled in deleteCenter()
+        // Remove overlay to allow retry
+        overlay.remove();
+    }
 }
 
 // Update financial center
@@ -367,6 +393,19 @@ async function updateCenter(event) {
 
 // Delete financial center
 async function deleteCenter(centerId) {
+    // ✅ Normalize ID to integer for correct comparison
+    const centerIdInt = typeof centerId === 'string' ? parseInt(centerId, 10) : centerId;
+
+    // ✅ Find center with normalized ID
+    const center = centersData.find(c => c.id === centerIdInt);
+
+    // ✅ Check for undefined BEFORE using center
+    if (!center) {
+        console.error(`Financial center with ID ${centerId} not found in centersData`);
+        showNotification('❌ Счет не найден', 'error');
+        return;
+    }
+
     // First confirmation - warning about cascade deletion
     const firstConfirm = await showConfirmDialog(
         '⚠️ ВНИМАНИЕ: Удаление счета приведёт к каскадному удалению!\n\n' +
@@ -399,7 +438,7 @@ async function deleteCenter(centerId) {
     }
 
     try {
-        const response = await fetch(`/api/v1/financial-centers/${centerId}`, {
+        const response = await fetch(`/api/v1/financial-centers/${centerIdInt}`, {
             method: 'DELETE',
             credentials: 'include',
         });

--- a/frontend/web/templates/admin_product_groups.html
+++ b/frontend/web/templates/admin_product_groups.html
@@ -115,7 +115,7 @@
                 <!-- Кнопка удаления - только иконка, видна только на мобильных (где нет чекбоксов) -->
                 {{ delete_button_mobile('deleteProductGroupFromEditModal()') }}
                 <!-- Разделитель (пустое пространство) -->
-                <div class="flex-1 md:hidden"></div>
+                <div class="flex-1"></div>
                 <button type="button" class="btn btn-sm sm:btn-md flex-1 sm:flex-initial" onclick="closeEditModal()">❌ Отмена</button>
                 <button type="submit" class="btn btn-sm sm:btn-md btn-primary flex-1 sm:flex-initial">💾 Сохранить</button>
             </div>
@@ -435,10 +435,36 @@ function closeEditModal() {
 }
 
 // Delete product group from edit modal (mobile only)
-function deleteProductGroupFromEditModal() {
+async function deleteProductGroupFromEditModal() {
     const productGroupId = document.getElementById('edit-id').value;
-    closeEditModal();
-    deleteProductGroup(productGroupId);
+    const modal = document.getElementById('edit-modal');
+
+    // ✅ Create overlay loader
+    const overlay = document.createElement('div');
+    overlay.className = 'absolute inset-0 bg-base-300/80 flex items-center justify-center z-50 rounded-lg';
+    overlay.innerHTML = `
+        <div class="flex flex-col items-center gap-4">
+            <span class="loading loading-spinner loading-lg text-primary"></span>
+            <p class="text-lg font-semibold">Удаление группы товаров...</p>
+        </div>
+    `;
+
+    // Add overlay to modal
+    const modalBox = modal.querySelector('.modal-box');
+    modalBox.style.position = 'relative';
+    modalBox.appendChild(overlay);
+
+    try {
+        // ✅ Wait for deletion to complete
+        await deleteProductGroup(productGroupId);
+
+        // ✅ Close modal AFTER successful deletion
+        closeEditModal();
+    } catch (error) {
+        // Error already handled in deleteProductGroup()
+        // Remove overlay to allow retry
+        overlay.remove();
+    }
 }
 
 // Update product group
@@ -535,7 +561,19 @@ async function restoreProductGroup(groupId) {
 
 // Delete product group
 async function deleteProductGroup(groupId) {
-    const group = productGroupsData.find(g => g.id === groupId);
+    // ✅ Normalize ID to integer for correct comparison
+    const groupIdInt = typeof groupId === 'string' ? parseInt(groupId, 10) : groupId;
+
+    // ✅ Find group with normalized ID
+    const group = productGroupsData.find(g => g.id === groupIdInt);
+
+    // ✅ Check for undefined BEFORE using group
+    if (!group) {
+        console.error(`Product group with ID ${groupId} not found in productGroupsData`);
+        showToast('❌ Группа товаров не найдена', 'error');
+        return;
+    }
+
     const confirmed = await showConfirmDialog(
         'Удалить группу товаров?',
         `⚠️ ВНИМАНИЕ: Вы уверены, что хотите УДАЛИТЬ "${group.name}"?\n\nЭто действие НЕОБРАТИМО и удалит все связанные данные:\n• Все дочерние группы\n• Все товары в списках покупок для этой группы\n\nРекомендуется использовать архивирование вместо удаления.`
@@ -544,7 +582,7 @@ async function deleteProductGroup(groupId) {
     if (!confirmed) return;
 
     try {
-        const response = await fetch(`/api/v1/product-groups/${groupId}`, {
+        const response = await fetch(`/api/v1/product-groups/${groupIdInt}`, {
             method: 'DELETE',
             credentials: 'include',
         });

--- a/frontend/web/templates/admin_stores.html
+++ b/frontend/web/templates/admin_stores.html
@@ -99,7 +99,7 @@
                 <!-- Кнопка удаления - только иконка, видна только на мобильных (где нет чекбоксов) -->
                 {{ delete_button_mobile('deleteStoreFromEditModal()') }}
                 <!-- Разделитель (пустое пространство) -->
-                <div class="flex-1 md:hidden"></div>
+                <div class="flex-1"></div>
                 <button type="button" class="btn btn-sm sm:btn-md flex-1 sm:flex-initial" onclick="closeEditModal()">❌ Отмена</button>
                 <button type="submit" class="btn btn-sm sm:btn-md btn-primary flex-1 sm:flex-initial">💾 Сохранить</button>
             </div>
@@ -332,10 +332,36 @@ function closeEditModal() {
 }
 
 // Delete store from edit modal (mobile only)
-function deleteStoreFromEditModal() {
+async function deleteStoreFromEditModal() {
     const storeId = document.getElementById('edit-id').value;
-    closeEditModal();
-    deleteStore(storeId);
+    const modal = document.getElementById('edit-modal');
+
+    // ✅ Create overlay loader
+    const overlay = document.createElement('div');
+    overlay.className = 'absolute inset-0 bg-base-300/80 flex items-center justify-center z-50 rounded-lg';
+    overlay.innerHTML = `
+        <div class="flex flex-col items-center gap-4">
+            <span class="loading loading-spinner loading-lg text-primary"></span>
+            <p class="text-lg font-semibold">Удаление магазина...</p>
+        </div>
+    `;
+
+    // Add overlay to modal
+    const modalBox = modal.querySelector('.modal-box');
+    modalBox.style.position = 'relative';
+    modalBox.appendChild(overlay);
+
+    try {
+        // ✅ Wait for deletion to complete
+        await deleteStore(storeId);
+
+        // ✅ Close modal AFTER successful deletion
+        closeEditModal();
+    } catch (error) {
+        // Error already handled in deleteStore()
+        // Remove overlay to allow retry
+        overlay.remove();
+    }
 }
 
 // Update store
@@ -432,7 +458,19 @@ async function restoreStore(storeId) {
 
 // Delete store
 async function deleteStore(storeId) {
-    const store = storesData.find(s => s.id === storeId);
+    // ✅ Normalize ID to integer for correct comparison
+    const storeIdInt = typeof storeId === 'string' ? parseInt(storeId, 10) : storeId;
+
+    // ✅ Find store with normalized ID
+    const store = storesData.find(s => s.id === storeIdInt);
+
+    // ✅ Check for undefined BEFORE using store
+    if (!store) {
+        console.error(`Store with ID ${storeId} not found in storesData`);
+        showToast('❌ Магазин не найден', 'error');
+        return;
+    }
+
     const confirmed = await showConfirmDialog(
         'Удалить магазин?',
         `⚠️ ВНИМАНИЕ: Вы уверены, что хотите УДАЛИТЬ "${store.name}"?\n\nЭто действие НЕОБРАТИМО и удалит все связанные данные:\n• Все товары в списках покупок для этого магазина\n\nРекомендуется использовать архивирование вместо удаления.`
@@ -441,7 +479,7 @@ async function deleteStore(storeId) {
     if (!confirmed) return;
 
     try {
-        const response = await fetch(`/api/v1/stores/${storeId}`, {
+        const response = await fetch(`/api/v1/stores/${storeIdInt}`, {
             method: 'DELETE',
             credentials: 'include',
         });

--- a/frontend/web/templates/components/macros/delete_buttons.html
+++ b/frontend/web/templates/components/macros/delete_buttons.html
@@ -106,11 +106,10 @@
 #}
 {% macro delete_button_mobile(onclick_handler, title='Удалить', extra_classes='') %}
 <button type="button"
-        class="btn btn-sm sm:btn-md btn-error btn-square md:hidden block {{ extra_classes }}"
+        class="btn btn-sm sm:btn-md btn-error btn-square md:hidden {{ extra_classes }}"
         onclick="{{ onclick_handler }}"
         title="{{ title }}"
-        aria-label="{{ title }}"
-        style="display: block !important;">
+        aria-label="{{ title }}">
     {{ delete_icon_svg('h-5 w-5') }}
 </button>
 {% endmacro %}


### PR DESCRIPTION
Fixes 6 bugs on admin pages based on investigation in docs/explore/admin-pages-investigation.md

## Fixed Issues

### Critical Bugs
- **Backend**: financial_center_ids AttributeError in Article update endpoint
- **Frontend**: deleteStore/deleteProductGroup undefined errors (type mismatch + null check)

### UX Improvements
- Modal closes AFTER delete completes (with loading indicator overlay)
- User cannot interact with form during deletion

### UI Polish
- Delete button alignment (flex-1 without md:hidden)
- Trash icon centering (removed display:block override)

## Testing

### Backend
```bash
cd backend
.venv/bin/pytest tests/api/test_articles.py -v
```

### Frontend
- Manual testing on https://fbd.ikeniborn.ru
- E2E testing via @skill:test-code

## Commits
- fix(backend): extract financial_center_ids before has_changes
- fix(frontend): normalize IDs and add null checks in delete functions
- fix(ui): center trash icon in delete button
