### PR TITLE
fix(lists+plan): broadcast list stats on item changes; fix plan modal ID mismatch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -352,3 +352,6 @@ backend/.env.test
 .claude/sessions/
 # Claude Code Agent Workspace
 .claude/workspace
+
+# Claude Code Agent Workspace
+.claude/workspace/

--- a/backend/app/api/v1/endpoints/shopping_list_items.py
+++ b/backend/app/api/v1/endpoints/shopping_list_items.py
@@ -28,6 +28,7 @@ from sqlmodel import select
 from backend.app.core.dependencies import get_current_user, get_session
 from backend.app.models import User
 from backend.app.models.product_group import ProductGroup
+from backend.app.models.shopping_list import ShoppingList
 from backend.app.models.shopping_list_item import ShoppingListItem
 from backend.app.models.store import Store
 from backend.app.schemas.errors import get_common_responses
@@ -62,6 +63,79 @@ def _get_ws_broadcast():
         from backend.app.api.v1.endpoints import budget_ws
         _ws_module = budget_ws
     return _ws_module
+
+
+async def _broadcast_list_stats_update(session: AsyncSession, shopping_list_id: int) -> None:
+    """
+    Broadcast shopping_list_updated event with updated item stats.
+
+    Called after item create/update/delete to notify all connected clients
+    that the parent shopping list's stats (total_items, completed_items) have changed.
+    This enables real-time stats refresh on landing page cards for other devices.
+
+    Args:
+        session: AsyncSession for database operations
+        shopping_list_id: Parent shopping list ID to compute stats for
+    """
+    try:
+        # Fetch the shopping list record
+        list_result = await session.execute(
+            select(ShoppingList).where(ShoppingList.id == shopping_list_id)
+        )
+        shopping_list = list_result.scalar_one_or_none()
+        if not shopping_list:
+            logger.warning(
+                f"[LIST_STATS] Shopping list {shopping_list_id} not found for stats broadcast"
+            )
+            return
+
+        # Count total and completed items (exclude soft-deleted)
+        total_result = await session.execute(
+            select(func.count()).where(
+                ShoppingListItem.shopping_list_id == shopping_list_id,
+                ShoppingListItem.deleted_at.is_(None),
+            )
+        )
+        total_items = total_result.scalar_one()
+
+        completed_result = await session.execute(
+            select(func.count()).where(
+                ShoppingListItem.shopping_list_id == shopping_list_id,
+                ShoppingListItem.is_completed == True,  # noqa: E712
+                ShoppingListItem.deleted_at.is_(None),
+            )
+        )
+        completed_items = completed_result.scalar_one()
+
+        completion_percentage = round(
+            (completed_items / total_items * 100) if total_items > 0 else 0.0, 1
+        )
+
+        # Build broadcast payload (matches SAFE_SHOPPING_LIST_FIELDS)
+        list_data = {
+            "id": shopping_list.id,
+            "name": shopping_list.name,
+            "description": shopping_list.description,
+            "creator_id": shopping_list.creator_id,
+            "is_active": shopping_list.is_active,
+            "total_items": total_items,
+            "completed_items": completed_items,
+            "completion_percentage": completion_percentage,
+            "created_at": shopping_list.created_at.isoformat() if shopping_list.created_at else None,
+            "updated_at": shopping_list.updated_at.isoformat() if shopping_list.updated_at else None,
+        }
+
+        ws = _get_ws_broadcast()
+        await ws.broadcast_shopping_list_updated(list_data)
+        logger.debug(
+            f"[LIST_STATS] Broadcast shopping_list_updated: list_id={shopping_list_id}, "
+            f"total={total_items}, completed={completed_items}"
+        )
+    except Exception as e:
+        # Non-critical: item operation already succeeded, only stats broadcast failed
+        logger.warning(
+            f"[LIST_STATS] Failed to broadcast shopping_list_updated for list {shopping_list_id}: {e}"
+        )
 
 
 router = APIRouter(
@@ -240,6 +314,9 @@ async def create_shopping_list_item(
         await ws.broadcast_item_created(item_data=response.model_dump(mode="json"))
     except Exception as e:
         logger.warning(f"WebSocket broadcast failed for created item {item.id}: {e}")
+
+    # Broadcast updated shopping list stats to refresh landing page cards on all devices
+    await _broadcast_list_stats_update(session, item.shopping_list_id)
 
     return response
 
@@ -662,6 +739,11 @@ async def update_shopping_list_item(
     except Exception as e:
         logger.warning(f"WebSocket broadcast failed for updated item {item_id}: {e}")
 
+    # Broadcast updated shopping list stats when completion status changes
+    # (completed_items count changes → landing page cards need refresh)
+    if update_data.is_completed is not None:
+        await _broadcast_list_stats_update(session, item.shopping_list_id)
+
     return response
 
 
@@ -723,6 +805,9 @@ async def delete_shopping_list_item(
         await ws.broadcast_item_deleted(item_id=item_id, shopping_list_id=list_id)
     except Exception as e:
         logger.warning(f"WebSocket broadcast failed for deleted item {item_id}: {e}")
+
+    # Broadcast updated shopping list stats to refresh landing page cards on all devices
+    await _broadcast_list_stats_update(session, list_id)
 
     return None  # 204 No Content
 
@@ -860,6 +945,10 @@ async def batch_complete_items(
     except Exception as e:
         logger.warning(f"WebSocket broadcast failed for batch complete: {e}")
 
+    # Broadcast updated shopping list stats for all affected lists
+    for list_id in items_by_list.keys():
+        await _broadcast_list_stats_update(session, list_id)
+
     return {
         "message": f"Marked {count} items as {'completed' if request.is_completed else 'incomplete'}",
         "count": count,
@@ -935,6 +1024,10 @@ async def batch_delete_items(
                 await ws.broadcast_item_deleted(item_id=item_id, shopping_list_id=list_id)
     except Exception as e:
         logger.warning(f"WebSocket broadcast failed for batch delete: {e}")
+
+    # Broadcast updated shopping list stats for all affected lists
+    for list_id in items_by_list.keys():
+        await _broadcast_list_stats_update(session, list_id)
 
     return {"message": f"Deleted {count} items", "count": count}
 

--- a/frontend/web/static/js/budget/budgetWSClient/integration/eventHandlers.ts
+++ b/frontend/web/static/js/budget/budgetWSClient/integration/eventHandlers.ts
@@ -155,7 +155,12 @@ export function handleShoppingListUpdated(data: ShoppingListUpdatedEvent): void 
   debugLog('[WS] Shopping list updated:', data);
   notifyHandlers('shopping_list_updated', data);
 
-  if ((window as any).listsManager?.refreshDashboard) {
+  // Use efficient in-state stats update (no API reload) when available
+  // This updates total_items/completed_items/completion_percentage in landing page cards
+  if ((window as any).listsManager?.handleShoppingListUpdated) {
+    (window as any).listsManager.handleShoppingListUpdated(data);
+  } else if ((window as any).listsManager?.refreshDashboard) {
+    // Fallback: full API reload (older implementation)
     (window as any).listsManager.refreshDashboard('updated', data);
   }
 }

--- a/frontend/web/static/js/lists-bundle.ts
+++ b/frontend/web/static/js/lists-bundle.ts
@@ -80,7 +80,8 @@ import {
   // WebSocket handlers (v7.0.1 - for budgetWSClient compatibility)
   handleItemCreated,
   handleItemUpdated,
-  handleItemDeleted
+  handleItemDeleted,
+  handleShoppingListUpdated
 } from './lists/listsManager/index';
 
 // Адаптеры с confirm dialogs
@@ -255,7 +256,7 @@ try {
 
     // Create window.listsManager object for backward compatibility
     // (used in onclick handlers: window.listsManager.showDetailView, toggleItemCompleted)
-    // (used by budgetWSClient: addItemToUI, updateItemInUI, removeItemFromUI)
+    // (used by budgetWSClient: addItemToUI, updateItemInUI, removeItemFromUI, handleShoppingListUpdated)
     Object.defineProperty(window, 'listsManager', {
       value: {
         showDetailView: renderDetailView,
@@ -264,7 +265,9 @@ try {
         // WebSocket compatibility aliases (v7.0.1)
         addItemToUI: handleItemCreated,
         updateItemInUI: handleItemUpdated,
-        removeItemFromUI: handleItemDeleted
+        removeItemFromUI: handleItemDeleted,
+        // Shopping list update handler (v11.5.x - stats refresh on item add/delete)
+        handleShoppingListUpdated
       },
       writable: false,
       configurable: false,

--- a/frontend/web/static/js/lists/listsManager/index.ts
+++ b/frontend/web/static/js/lists/listsManager/index.ts
@@ -140,6 +140,7 @@ export {
   handleItemUpdated,
   handleItemDeleted,
   handleItemCompletedToggled,
+  handleShoppingListUpdated,
   handleShoppingListDeleted
 } from './integration/wsEventHandlers';
 

--- a/frontend/web/static/js/lists/listsManager/integration/wsEventHandlers.ts
+++ b/frontend/web/static/js/lists/listsManager/integration/wsEventHandlers.ts
@@ -215,6 +215,63 @@ export function handleItemCompletedToggled(itemId: number, isCompleted: boolean,
 }
 
 /**
+ * Handle shopping list updated event from WebSocket
+ *
+ * Updates item stats (total_items, completed_items, completion_percentage) in global state
+ * and re-renders landing page cards if currently on the landing view.
+ *
+ * Called when: items are added/deleted/completed on another device (after Phase 1 backend fix)
+ *
+ * @param shoppingListData - Updated shopping list data from server (includes stats)
+ */
+export function handleShoppingListUpdated(shoppingListData: any): void {
+  if (!shoppingListData || !shoppingListData.id) {
+    debugLog('[ListsManager] Invalid data for handleShoppingListUpdated');
+    return;
+  }
+
+  const state = getState();
+
+  // Find the list in current state
+  const listIndex = state.shoppingLists.findIndex(list => list.id === shoppingListData.id);
+  if (listIndex === -1) {
+    debugLog('[ListsManager] Shopping list not found in state for update:', shoppingListData.id);
+    // List not in state - trigger full reload on landing view
+    const landingView = document.getElementById('landing-view');
+    if (landingView && !landingView.classList.contains('hidden')) {
+      renderShoppingListCards();
+    }
+    return;
+  }
+
+  // Update stats in state (merge new stats into existing list entry)
+  const updatedList = {
+    ...state.shoppingLists[listIndex],
+    ...(shoppingListData.total_items !== undefined && { total_items: shoppingListData.total_items }),
+    ...(shoppingListData.completed_items !== undefined && { completed_items: shoppingListData.completed_items }),
+    ...(shoppingListData.completion_percentage !== undefined && { completion_percentage: shoppingListData.completion_percentage }),
+    ...(shoppingListData.name !== undefined && { name: shoppingListData.name }),
+  };
+
+  const newLists = [...state.shoppingLists];
+  newLists[listIndex] = updatedList;
+  updateState({ shoppingLists: newLists });
+
+  debugLog('[ListsManager] Updated shopping list stats from WebSocket:', {
+    id: shoppingListData.id,
+    total_items: shoppingListData.total_items,
+    completed_items: shoppingListData.completed_items,
+  });
+
+  // Re-render landing page cards if on landing view
+  const landingView = document.getElementById('landing-view');
+  if (landingView && !landingView.classList.contains('hidden')) {
+    renderShoppingListCards();
+    debugLog('[ListsManager] Re-rendered landing page cards with updated stats');
+  }
+}
+
+/**
  * Handle shopping list deleted event from WebSocket
  *
  * Removes shopping list from global state and triggers UI reload

--- a/frontend/web/static/js/modules/uiComponents/modals/DexieDiagnosticModal.ts
+++ b/frontend/web/static/js/modules/uiComponents/modals/DexieDiagnosticModal.ts
@@ -397,8 +397,8 @@ export class DexieDiagnosticModal extends BaseModal {
               <td>${data.tableStats.facts} <span class="text-xs opacity-60">(${data.syncPeriod.facts} days)</span></td>
             </tr>
             <tr>
-              <td>Plans</td>
-              <td>${data.tableStats.plans} <span class="text-xs opacity-60">(−${data.syncPeriod.plansHistory} / +${data.syncPeriod.plansFuture} months)</span></td>
+              <td>Plans <span class="text-xs opacity-60">(cached)</span></td>
+              <td>${data.tableStats.plans} <span class="text-xs opacity-60">(−${data.syncPeriod.plansHistory} / +${data.syncPeriod.plansFuture} months window)</span></td>
             </tr>
             <tr><td>Stores</td><td>${data.tableStats.stores}</td></tr>
             <tr><td>Product Groups</td><td>${data.tableStats.productGroups}</td></tr>

--- a/frontend/web/templates/plan.html
+++ b/frontend/web/templates/plan.html
@@ -121,7 +121,7 @@
 </div>
 
 <!-- v9.0 Tabbed Modals -->
-{{ modal_plan('modal_plan') }}
+{{ modal_plan('modal_add_plan') }}
 
 <!-- Edit Plan Modal -->
 {{ edit_plan_modal('edit-modal') }}
@@ -1199,10 +1199,15 @@ document.addEventListener('DOMContentLoaded', function() {
     deferredInit(() => initializeReminderTimeInputs(modalId));
 
     // Обработчик отправки формы создания плана
-    document.getElementById('form_modal_add_plan').addEventListener('submit', async function(e) {
-        e.preventDefault();
-        await createPlan(e);
-    });
+    const addPlanForm = document.getElementById('form_modal_add_plan');
+    if (addPlanForm) {
+        addPlanForm.addEventListener('submit', async function(e) {
+            e.preventDefault();
+            await createPlan(e);
+        });
+    } else {
+        console.warn('[plan.html] form_modal_add_plan not found in DOM');
+    }
 
     // Transfer form submit handler (online only)
     // CRITICAL: Guard against duplicate event listener registration


### PR DESCRIPTION
## Summary

- **Bug 1+2 (/lists - Shopping Lists)**: Backend `shopping_list_items.py` was not broadcasting `shopping_list_updated` events after item mutations. Added `_broadcast_list_stats_update()` helper that computes fresh `total_items`/`completed_items`/`completion_percentage` and broadcasts via WebSocket. Frontend `wsEventHandlers.ts` now has `handleShoppingListUpdated()` that merges stats into state and re-renders landing page cards without an API round-trip.
- **Bug 3 (/plan - Modal JS Errors)**: `plan.html` was calling `modal_plan('modal_plan')` making HTML element ID=`modal_plan`, while all JS code queries `modal_add_plan`. Fixed macro call and added null guard on `addEventListener` to prevent `TypeError`.
- **Bug 4 (Dexie Diagnostics label)**: Clarified Plans count label to show `(cached)` with `(N months window)` — not a bug, just label ambiguity causing user confusion.

## Root Causes

| # | Page | Root Cause | Fix |
|---|------|-----------|-----|
| 1 | /lists | Backend item endpoints never called `broadcast_shopping_list_updated` | Added `_broadcast_list_stats_update()` to 5 endpoints |
| 2 | /lists | Frontend `handleShoppingListUpdated` missing from `window.listsManager` | Added to `wsEventHandlers.ts` + exported via `lists-bundle.ts` |
| 3 | /plan | `modal_plan('modal_plan')` gave wrong ID; no null guard on `addEventListener` | Fixed macro arg + added null check |
| 4 | /plan | Dexie shows ±3 month window count, filter uses API total — label ambiguous | Updated label to say "cached" + "months window" |

## Files Changed

- `backend/app/api/v1/endpoints/shopping_list_items.py` — Added `_broadcast_list_stats_update()` helper + calls after item create/update/delete/batch operations
- `frontend/web/static/js/lists/listsManager/integration/wsEventHandlers.ts` — Added `handleShoppingListUpdated()` for in-state stats merge + card re-render
- `frontend/web/static/js/lists/listsManager/index.ts` — Exported `handleShoppingListUpdated`
- `frontend/web/static/js/lists-bundle.ts` — Added to imports + `window.listsManager`
- `frontend/web/static/js/budget/budgetWSClient/integration/eventHandlers.ts` — Use efficient in-state path (no API reload) with fallback
- `frontend/web/templates/plan.html` — Fixed `modal_plan('modal_add_plan')` + null guard
- `frontend/web/static/js/modules/uiComponents/modals/DexieDiagnosticModal.ts` — Clarified Plans label

## Test plan

- [ ] Open `/lists` on Device A and Device B
- [ ] Create a new shopping list on Device A — verify it appears on Device B landing page
- [ ] Add items to a list on Device A — verify `total_items` counter updates on Device B landing page cards (without page refresh)
- [ ] Mark items complete on Device A — verify `completed_items` and `completion_percentage` update on Device B
- [ ] Open `/plan` — verify no JS errors in console (`Reminder inputs not found`, `addEventListener TypeError`, `Create modal select not found`)
- [ ] Open add plan modal on `/plan` — verify modal renders correctly with all fields
- [ ] Check Dexie Diagnostics on `/plan` — verify Plans row shows `(cached)` label and `(N months window)` suffix

🤖 Generated with [Claude Code](https://claude.com/claude-code)