### PR TITLE
fix(plan): restore global state and missing functions after inline JS removal

### DIFF
--- a/frontend/web/static/js/plan/adapters/windowExports.ts
+++ b/frontend/web/static/js/plan/adapters/windowExports.ts
@@ -83,6 +83,16 @@ export function setupWindowExports(
   window.updateEditReminderDatetime = planApp.updateEditReminderDatetime;
 
   // -----------------------------------------------------------------------
+  // Глобальные переменные состояния (ранее — inline JS plan.html)
+  // -----------------------------------------------------------------------
+  // allCategories: пустой массив, заполняется в loadArticlesDropdown (index.ts)
+  if (!(window as any).allCategories) {
+    (window as any).allCategories = [];
+  }
+  (window as any).ModalListenerManager = PlanModal.ModalListenerManager;
+  (window as any).showNotification = PlanHelpers.showNotification;
+
+  // -----------------------------------------------------------------------
   // Plan Modal helpers (ранее были в inline JS plan.html — Unit 4 рефакторинг)
   // -----------------------------------------------------------------------
   (window as any).setSubmitLoading = PlanModal.setSubmitLoading;

--- a/frontend/web/static/js/plan/crud.ts
+++ b/frontend/web/static/js/plan/crud.ts
@@ -9,6 +9,7 @@
 
 import * as PlanHelpers from './helpers';
 import * as PlanFactsTable from './factsTable';
+import { remindersMap, selectedFactIds } from './factsTable';
 
 // Import BudgetShared from global
 declare const BudgetShared: {
@@ -30,16 +31,17 @@ declare const BudgetShared: {
   ChoicesCategoryTree: any; // Constructor
 };
 
-// Global variables from plan.html
+// Global variables from plan.html (set via window in planModal/windowExports)
 declare let allCategories: any[];
-declare let editCategoryTreeSelect: any;
-declare let editDateCalendar: any;
-declare let createCategoryTreeSelect: any;
-declare const remindersMap: Map<number, any>;
 declare const ModalListenerManager: any;
 declare const showNotification: (message: string, type: string) => void;
-declare const selectedFactIds: Set<number>;
 declare const selectedRecurringPlanIds: Set<number>;
+
+// Module-local state (previously declared as globals, only used in this module)
+let editCategoryTreeSelect: any = null;
+let editDateCalendar: any = null;
+let createCategoryTreeSelect: any = null;
+// remindersMap and selectedFactIds are imported from factsTable (see import above)
 
 // Logger class from utils/logger.js (loaded globally via bundle)
 declare class Logger {
@@ -637,7 +639,7 @@ export async function showEditModal(factId: number): Promise<void> {
   if (reminder) {
     if (reminderCheckbox) reminderCheckbox.checked = true;
     // Populate separate date/hour/minute fields
-    populateEditReminderFields(reminder.reminder_datetime);
+    populateEditReminderFields(reminder.remind_at);
     if (reminderSettingsDiv) reminderSettingsDiv.classList.remove('hidden');
     // Initialize CalendarWidget for edit reminder date
     initEditReminderCalendarWidget();

--- a/frontend/web/static/js/plan/factsTable.ts
+++ b/frontend/web/static/js/plan/factsTable.ts
@@ -56,14 +56,16 @@ let totalFacts = 0;
 let factsData: BudgetFact[] = [];
 
 /**
- * Set of selected fact IDs for batch operations
+ * Set of selected fact IDs for batch operations.
+ * Exported for use by crud.ts (shared live binding via Rollup).
  */
-let selectedFactIds: Set<number> = new Set();
+export let selectedFactIds: Set<number> = new Set();
 
 /**
- * Map of fact ID → reminder for reminder status display
+ * Map of fact ID → reminder for reminder status display.
+ * Exported for use by crud.ts (shared live binding via Rollup).
  */
-const remindersMap: Map<number, Reminder> = new Map();
+export const remindersMap: Map<number, Reminder> = new Map();
 
 /**
  * Get current page number

--- a/frontend/web/static/js/plan/index.ts
+++ b/frontend/web/static/js/plan/index.ts
@@ -260,6 +260,10 @@ function createArticleOption(node: PlanHelpers.FlatArticle): HTMLOptionElement {
 async function loadArticlesDropdown(): Promise<void> {
   try {
     const articles = await PlanHelpers.loadArticles();
+
+    // Populate global allCategories used by crud.ts (declare let allCategories)
+    (window as any).allCategories = articles;
+
     const tree = PlanHelpers.buildArticleTree(articles);
     const flatNodes = PlanHelpers.flattenArticleTree(tree);
     const sortedNodes = groupArticlesByType(flatNodes);

--- a/frontend/web/static/js/plan/planModal.ts
+++ b/frontend/web/static/js/plan/planModal.ts
@@ -24,6 +24,38 @@ let editReminderCalendarWidget: any = null;
 export const selectedRecurringPlanIds = new Set<number>();
 
 // ============================================================================
+// Modal Listener Manager
+// ============================================================================
+
+/**
+ * Encapsulated AbortController for edit modal event listeners.
+ * Ensures previous listeners are cleaned up before attaching new ones.
+ */
+export const ModalListenerManager = (() => {
+  let abortController: AbortController | null = null;
+
+  return {
+    registerListener(
+      element: HTMLElement,
+      eventName: string,
+      handler: EventListenerOrEventListenerObject
+    ): void {
+      if (abortController) {
+        abortController.abort();
+      }
+      abortController = new AbortController();
+      element.addEventListener(eventName, handler, { signal: abortController.signal });
+    },
+    abort(): void {
+      if (abortController) {
+        abortController.abort();
+        abortController = null;
+      }
+    },
+  };
+})();
+
+// ============================================================================
 // Submit Loading State
 // ============================================================================
 


### PR DESCRIPTION
## Summary

- Export `remindersMap` and `selectedFactIds` from `factsTable.ts` so `crud.ts` imports them via Rollup live bindings (fixes `ReferenceError: allCategories / remindersMap is not defined`)
- Convert `declare let editCategoryTreeSelect/editDateCalendar/createCategoryTreeSelect` to real module-local `let` in `crud.ts`
- Populate `window.allCategories` in `loadArticlesDropdown` (`index.ts`)
- Add `ModalListenerManager` to `planModal.ts` and expose via `windowExports.ts`
- Expose `showNotification` and `allCategories` initialiser via `windowExports.ts`
- Fix latent bug: `reminder.reminder_datetime` → `reminder.remind_at` (correct field from `Reminder` interface)

## Root cause

PR #447 removed 5544 lines of inline JS from `plan.html`. Two categories of globals were lost:
1. **Functions** (`loadFinancialCenters`, etc.) — fixed in PR #449
2. **State variables** (`allCategories`, `ModalListenerManager`, `remindersMap`, `selectedFactIds`) — fixed here

## Test plan

- [ ] Open plan page — no `ReferenceError` in console on load
- [ ] Click "Edit" on any plan entry — edit modal opens, financial/cost centers load
- [ ] Category dropdown populates (allCategories filled)
- [ ] Batch delete works (selectedFactIds tracked correctly)
- [ ] Reminders display correctly in edit modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)