### PR TITLE
fix(p2p+backend): SDP parsing, live camera scan, admin articles, XSS fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -354,10 +354,8 @@ backend/.env.test
 
 .claude/sessions/
 # Claude Code Agent Workspace
-.claude/workspace
-
-# Claude Code Agent Workspace
 .claude/workspace/
+.claude/tools/
 
 # Sphinx build output
 docs/sphinx/_build/.doctrees/

--- a/backend/app/api/v1/analytics.py
+++ b/backend/app/api/v1/analytics.py
@@ -4,6 +4,7 @@ Analytics API endpoints.
 Provides aggregated data for charts and dashboards.
 """
 import calendar as cal_module
+import html
 import logging
 from datetime import date, datetime, timedelta
 
@@ -814,7 +815,7 @@ async def get_account_balances_html(
 
     # Handle case: no active financial centers
     if not balances:
-        html = """
+        empty_html = """
         <div class="alert alert-info">
             <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" class="stroke-current shrink-0 w-6 h-6">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
@@ -823,15 +824,16 @@ async def get_account_balances_html(
         </div>
         """
         # Cache empty state too (TTL 30s)
-        await cache_service.set(cache_key, html, CacheTTL.DASHBOARD())
-        return html
+        await cache_service.set(cache_key, empty_html, CacheTTL.DASHBOARD())
+        return empty_html
 
     # Generate unified responsive cards
     balance_cards = ""
     for bal in balances:
+        _name = html.escape(bal['name'])
         balance_cards += f"""
         <div class="balance-card" data-movement="{bal['month_movement']:.2f}">
-            <div class="balance-title" title="{bal['name']}">{bal['name']}</div>
+            <div class="balance-title" title="{_name}">{_name}</div>
             <div>
                 <div class="balance-row">
                     <span class="balance-label">Начало</span>
@@ -850,7 +852,7 @@ async def get_account_balances_html(
             </div>
         </div>"""
 
