### PR TITLE
fix(facts): always load facts even if dropdowns fail

### DIFF
--- a/frontend/web/static/js/facts/index.ts
+++ b/frontend/web/static/js/facts/index.ts
@@ -106,25 +106,24 @@ export function initialize(): void {
  * Initialize UI components and load initial data
  */
 async function initializeUI(): Promise<void> {
+    // 1. Initialize default period filter
+    initDefaultPeriodFilter();
+
+    // 2. Initialize CalendarWidget for date range
+    initDateRangeCalendar();
+
+    // 3. Load all dropdown data independently — does not block facts loading
     try {
-        // 1. Initialize default period filter
-        initDefaultPeriodFilter();
-
-        // 2. Initialize CalendarWidget for date range
-        initDateRangeCalendar();
-
-        // 3. Load all dropdown data in parallel
         await loadAndPopulateDropdowns();
-
-        // 4. Setup modal_fact event listeners (Today button, etc.)
-        setupModalFactListeners();
-
-        // 5. Load facts with default filters (forceAPI for correct sort order)
-        await loadFacts({ forceAPI: true });
-
     } catch (error) {
-        logger.error(' Initialization error:', error);
+        logger.error(' Ошибка загрузки dropdown:', error);
     }
+
+    // 4. Setup modal_fact event listeners (Today button, etc.)
+    setupModalFactListeners();
+
+    // 5. Always load facts, even if dropdowns failed (forceAPI for correct sort order)
+    await loadFacts({ forceAPI: true });
 }
 
 /**


### PR DESCRIPTION
## Summary
- Resolves merge conflict from PR #452 (rebased on current `test`)
- Separate try-catch for `loadAndPopulateDropdowns()` — `loadFacts()` now always runs
- Fixes Stats Section showing zeros when dropdown API fails on page open

## Closes
Supersedes #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)