### PR TITLE
Fix admin pages bugs (6 issues)

### DIFF
--- a/backend/app/api/v1/endpoints/articles.py
+++ b/backend/app/api/v1/endpoints/articles.py
@@ -482,7 +482,7 @@ async def update_article(
     logger = logging.getLogger(__name__)
     logger.info(f"[ARTICLE UPDATE] article_id={article_id}, changed={changed}, changed_fields={changed_fields}, update_data={update_data}")
 
-    if not changed:
+    if not changed and financial_center_ids is None:
         # No changes, return existing article
         logger.info("[ARTICLE UPDATE] No changes detected, returning old article")
         return old_article

--- a/backend/app/api/v1/endpoints/articles.py
+++ b/backend/app/api/v1/endpoints/articles.py
@@ -430,7 +430,12 @@ async def update_article(
 
     # Validate: At least one field provided
     update_data = article_data.model_dump(exclude_unset=True)
-    if not update_data:
+
+    # Извлечь financial_center_ids ДО проверки изменений
+    financial_center_ids = update_data.pop('financial_center_ids', None)
+    logger.info(f"[UPDATE_ARTICLE] Extracted financial_center_ids: {financial_center_ids}")
+
+    if not update_data and financial_center_ids is None:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="At least one field must be provided for update"
@@ -526,15 +531,44 @@ async def update_article(
             change_type="UPDATE",
         )
         logger.info(f"[ARTICLE UPDATE] Updated article (SCD1+History): id={article_id}")
-        # Invalidate articles cache
-        await cache_service.invalidate_articles()
-        return updated_article
+        result_article = updated_article
     else:
         # Only is_active was changed, return updated article (no history record needed - already done by archive/restore)
         logger.info("[ARTICLE UPDATE] Only is_active changed, returning updated article")
-        # Invalidate articles cache (is_active change affects listing)
-        await cache_service.invalidate_articles()
-        return old_article
+        result_article = old_article
+
+    # Обработка financial_center_ids (Many-to-Many связь)
+    if financial_center_ids is not None:
+        from sqlalchemy import delete
+        from backend.app.models.article_financial_center import ArticleFinancialCenter
+
+        logger.info(f"[UPDATE_ARTICLE] Updating financial center links for article_id={article_id}")
+
+        # Удалить существующие связи
+        delete_stmt = delete(ArticleFinancialCenter).where(
+            ArticleFinancialCenter.article_id == article_id
+        )
+        await session.execute(delete_stmt)
+        logger.info(f"[UPDATE_ARTICLE] Deleted existing FC links")
+
+        # Вставить новые связи (если список не пустой)
+        if financial_center_ids:
+            for fc_id in financial_center_ids:
+                link = ArticleFinancialCenter(
+                    article_id=article_id,
+                    financial_center_id=fc_id
+                )
+                session.add(link)
+            logger.info(f"[UPDATE_ARTICLE] Created {len(financial_center_ids)} new FC links")
+        else:
+            logger.info("[UPDATE_ARTICLE] Cleared all FC links (available for all FCs)")
+
+        await session.commit()
+        await session.refresh(result_article)
+
+    # Invalidate cache ПОСЛЕ обновления M2M связей
+    await cache_service.invalidate_articles()
+    return result_article
 
 
 @router.delete(

--- a/frontend/web/templates/admin_articles.html
+++ b/frontend/web/templates/admin_articles.html
@@ -171,7 +171,7 @@
                 <!-- Кнопка удаления - только иконка, видна только на мобильных (где нет чекбоксов) -->
                 {{ delete_button_mobile('deleteArticleFromEditModal()') }}
                 <!-- Разделитель (пустое пространство) -->
-                <div class="flex-1 md:hidden"></div>
+                <div class="flex-1"></div>
                 <button type="button" class="btn btn-sm sm:btn-md flex-1 sm:flex-initial" onclick="closeEditModal()">❌ Отмена</button>
                 <button type="submit" class="btn btn-sm sm:btn-md btn-primary flex-1 sm:flex-initial">💾 Сохранить</button>
             </div>
@@ -753,10 +753,36 @@ function closeEditModal() {
 }
 
 // Delete article from edit modal (mobile only)
-function deleteArticleFromEditModal() {
+async function deleteArticleFromEditModal() {
     const articleId = document.getElementById('edit-id').value;
-    closeEditModal();
-    deactivateArticle(articleId);
+    const modal = document.getElementById('edit-modal');
+
+    // ✅ Создать overlay loader
+    const overlay = document.createElement('div');
+    overlay.className = 'absolute inset-0 bg-base-300/80 flex items-center justify-center z-50 rounded-lg';
+    overlay.innerHTML = `
+        <div class="flex flex-col items-center gap-4">
+            <span class="loading loading-spinner loading-lg text-primary"></span>
+            <p class="text-lg font-semibold">Удаление категории...</p>
+        </div>
+    `;
+
+    // Добавить overlay к модальному окну
+    const modalBox = modal.querySelector('.modal-box');
+    modalBox.style.position = 'relative';
+    modalBox.appendChild(overlay);
+
+    try {
+        // ✅ Ждем завершения удаления
+        await deactivateArticle(articleId);
+
+        // ✅ Закрываем модальное окно ПОСЛЕ успешного удаления
+        closeEditModal();
+    } catch (error) {
+        // Ошибка уже обработана в deactivateArticle()
+        // Убрать overlay
+        overlay.remove();
+    }
 }
 
 // Update article

--- a/frontend/web/templates/admin_cost_centers.html
+++ b/frontend/web/templates/admin_cost_centers.html
@@ -115,7 +115,7 @@
                 <!-- Кнопка удаления - только иконка, видна только на мобильных (где нет чекбоксов) -->
                 {{ delete_button_mobile('deleteCenterFromEditModal()') }}
                 <!-- Разделитель (пустое пространство) -->
-                <div class="flex-1 md:hidden"></div>
+                <div class="flex-1"></div>
                 <button type="button" class="btn btn-sm sm:btn-md flex-1 sm:flex-initial" onclick="closeEditModal()">❌ Отмена</button>
                 <button type="submit" class="btn btn-sm sm:btn-md btn-primary flex-1 sm:flex-initial">💾 Сохранить</button>
             </div>
@@ -392,10 +392,36 @@ function closeEditModal() {
 }
 
 // Delete center from edit modal (mobile only)
-function deleteCenterFromEditModal() {
+async function deleteCenterFromEditModal() {
     const centerId = document.getElementById('edit-id').value;
-    closeEditModal();
-    deleteCenter(centerId);
+    const modal = document.getElementById('edit-modal');
+
+    // ✅ Создать overlay loader
+    const overlay = document.createElement('div');
+    overlay.className = 'absolute inset-0 bg-base-300/80 flex items-center justify-center z-50 rounded-lg';
+    overlay.innerHTML = `
+        <div class="flex flex-col items-center gap-4">
+            <span class="loading loading-spinner loading-lg text-primary"></span>
+            <p class="text-lg font-semibold">Удаление МЗ...</p>
+        </div>
+    `;
+
+    // Добавить overlay к модальному окну
+    const modalBox = modal.querySelector('.modal-box');
+    modalBox.style.position = 'relative';
+    modalBox.appendChild(overlay);
+
+    try {
+        // ✅ Ждем завершения удаления
+        await deleteCenter(centerId);
+
+        // ✅ Закрываем модальное окно ПОСЛЕ успешного удаления
+        closeEditModal();
+    } catch (error) {
+        // Ошибка уже обработана в deleteCenter()
+        // Убрать overlay
+        overlay.remove();
+    }
 }
 
 // Update cost center

--- a/frontend/web/templates/admin_financial_centers.html
+++ b/frontend/web/templates/admin_financial_centers.html
@@ -93,7 +93,7 @@
                 <!-- Кнопка удаления - только иконка, видна только на мобильных (где нет чекбоксов) -->
                 {{ delete_button_mobile('deleteCenterFromEditModal()') }}
                 <!-- Разделитель (пустое пространство) -->
-                <div class="flex-1 md:hidden"></div>
+                <div class="flex-1"></div>
                 <button type="button" class="btn btn-sm sm:btn-md flex-1 sm:flex-initial" onclick="closeEditModal()">❌ Отмена</button>
                 <button type="submit" class="btn btn-sm sm:btn-md btn-primary flex-1 sm:flex-initial">💾 Сохранить</button>
             </div>
@@ -309,10 +309,36 @@ function closeEditModal() {
 }
 
 // Delete center from edit modal (mobile only)
-function deleteCenterFromEditModal() {
+async function deleteCenterFromEditModal() {
     const centerId = document.getElementById('edit-id').value;
-    closeEditModal();
-    deleteCenter(centerId);
+    const modal = document.getElementById('edit-modal');
+
+    // ✅ Создать overlay loader
+    const overlay = document.createElement('div');
+    overlay.className = 'absolute inset-0 bg-base-300/80 flex items-center justify-center z-50 rounded-lg';
+    overlay.innerHTML = `
+        <div class="flex flex-col items-center gap-4">
+            <span class="loading loading-spinner loading-lg text-primary"></span>
+            <p class="text-lg font-semibold">Удаление счета...</p>
+        </div>
+    `;
+
+    // Добавить overlay к модальному окну
+    const modalBox = modal.querySelector('.modal-box');
+    modalBox.style.position = 'relative';
+    modalBox.appendChild(overlay);
+
+    try {
+        // ✅ Ждем завершения удаления
+        await deleteCenter(centerId);
+
+        // ✅ Закрываем модальное окно ПОСЛЕ успешного удаления
+        closeEditModal();
+    } catch (error) {
+        // Ошибка уже обработана в deleteCenter()
+        // Убрать overlay
+        overlay.remove();
+    }
 }
 
 // Update financial center

--- a/frontend/web/templates/admin_product_groups.html
+++ b/frontend/web/templates/admin_product_groups.html
@@ -115,7 +115,7 @@
                 <!-- Кнопка удаления - только иконка, видна только на мобильных (где нет чекбоксов) -->
                 {{ delete_button_mobile('deleteProductGroupFromEditModal()') }}
                 <!-- Разделитель (пустое пространство) -->
-                <div class="flex-1 md:hidden"></div>
+                <div class="flex-1"></div>
                 <button type="button" class="btn btn-sm sm:btn-md flex-1 sm:flex-initial" onclick="closeEditModal()">❌ Отмена</button>
                 <button type="submit" class="btn btn-sm sm:btn-md btn-primary flex-1 sm:flex-initial">💾 Сохранить</button>
             </div>
@@ -435,10 +435,36 @@ function closeEditModal() {
 }
 
 // Delete product group from edit modal (mobile only)
-function deleteProductGroupFromEditModal() {
+async function deleteProductGroupFromEditModal() {
     const productGroupId = document.getElementById('edit-id').value;
-    closeEditModal();
-    deleteProductGroup(productGroupId);
+    const modal = document.getElementById('edit-modal');
+
+    // ✅ Создать overlay loader
+    const overlay = document.createElement('div');
+    overlay.className = 'absolute inset-0 bg-base-300/80 flex items-center justify-center z-50 rounded-lg';
+    overlay.innerHTML = `
+        <div class="flex flex-col items-center gap-4">
+            <span class="loading loading-spinner loading-lg text-primary"></span>
+            <p class="text-lg font-semibold">Удаление группы товаров...</p>
+        </div>
+    `;
+
+    // Добавить overlay к модальному окну
+    const modalBox = modal.querySelector('.modal-box');
+    modalBox.style.position = 'relative';
+    modalBox.appendChild(overlay);
+
+    try {
+        // ✅ Ждем завершения удаления
+        await deleteProductGroup(productGroupId);
+
+        // ✅ Закрываем модальное окно ПОСЛЕ успешного удаления
+        closeEditModal();
+    } catch (error) {
+        // Ошибка уже обработана в deleteProductGroup()
+        // Убрать overlay
+        overlay.remove();
+    }
 }
 
 // Update product group
@@ -535,7 +561,19 @@ async function restoreProductGroup(groupId) {
 
 // Delete product group
 async function deleteProductGroup(groupId) {
-    const group = productGroupsData.find(g => g.id === groupId);
+    // ✅ Нормализуем ID к integer для корректного сравнения
+    const groupIdInt = typeof groupId === 'string' ? parseInt(groupId, 10) : groupId;
+
+    // ✅ Поиск с нормализованным ID
+    const group = productGroupsData.find(g => g.id === groupIdInt);
+
+    // ✅ Проверка на undefined ПЕРЕД использованием
+    if (!group) {
+        console.error(`Product group with ID ${groupId} not found in productGroupsData`);
+        showToast('❌ Группа товаров не найдена', 'error');
+        return;
+    }
+
     const confirmed = await showConfirmDialog(
         'Удалить группу товаров?',
         `⚠️ ВНИМАНИЕ: Вы уверены, что хотите УДАЛИТЬ "${group.name}"?\n\nЭто действие НЕОБРАТИМО и удалит все связанные данные:\n• Все дочерние группы\n• Все товары в списках покупок для этой группы\n\nРекомендуется использовать архивирование вместо удаления.`
@@ -544,7 +582,7 @@ async function deleteProductGroup(groupId) {
     if (!confirmed) return;
 
     try {
-        const response = await fetch(`/api/v1/product-groups/${groupId}`, {
+        const response = await fetch(`/api/v1/product-groups/${groupIdInt}`, {
             method: 'DELETE',
             credentials: 'include',
         });

--- a/frontend/web/templates/admin_product_groups.html
+++ b/frontend/web/templates/admin_product_groups.html
@@ -571,7 +571,7 @@ async function deleteProductGroup(groupId) {
     if (!group) {
         console.error(`Product group with ID ${groupId} not found in productGroupsData`);
         showToast('❌ Группа товаров не найдена', 'error');
-        return;
+        throw new Error(`Product group with ID ${groupId} not found`);
     }
 
     const confirmed = await showConfirmDialog(

--- a/frontend/web/templates/admin_stores.html
+++ b/frontend/web/templates/admin_stores.html
@@ -99,7 +99,7 @@
                 <!-- Кнопка удаления - только иконка, видна только на мобильных (где нет чекбоксов) -->
                 {{ delete_button_mobile('deleteStoreFromEditModal()') }}
                 <!-- Разделитель (пустое пространство) -->
-                <div class="flex-1 md:hidden"></div>
+                <div class="flex-1"></div>
                 <button type="button" class="btn btn-sm sm:btn-md flex-1 sm:flex-initial" onclick="closeEditModal()">❌ Отмена</button>
                 <button type="submit" class="btn btn-sm sm:btn-md btn-primary flex-1 sm:flex-initial">💾 Сохранить</button>
             </div>
@@ -332,10 +332,36 @@ function closeEditModal() {
 }
 
 // Delete store from edit modal (mobile only)
-function deleteStoreFromEditModal() {
+async function deleteStoreFromEditModal() {
     const storeId = document.getElementById('edit-id').value;
-    closeEditModal();
-    deleteStore(storeId);
+    const modal = document.getElementById('edit-modal');
+
+    // ✅ Создать overlay loader
+    const overlay = document.createElement('div');
+    overlay.className = 'absolute inset-0 bg-base-300/80 flex items-center justify-center z-50 rounded-lg';
+    overlay.innerHTML = `
+        <div class="flex flex-col items-center gap-4">
+            <span class="loading loading-spinner loading-lg text-primary"></span>
+            <p class="text-lg font-semibold">Удаление магазина...</p>
+        </div>
+    `;
+
+    // Добавить overlay к модальному окну
+    const modalBox = modal.querySelector('.modal-box');
+    modalBox.style.position = 'relative';
+    modalBox.appendChild(overlay);
+
+    try {
+        // ✅ Ждем завершения удаления
+        await deleteStore(storeId);
+
+        // ✅ Закрываем модальное окно ПОСЛЕ успешного удаления
+        closeEditModal();
+    } catch (error) {
+        // Ошибка уже обработана в deleteStore()
+        // Убрать overlay
+        overlay.remove();
+    }
 }
 
 // Update store
@@ -432,7 +458,19 @@ async function restoreStore(storeId) {
 
 // Delete store
 async function deleteStore(storeId) {
-    const store = storesData.find(s => s.id === storeId);
+    // ✅ Нормализуем ID к integer для корректного сравнения
+    const storeIdInt = typeof storeId === 'string' ? parseInt(storeId, 10) : storeId;
+
+    // ✅ Поиск с нормализованным ID
+    const store = storesData.find(s => s.id === storeIdInt);
+
+    // ✅ Проверка на undefined ПЕРЕД использованием
+    if (!store) {
+        console.error(`Store with ID ${storeId} not found in storesData`);
+        showToast('❌ Магазин не найден', 'error');
+        return;
+    }
+
     const confirmed = await showConfirmDialog(
         'Удалить магазин?',
         `⚠️ ВНИМАНИЕ: Вы уверены, что хотите УДАЛИТЬ "${store.name}"?\n\nЭто действие НЕОБРАТИМО и удалит все связанные данные:\n• Все товары в списках покупок для этого магазина\n\nРекомендуется использовать архивирование вместо удаления.`
@@ -441,7 +479,7 @@ async function deleteStore(storeId) {
     if (!confirmed) return;
 
     try {
-        const response = await fetch(`/api/v1/stores/${storeId}`, {
+        const response = await fetch(`/api/v1/stores/${storeIdInt}`, {
             method: 'DELETE',
             credentials: 'include',
         });

--- a/frontend/web/templates/admin_stores.html
+++ b/frontend/web/templates/admin_stores.html
@@ -468,7 +468,7 @@ async function deleteStore(storeId) {
     if (!store) {
         console.error(`Store with ID ${storeId} not found in storesData`);
         showToast('❌ Магазин не найден', 'error');
-        return;
+        throw new Error(`Store with ID ${storeId} not found`);
     }
 
     const confirmed = await showConfirmDialog(

--- a/frontend/web/templates/components/macros/delete_buttons.html
+++ b/frontend/web/templates/components/macros/delete_buttons.html
@@ -106,11 +106,10 @@
 #}
 {% macro delete_button_mobile(onclick_handler, title='Удалить', extra_classes='') %}
 <button type="button"
-        class="btn btn-sm sm:btn-md btn-error btn-square md:hidden block {{ extra_classes }}"
+        class="btn btn-sm sm:btn-md btn-error btn-square md:hidden {{ extra_classes }}"
         onclick="{{ onclick_handler }}"
         title="{{ title }}"
-        aria-label="{{ title }}"
-        style="display: block !important;">
+        aria-label="{{ title }}">
     {{ delete_icon_svg('h-5 w-5') }}
 </button>
 {% endmacro %}


### PR DESCRIPTION
Fixes 6 bugs on admin pages based on investigation in docs/explore/admin-pages-investigation.md

**Critical bugs:**
- Backend: financial_center_ids AttributeError
- Frontend: deleteStore/deleteProductGroup undefined errors

**UX improvements:**
- Modal closes after delete completes (with loading indicator)

**UI polish:**
- Delete button alignment
- Trash icon centering

**Testing:**
- Backend: pytest tests/api/test_articles.py
- Frontend: Manual testing + E2E via @skill:test-code

**Commits:**
1. fix(backend): extract financial_center_ids before has_changes
2. fix(frontend): normalize IDs and add null checks in delete functions
3. fix(frontend): async modal close with overlay loader
4. fix(ui): align delete button and center trash icon