-    html = f"""
+    result_html = f"""
     <style>
         /* === BALANCES: 5 Breakpoints Grid Layout (fixed like quick-stats) === */
         .balances-grid {{
@@ -966,9 +968,9 @@ async def get_account_balances_html(
     """
 
     # Cache the generated HTML (TTL 30s)
-    await cache_service.set(cache_key, html, CacheTTL.DASHBOARD())
+    await cache_service.set(cache_key, result_html, CacheTTL.DASHBOARD())
 
-    return html
+    return result_html
 
 
 @router.get("/plan-fact")

--- a/backend/app/api/v1/endpoints/articles.py
+++ b/backend/app/api/v1/endpoints/articles.py
@@ -417,8 +417,7 @@ async def update_article(
     - If is_active + other fields change: both operations execute
 
     **Shared References Architecture:**
-    - All authenticated users can update articles
-    - All articles are shared across all users
+    - Only admins can update articles (shared across all users)
 
     **Validation:**
     - At least one field must be provided
@@ -427,12 +426,20 @@ async def update_article(
 
     **Returns:**
     - 200 OK: Article updated (in-place update with history)
+    - 403 Forbidden: Not an administrator
     - 404 Not Found: Article not found
     - 400 Bad Request: No fields provided for update
     """
     import logging
     logger = logging.getLogger(__name__)
     logger.info(f"[UPDATE_ARTICLE] ENTRY: article_id={article_id}")
+
+    # Check: Only admins can update articles
+    if not current_user.is_admin:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Only administrators can update articles"
+        )
 
     # Validate: At least one field provided
     update_data = article_data.model_dump(exclude_unset=True)

--- a/backend/app/services/telegram_auth.py
+++ b/backend/app/services/telegram_auth.py
@@ -349,17 +349,17 @@ def validate_telegram_auth(data: dict[str, Any]) -> bool:
         - TASK-012: Telegram OAuth endpoint
         - TASK-026: Auth unit tests (validation required)
     """
-    # Step 1: Extract and remove hash from data
-    received_hash = data.pop("hash", None)
+    # Step 1: Extract hash without mutating the caller's dict
+    received_hash = data.get("hash")
 
     if received_hash is None:
         return False
 
-    # Step 2: Create data check string
+    # Step 2: Create data check string (exclude 'hash' key)
     # Format: "key=value\nkey=value\n..." (sorted by key)
     # All values must be strings
     data_check_string = "\n".join(
-        [f"{key}={value}" for key, value in sorted(data.items())]
+        [f"{key}={value}" for key, value in sorted(data.items()) if key != "hash"]
     )
 
     # Step 3: Compute secret key (SHA256 of bot token)

--- a/backend/tests/integration/test_error_handling.py
+++ b/backend/tests/integration/test_error_handling.py
@@ -185,13 +185,13 @@ async def test_get_nonexistent_fact(auth_client: AsyncClient):
 
 
 @pytest.mark.asyncio
-async def test_update_nonexistent_article(auth_client: AsyncClient):
+async def test_update_nonexistent_article(admin_client: AsyncClient):
     """
     Test updating article that doesn't exist.
 
     Expected: 404 Not Found
     """
-    response = await auth_client.put(
+    response = await admin_client.put(
         "/api/v1/articles/99999",
         json={"name": "Updated"},
     )
@@ -379,7 +379,7 @@ async def test_failed_fact_creation_leaves_no_partial_data(
 
 @pytest.mark.asyncio
 async def test_update_article_with_invalid_data_no_changes(
-    auth_client: AsyncClient, session: AsyncSession
+    auth_client: AsyncClient, admin_client: AsyncClient, session: AsyncSession
 ):
     """
     Test that failed update doesn't modify article.
@@ -397,7 +397,7 @@ async def test_update_article_with_invalid_data_no_changes(
     article_id = response.json()["id"]
 
     # Try to update with invalid type
-    update_response = await auth_client.put(
+    update_response = await admin_client.put(
         f"/api/v1/articles/{article_id}",
         json={"type": "invalid_type"},
     )
@@ -502,7 +502,7 @@ async def test_delete_article_with_facts_still_works(auth_client: AsyncClient):
 
 
 @pytest.mark.asyncio
-async def test_concurrent_updates_to_same_article(auth_client: AsyncClient):
+async def test_concurrent_updates_to_same_article(auth_client: AsyncClient, admin_client: AsyncClient):
     """
     Test concurrent updates to same article (SCD Type 2 versioning handles this).
 
@@ -519,14 +519,14 @@ async def test_concurrent_updates_to_same_article(auth_client: AsyncClient):
     article_id = response.json()["id"]
 
     # First update
-    update1 = await auth_client.put(
+    update1 = await admin_client.put(
         f"/api/v1/articles/{article_id}",
         json={"name": "V2"},
     )
     assert update1.status_code == 200
 
     # Second update
-    update2 = await auth_client.put(
+    update2 = await admin_client.put(
         f"/api/v1/articles/{article_id}",
         json={"name": "V3"},
     )

--- a/backend/tests/integration/test_scd_type2_versioning.py
+++ b/backend/tests/integration/test_scd_type2_versioning.py
@@ -192,7 +192,7 @@ async def test_user_versioning_name_change(client: AsyncClient, session: AsyncSe
 
 
 @pytest.mark.asyncio
-async def test_article_versioning_name_change(auth_client: AsyncClient, session: AsyncSession):
+async def test_article_versioning_name_change(auth_client: AsyncClient, admin_client: AsyncClient, session: AsyncSession):
     """
     Test article versioning when name changes.
 
@@ -214,8 +214,8 @@ async def test_article_versioning_name_change(auth_client: AsyncClient, session:
     )
     article_id = create_response.json()["id"]
 
-    # Update article name
-    update_response = await auth_client.put(
+    # Update article name (admin-only operation)
+    update_response = await admin_client.put(
         f"/api/v1/articles/{article_id}",
         json={"name": "Food & Dining"},
     )
@@ -245,7 +245,7 @@ async def test_article_versioning_name_change(auth_client: AsyncClient, session:
 
 
 @pytest.mark.asyncio
-async def test_article_versioning_code_change(auth_client: AsyncClient, session: AsyncSession):
+async def test_article_versioning_code_change(auth_client: AsyncClient, admin_client: AsyncClient, session: AsyncSession):
     """
     Test article versioning when code changes.
 
@@ -261,8 +261,8 @@ async def test_article_versioning_code_change(auth_client: AsyncClient, session:
     )
     article_id = create_response.json()["id"]
 
-    # Update name
-    update_response = await auth_client.put(
+    # Update name (admin-only operation)
+    update_response = await admin_client.put(
         f"/api/v1/articles/{article_id}",
         json={"name": "Transportation"},
     )
@@ -283,7 +283,7 @@ async def test_article_versioning_code_change(auth_client: AsyncClient, session:
 
 @pytest.mark.asyncio
 async def test_article_versioning_multiple_updates(
-    auth_client: AsyncClient, session: AsyncSession
+    auth_client: AsyncClient, admin_client: AsyncClient, session: AsyncSession
 ):
     """
     Test article versioning with multiple sequential updates.
@@ -302,11 +302,11 @@ async def test_article_versioning_multiple_updates(
     )
     article_id = create_response.json()["id"]
 
-    # Update to V2
-    await auth_client.put(f"/api/v1/articles/{article_id}", json={"name": "V2"})
+    # Update to V2 (admin-only operation)
+    await admin_client.put(f"/api/v1/articles/{article_id}", json={"name": "V2"})
 
     # Update to V3
-    await auth_client.put(f"/api/v1/articles/{article_id}", json={"name": "V3"})
+    await admin_client.put(f"/api/v1/articles/{article_id}", json={"name": "V3"})
 
     # Verify three versions
     stmt = select(Article).where(Article.id == article_id)
@@ -490,7 +490,7 @@ async def test_fact_versioning_date_change(auth_client: AsyncClient, session: As
 
 @pytest.mark.asyncio
 async def test_historical_query_article_at_point_in_time(
-    auth_client: AsyncClient, session: AsyncSession
+    auth_client: AsyncClient, admin_client: AsyncClient, session: AsyncSession
 ):
     """
     Test querying article data as it existed at a specific point in time.
@@ -514,8 +514,8 @@ async def test_historical_query_article_at_point_in_time(
     v1_article = result.scalar_one()
     t1 = v1_article.created_at
 
-    # Update to V2
-    await auth_client.put(f"/api/v1/articles/{article_id}", json={"name": "V2"})
+    # Update to V2 (admin-only operation)
+    await admin_client.put(f"/api/v1/articles/{article_id}", json={"name": "V2"})
 
     # Query at T1 (should return V1)
     stmt_historical = (
@@ -532,7 +532,7 @@ async def test_historical_query_article_at_point_in_time(
 
 @pytest.mark.asyncio
 async def test_current_query_always_returns_latest_version(
-    auth_client: AsyncClient, session: AsyncSession
+    auth_client: AsyncClient, admin_client: AsyncClient, session: AsyncSession
 ):
     """
     Test that queries with is_current=True always return latest version.
@@ -550,9 +550,9 @@ async def test_current_query_always_returns_latest_version(
     )
     article_id = create_response.json()["id"]
 
-    await auth_client.put(f"/api/v1/articles/{article_id}", json={"name": "V2"})
-    await auth_client.put(f"/api/v1/articles/{article_id}", json={"name": "V3"})
-    await auth_client.put(f"/api/v1/articles/{article_id}", json={"name": "V4"})
+    await admin_client.put(f"/api/v1/articles/{article_id}", json={"name": "V2"})
+    await admin_client.put(f"/api/v1/articles/{article_id}", json={"name": "V3"})
+    await admin_client.put(f"/api/v1/articles/{article_id}", json={"name": "V4"})
 
     # Query current version
     stmt = select(Article).where(Article.id == article_id, Article.is_active)
@@ -612,7 +612,7 @@ async def test_soft_delete_creates_final_version(
 
 
 @pytest.mark.asyncio
-async def test_version_chain_no_gaps(auth_client: AsyncClient, session: AsyncSession):
+async def test_version_chain_no_gaps(auth_client: AsyncClient, admin_client: AsyncClient, session: AsyncSession):
     """
     Test that version chains have no gaps (valid_to of V1 = valid_from of V2).
 
@@ -628,9 +628,9 @@ async def test_version_chain_no_gaps(auth_client: AsyncClient, session: AsyncSes
     )
     article_id = create_response.json()["id"]
 
-    # Multiple updates
-    await auth_client.put(f"/api/v1/articles/{article_id}", json={"name": "V2"})
-    await auth_client.put(f"/api/v1/articles/{article_id}", json={"name": "V3"})
+    # Multiple updates (admin-only operation)
+    await admin_client.put(f"/api/v1/articles/{article_id}", json={"name": "V2"})
+    await admin_client.put(f"/api/v1/articles/{article_id}", json={"name": "V3"})
 
     # Get all versions sorted by valid_from
     stmt = select(Article).where(Article.id == article_id).order_by(Article.valid_from)
@@ -648,7 +648,7 @@ async def test_version_chain_no_gaps(auth_client: AsyncClient, session: AsyncSes
 
 
 @pytest.mark.asyncio
-async def test_version_chain_ordered_by_time(auth_client: AsyncClient, session: AsyncSession):
+async def test_version_chain_ordered_by_time(auth_client: AsyncClient, admin_client: AsyncClient, session: AsyncSession):
     """
     Test that versions are correctly ordered chronologically.
 
@@ -664,9 +664,9 @@ async def test_version_chain_ordered_by_time(auth_client: AsyncClient, session: 
     )
     article_id = create_response.json()["id"]
 
-    # Multiple updates
-    await auth_client.put(f"/api/v1/articles/{article_id}", json={"name": "V2"})
-    await auth_client.put(f"/api/v1/articles/{article_id}", json={"name": "V3"})
+    # Multiple updates (admin-only operation)
+    await admin_client.put(f"/api/v1/articles/{article_id}", json={"name": "V2"})
+    await admin_client.put(f"/api/v1/articles/{article_id}", json={"name": "V3"})
 
     # Get all versions
     stmt = select(Article).where(Article.id == article_id).order_by(Article.valid_from)
@@ -689,7 +689,7 @@ async def test_version_chain_ordered_by_time(auth_client: AsyncClient, session: 
 
 @pytest.mark.asyncio
 async def test_fact_references_current_article_version(
-    auth_client: AsyncClient, session: AsyncSession
+    auth_client: AsyncClient, admin_client: AsyncClient, session: AsyncSession
 ):
     """
     Test that facts reference articles correctly even when article is versioned.
@@ -719,8 +719,8 @@ async def test_fact_references_current_article_version(
     )
     fact_id = fact_response.json()["id"]
 
-    # Update article
-    await auth_client.put(f"/api/v1/articles/{article_id}", json={"name": "V2"})
+    # Update article (admin-only operation)
+    await admin_client.put(f"/api/v1/articles/{article_id}", json={"name": "V2"})
 
     # Verify fact still accessible
     fact_get_response = await auth_client.get(f"/api/v1/facts/{fact_id}")

--- a/frontend/web/static/css/p2p.css
+++ b/frontend/web/static/css/p2p.css
@@ -6,19 +6,21 @@
 
 /* ── QR Container ─────────────────────────────────────── */
 .p2p-qr-container {
-    width: 300px;
-    height: 300px;
+    width: min(300px, 100%);
+    aspect-ratio: 1 / 1;
+    height: auto;
     padding: 12px;
+    box-sizing: border-box;
     background: #ffffff;
     border-radius: 1rem;
     box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
-    flex-shrink: 0;
+    flex-shrink: 1;
 }
 
 .p2p-qr-container canvas {
     display: block;
-    width: 276px !important;
-    height: 276px !important;
+    width: 100% !important;
+    height: auto !important; /* relies on canvas 1:1 intrinsic ratio; avoids flex height-100% ambiguity */
     image-rendering: pixelated; /* Keep QR crisp on high-DPI */
 }
 

--- a/frontend/web/static/js/offline/p2p/P2PManager.js
+++ b/frontend/web/static/js/offline/p2p/P2PManager.js
@@ -8,6 +8,10 @@
  * @version 1.0.0
  */
 
+// Module-level flag: getUserMedia for iOS ICE unblock is done at most once per page load.
+// Avoids repeated permission prompts when user opens multiple sync sessions.
+let _iceUnblockDone = false;
+
 const P2P_STUN_SERVERS = [
   { urls: 'stun:stun.l.google.com:19302' },
   { urls: 'stun:stun1.l.google.com:19302' },
@@ -52,12 +56,15 @@ class P2PManager {
    */
   async getUnblockMediaStream() {
     if (!isIOS()) return;
+    if (_iceUnblockDone) return;
     try {
       const stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: false });
       this._iceUnblockStream = stream;
       stream.getTracks().forEach(track => track.stop());
+      _iceUnblockDone = true;
       console.debug('[P2PManager] iOS ICE unblock: getUserMedia succeeded, tracks stopped');
     } catch (err) {
+      _iceUnblockDone = true; // don't retry on denial
       console.warn('[P2PManager] iOS ICE unblock: getUserMedia denied or unavailable:', err.message);
     }
   }

--- a/frontend/web/static/js/offline/p2p/P2PSignaling.js
+++ b/frontend/web/static/js/offline/p2p/P2PSignaling.js
@@ -98,6 +98,7 @@ class P2PSignaling {
         !line.startsWith('a=rtcp-fb') &&
         !line.startsWith('a=rtpmap') &&
         !line.startsWith('a=fmtp') &&
+        !line.startsWith('a=max-message-size') &&
         line.trim() !== ''
       )
       .join('\r\n');

--- a/frontend/web/static/js/ui/P2PUIController.js
+++ b/frontend/web/static/js/ui/P2PUIController.js
@@ -57,6 +57,10 @@ class P2PUIController {
     this._relayCode = null;
     this._relayPollTimer = null;
 
+    // Camera scanning state
+    this._cameraStream = null;
+    this._scanTimer = null;
+
     // Expose globally for inline onclick handlers in templates
     window.p2pUI = this;
 
@@ -461,6 +465,7 @@ class P2PUIController {
    * Cancel sync and close modal.
    */
   cancel() {
+    this._stopCameraScanning();
     this._stopOfferTimer();
     this._stopRelayPoll();
     if (this.manager) {
@@ -516,6 +521,99 @@ class P2PUIController {
     if (isIOS() && isPWAStandalone()) {
       const warn = document.getElementById('p2p-ios-pwa-warning');
       if (warn) warn.classList.remove('hidden');
+    }
+  }
+
+  // ── Private: live camera scanning ────────────────────
+
+  /**
+   * Start live camera stream and continuously scan for QR codes.
+   * Primary: BarcodeDetector (Chrome 83+, Android WebView).
+   * Fallback: jsQR (pure JS, iOS Safari).
+   * On permission denial shows the camera error state with a photo-fallback button.
+   * @param {HTMLVideoElement} videoEl
+   */
+  async _startCameraScanning(videoEl) {
+    if (!navigator.mediaDevices?.getUserMedia) {
+      this._showCameraError();
+      return;
+    }
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({
+        video: { facingMode: 'environment' },
+        audio: false,
+      });
+      // Guard: user may have cancelled while the permission dialog was open
+      if (!this._modal) {
+        stream.getTracks().forEach(t => t.stop());
+        return;
+      }
+      this._cameraStream = stream;
+      videoEl.srcObject = stream;
+
+      const useDetector = typeof BarcodeDetector !== 'undefined';
+      const detector = useDetector ? new BarcodeDetector({ formats: ['qr_code'] }) : null;
+      const canvas = useDetector ? null : document.createElement('canvas');
+      const ctx = canvas ? canvas.getContext('2d') : null;
+      let busy = false;
+      let frameCount = 0;
+
+      const scan = async () => {
+        if (!this._cameraStream || !this._scanTimer) return;
+        if (videoEl.readyState < videoEl.HAVE_ENOUGH_DATA || busy) return;
+        frameCount++;
+        // BarcodeDetector: every tick (native, fast); jsQR: every 2nd tick (JS)
+        if (!detector && frameCount % 2 !== 0) return;
+        busy = true;
+        try {
+          let result = null;
+          if (detector) {
+            const codes = await detector.detect(videoEl);
+            if (codes.length > 0) result = codes[0].rawValue;
+          } else if (typeof window.jsQR === 'function') {
+            canvas.width = videoEl.videoWidth || 320;
+            canvas.height = videoEl.videoHeight || 240;
+            ctx.drawImage(videoEl, 0, 0, canvas.width, canvas.height);
+            const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+            const code = window.jsQR(imageData.data, imageData.width, imageData.height);
+            result = code?.data || null;
+          }
+          if (result && this._scanTimer) {
+            this._stopCameraScanning();
+            await this._handleScannedQR(result);
+          }
+        } catch { /* ignore individual frame errors */ }
+        busy = false;
+      };
+
+      // 200ms interval = 5fps — sufficient for steady QR, light on CPU
+      this._scanTimer = setInterval(scan, 200);
+    } catch (err) {
+      console.warn('[P2PUIController] Camera access denied:', err.message);
+      this._showCameraError();
+    }
+  }
+
+  /**
+   * Show camera error state and reveal the photo-fallback button.
+   */
+  _showCameraError() {
+    document.getElementById('p2p-camera-error')?.classList.remove('hidden');
+    const video = document.getElementById('p2p-camera-video');
+    if (video?.parentElement) video.parentElement.classList.add('hidden');
+  }
+
+  /**
+   * Stop live camera scanning and release the media stream.
+   */
+  _stopCameraScanning() {
+    if (this._scanTimer) {
+      clearInterval(this._scanTimer);
+      this._scanTimer = null;
+    }
+    if (this._cameraStream) {
+      this._cameraStream.getTracks().forEach(t => t.stop());
+      this._cameraStream = null;
     }
   }
 
@@ -616,6 +714,7 @@ class P2PUIController {
   }
 
   _showAnswerQR(answerPayload) {
+    this._stopCameraScanning();
     const section = document.getElementById('p2p-answer-qr-section');
     const container = document.getElementById('p2p-answer-qr-container');
     const manualText = document.getElementById('p2p-manual-answer-text');
@@ -628,6 +727,7 @@ class P2PUIController {
   // ── Private: connection lifecycle ───────────────────
 
   _waitForConnection() {
+    this._stopCameraScanning();
     // Close modal so the status overlay (z-9500) is fully visible
     this._closeModal();
     // Manager's onStateChange will call _onConnected when connected
@@ -858,18 +958,30 @@ class P2PUIController {
         ].join('');
     } else if (screenName === 'scanner' || screenName === 'scanner-answer') {
       content.innerHTML = [
-        '<div class="flex flex-col items-center gap-6 p-4 pb-8 w-full">',
-          // Primary: photo capture button
-          '<div class="flex flex-col items-center gap-2 w-full max-w-xs">',
-            '<p class="text-sm text-base-content/60 text-center">Сфотографируйте QR-код с экрана другого устройства</p>',
-            '<input type="file" id="p2p-photo-input" accept="image/*" capture="environment" class="hidden">',
-            '<button class="btn btn-primary w-full" onclick="document.getElementById(\'p2p-photo-input\').click()">',
-              'Сфотографировать QR',
-            '</button>',
+        '<div class="flex flex-col items-center gap-4 p-4 pb-8 w-full">',
+          // Live camera view
+          '<div id="p2p-camera-wrapper" class="relative w-full max-w-xs">',
+            '<div class="p2p-scanner-overlay rounded-xl overflow-hidden bg-black" style="aspect-ratio:1/1;position:relative">',
+              '<video id="p2p-camera-video" class="w-full h-full object-cover" autoplay playsinline muted></video>',
+              '<div style="position:absolute;inset:0;display:flex;align-items:center;justify-content:center;pointer-events:none">',
+                '<div style="width:9rem;height:9rem;border:2px solid oklch(var(--p,65% 0.27 264)/0.85);border-radius:0.5rem"></div>',
+              '</div>',
+            '</div>',
+            // Camera error/fallback
+            '<div id="p2p-camera-error" class="hidden" style="position:absolute;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center;background:oklch(var(--b2,100% 0 0));border-radius:0.75rem;gap:0.75rem;padding:1rem">',
+              '<svg xmlns="http://www.w3.org/2000/svg" style="width:2rem;height:2rem;color:oklch(var(--wa,80% 0.15 85))" fill="none" viewBox="0 0 24 24" stroke="currentColor">',
+                '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 9a2 2 0 012-2h.93a2 2 0 001.664-.89l.812-1.22A2 2 0 0110.07 4h3.86a2 2 0 011.664.89l.812 1.22A2 2 0 0018.07 7H19a2 2 0 012 2v9a2 2 0 01-2 2H5a2 2 0 01-2-2V9z"/>',
+              '</svg>',
+              '<p class="text-xs text-center text-base-content/60">Нет доступа к камере</p>',
+              '<button class="btn btn-xs btn-primary" onclick="document.getElementById(\'p2p-photo-input\').click()">Сфотографировать QR</button>',
+            '</div>',
           '</div>',
+          // Hidden file input (fallback)
+          '<input type="file" id="p2p-photo-input" accept="image/*" capture="environment" class="hidden">',
           // Answer QR section (shown after processing scanned offer)
           '<div id="p2p-answer-qr-section" class="hidden flex flex-col items-center gap-2 w-full">',
-            '<div id="p2p-answer-qr-container" class="p2p-qr-container flex items-center justify-center bg-white rounded-xl">',
+            '<div class="divider text-xs">Шаг 2: Покажите QR первому устройству</div>',
+            '<div id="p2p-answer-qr-container" class="p2p-qr-container flex items-center justify-center bg-white rounded-2xl shadow-md">',
               '<span class="loading loading-ring loading-lg"></span>',
             '</div>',
             '<div class="w-full max-w-xs">',
@@ -883,16 +995,23 @@ class P2PUIController {
             '</div>',
           '</div>',
           // Paste fallback
-          '<div class="w-full max-w-xs">',
-            '<p class="text-xs text-base-content/50 mb-1">Или вставьте код вручную:</p>',
-            '<textarea id="p2p-paste-input" class="textarea textarea-bordered textarea-xs font-mono text-xs h-16 w-full" placeholder="Вставьте код..."></textarea>',
-            '<button class="btn btn-xs btn-primary mt-1 w-full" onclick="window.p2pUI?.processPastedCode()">Подключиться</button>',
+          '<div class="collapse collapse-arrow bg-base-200 w-full max-w-xs">',
+            '<input type="checkbox">',
+            '<div class="collapse-title text-sm font-medium">Вставить код вручную</div>',
+            '<div class="collapse-content">',
+              '<textarea id="p2p-paste-input" class="textarea textarea-bordered textarea-xs font-mono text-xs h-16 w-full" placeholder="Вставьте код..."></textarea>',
+              '<button class="btn btn-xs btn-primary mt-1 w-full" onclick="window.p2pUI?.processPastedCode()">Подключиться</button>',
+            '</div>',
           '</div>',
           '<button class="btn btn-ghost btn-sm" onclick="window.p2pUI?.cancel()">Отмена</button>',
         '</div>',
       ].join('');
 
-      // Wire photo capture input
+      // Start live camera scanning
+      const videoEl = content.querySelector('#p2p-camera-video');
+      if (videoEl) this._startCameraScanning(videoEl);
+
+      // Wire photo input fallback
       const photoInput = content.querySelector('#p2p-photo-input');
       if (photoInput) {
         photoInput.addEventListener('change', (e) => {


### PR DESCRIPTION
## Summary

### P2P синхронизация
- **Fix SDP parsing** (`P2PSignaling.js`): добавлен `a=max-message-size` в `_stripSDP()` — устраняет ошибку `setRemoteDescription` в relay и QR-канале при кросс-браузерных сессиях (Chrome генерирует эту строку, Firefox/Safari отвергают)
- **Live camera scanner** (`P2PUIController.js`): экран сканера заменён на live camera stream с `setInterval 200ms` + `BarcodeDetector`/`jsQR`; добавлен guard после `getUserMedia` против утечки стрима при отмене во время диалога разрешений
- **Responsive QR container** (`p2p.css`): фиксированные `300×300px` → `min(300px,100%) + aspect-ratio:1/1`; canvas `height:auto` вместо `100%` для корректного поведения в flex
- **Cache getUserMedia** (`P2PManager.js`): module-level флаг `_iceUnblockDone` — iOS запрос разрешения на микрофон только один раз за сессию страницы

### Backend
- **Admin-only article updates** (`articles.py`): `PUT /api/v1/articles/{id}` теперь требует `is_admin`; возвращает 403 для обычных пользователей
- **XSS escape** (`analytics.py`): `html.escape()` для имён финансовых центров в balance cards; переименование локальной переменной `html` → не конфликтует со stdlib
- **telegram_auth mutation fix** (`telegram_auth.py`): `data.pop('hash')` → `data.get('hash')` + фильтрация в `sorted()` — не мутирует dict вызывающего кода
- **Тесты** (`test_error_handling.py`, `test_scd_type2_versioning.py`): article update тесты переключены на `admin_client`
- **`.gitignore`**: дедупликация, добавлен `.claude/tools/`

## Test plan
- [ ] QR relay: ввести код с устройства A на устройстве B с другим браузером — соединение должно установиться без ошибки SDP
- [ ] QR scan: открыть "Сканировать QR" — должна появиться live camera, не кнопка "Сфотографировать"
- [ ] QR container на iPhone SE (375px): QR не должен выходить за границы модала
- [ ] iOS PWA: нажать "Получить код" дважды подряд — запрос микрофона только при первом открытии
- [ ] PUT /api/v1/articles/{id} от обычного пользователя — 403
- [ ] Тесты: `pytest backend/tests/integration/test_error_handling.py backend/tests/integration/test_scd_type2_versioning.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)