### PR TITLE
fix(ci): use TEST_POSTGRES_PASSWORD secret instead of reading /opt/budget/.env

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1088,6 +1088,8 @@ jobs:
       # ============================================================================
       - name: Run backend tests on test server
         if: matrix.test-suite == 'backend'
+        env:
+          POSTGRES_PASSWORD: ${{ secrets.TEST_POSTGRES_PASSWORD }}
         run: |
           ssh budget-test "bash -s" << 'EOF'
             set -e
@@ -1097,19 +1099,17 @@ jobs:
             git fetch origin
             git checkout ${{ github.sha }}
 
-            # Load all secrets from test server .env
-            set -a && source /opt/budget/.env && set +a
-
             # Build DATABASE_URL with localhost (tests run on host, not inside Docker network)
-            export DATABASE_URL="postgresql+asyncpg://${POSTGRES_USER:-familybudget}:${POSTGRES_PASSWORD}@localhost:5432/${POSTGRES_DB:-familybudget}"
+            # POSTGRES_PASSWORD is passed via SSH from GitHub secret TEST_POSTGRES_PASSWORD
+            # to avoid requiring read access to /opt/budget/.env on the server
+            export DATABASE_URL="postgresql+asyncpg://familybudget:${{ secrets.TEST_POSTGRES_PASSWORD }}@localhost:5432/familybudget"
 
             # Apply migrations (idempotent — deployment already ran them)
             backend/.venv/bin/alembic -c backend/db/migrations/alembic.ini upgrade head
 
             # Run pytest using test server's existing database
-            # Tests use rollback isolation — no data is permanently written
+            # Tests create and delete their own data (DELETE cleanup) — no existing data is modified
             cd backend
-            export REDIS_URL="redis://:${REDIS_PASSWORD}@localhost:6379/0"
             export ENVIRONMENT="test"
             export PYTHONPATH="/home/ikeniborn/familyBudget"
 


### PR DESCRIPTION
## Summary

- **Root cause:** The SSH user running backend tests lacks read permission on `/opt/budget/.env`, causing `Permission denied` when sourcing it. This left `POSTGRES_PASSWORD` empty, which caused alembic to fail with `fe_sendauth: no password supplied` — blocking all tests from running.
- **Fix:** Replace `source /opt/budget/.env` with a hardcoded `DATABASE_URL` using `${{ secrets.TEST_POSTGRES_PASSWORD }}` (already configured as a GitHub secret since 2026-02-17).
- **Cleanup:** Remove `REDIS_URL` export since `REDIS_URL` is optional (`str | None = None`) in app config and no `TEST_REDIS_PASSWORD` secret is configured.

## Failing job reference

Job: https://github.com/ikeniborn/familyBudget/actions/runs/22144168604/job/64017559784

Error from logs:
```
bash: line 9: /opt/budget/.env: Permission denied
psycopg2.OperationalError: connection to server at "localhost" (127.0.0.1), port 5432 failed: fe_sendauth: no password supplied
```

## Test plan

- [ ] Verify the `Post-Deploy Tests (backend)` job passes in the next CI run triggered by merging this PR to `test`
- [ ] Confirm alembic migration step completes successfully
- [ ] Confirm pytest runs and results are visible in logs
- [ ] Verify no existing data is deleted (tests use DELETE cleanup for their own created data only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)