### PR TITLE
fix(facts): fix edit modal category type, add search, fix loader button

### DIFF
--- a/frontend/web/static/js/facts/features/modalFact/categoryWidget.ts
+++ b/frontend/web/static/js/facts/features/modalFact/categoryWidget.ts
@@ -13,7 +13,9 @@ import {
     getCreateTransferFromTree,
     setCreateTransferFromTree,
     getCreateTransferToTree,
-    setCreateTransferToTree
+    setCreateTransferToTree,
+    getEditCategoryTreeSelect,
+    setEditCategoryTreeSelect
 } from '../../core/stateManager';
 import { setupMobileModalPositioning } from '../../../utils/mobileModalPositioning';
 
@@ -251,6 +253,43 @@ function setupTransferFCListeners(): void {
         });
         toFcSelect.dataset.listenerAttached = 'true';
     }
+}
+
+// ============================================================================
+// Edit Modal Category Tree
+// ============================================================================
+
+/**
+ * Initialize ChoicesCategoryTree for the Edit Fact modal (#edit-article).
+ * Called on each modal open; destroys any previous instance first.
+ */
+export function initEditCategoryTree(articleType: string, selectedId: number | null): void {
+    const ChoicesCategoryTree = (window as any).BudgetShared?.ChoicesCategoryTree;
+    if (!ChoicesCategoryTree) return;
+    const articleSelect = document.querySelector('#edit-article');
+    if (!articleSelect) return;
+
+    const prev = getEditCategoryTreeSelect();
+    if (prev) { try { prev.destroy(); } catch (_) {} setEditCategoryTreeSelect(null); }
+
+    const instance = new ChoicesCategoryTree('#edit-article', {
+        type: articleType,
+        showLeafOnly: true,
+        mode: 'edit',
+        selectedId: selectedId,
+        onCategoryChange: () => {}
+    });
+    setEditCategoryTreeSelect(instance);
+    setupMobileModalPositioning(instance, 'edit-modal');
+}
+
+/**
+ * Destroy the Edit Fact modal category tree instance.
+ * Called on modal close to prevent double-init errors.
+ */
+export function destroyEditCategoryTree(): void {
+    const inst = getEditCategoryTreeSelect();
+    if (inst) { try { inst.destroy(); } catch (_) {} setEditCategoryTreeSelect(null); }
 }
 
 /**

--- a/frontend/web/static/js/facts/operations/factsController.ts
+++ b/frontend/web/static/js/facts/operations/factsController.ts
@@ -13,6 +13,8 @@ import type { CreateFactData, UpdateFactData, FactRow } from '../types/models';
 import { escapeHtml, sanitizeErrorMessage } from '../../shared/htmlSanitizer';
 import { TableFormatters } from '../../shared/tableUtils';
 import { factsControllerLogger as logger } from '../utilities/logger';
+import { setButtonLoading } from '../../dashboard/shared/utils/buttonState';
+import { initEditCategoryTree, destroyEditCategoryTree } from '../features/modalFact/categoryWidget';
 
 // ============================================================================
 // Main Load Function
@@ -204,12 +206,8 @@ export async function updateFact(event: Event): Promise<void> {
         return;
     }
 
-    // Disable save button (loading state)
     const submitBtn = form.querySelector('[type="submit"]') as HTMLButtonElement | null;
-    if (submitBtn) {
-        submitBtn.disabled = true;
-        submitBtn.classList.add('loading', 'loading-spinner');
-    }
+    setButtonLoading(submitBtn, true);
 
     try {
         // Import dynamically to avoid circular dependency
@@ -233,10 +231,7 @@ export async function updateFact(event: Event): Promise<void> {
         const errorMessage = error instanceof Error ? error.message : String(error);
         showToast(`Ошибка обновления: ${errorMessage}`, 'error');
     } finally {
-        if (submitBtn) {
-            submitBtn.disabled = false;
-            submitBtn.classList.remove('loading', 'loading-spinner');
-        }
+        setButtonLoading(submitBtn, false);
     }
 }
 
@@ -347,6 +342,9 @@ export async function showEditModal(factId: number): Promise<void> {
         // Populate edit modal
         populateEditModal(fact, getBudgetShared());
 
+        // Initialize category search tree for edit modal
+        initEditCategoryTree(fact.article_type ?? 'expense', fact.article_id ?? null);
+
         // Hide skeleton, show form
         if (skeleton) skeleton.classList.add('hidden');
         if (formFields) formFields.classList.remove('hidden');
@@ -383,14 +381,14 @@ function populateEditModal(fact: any, BudgetShared: any): void {
 
     // Тип категории - badge
     const categoryTypeLabel = document.getElementById('edit-category-type-label');
-    if (categoryTypeLabel && fact.article) {
+    if (categoryTypeLabel && fact.article_type) {
         const typeMap: Record<string, { text: string; badgeClass: string }> = {
             'expense': { text: 'Расход', badgeClass: 'badge-error' },
             'income': { text: 'Доход', badgeClass: 'badge-success' },
             'debit': { text: 'Списание', badgeClass: 'badge-info' },
             'credit': { text: 'Пополнение', badgeClass: 'badge-warning' }
         };
-        const typeInfo = typeMap[fact.article.record_type] || { text: 'Неизвестно', badgeClass: 'badge-neutral' };
+        const typeInfo = typeMap[fact.article_type] || { text: 'Неизвестно', badgeClass: 'badge-neutral' };
         categoryTypeLabel.textContent = typeInfo.text;
         categoryTypeLabel.className = `badge badge-sm ${typeInfo.badgeClass}`;
     }
@@ -428,6 +426,7 @@ export function closeEditModal(): void {
     if (modal?.close) {
         modal.close();
     }
+    destroyEditCategoryTree();
 }
 
 /**


### PR DESCRIPTION
## Summary
- Resolves merge conflict from PR #453 (rebased on current `test`)
- `populateEditModal`: use `fact.article_type` instead of `fact.article.record_type`
- Add `initEditCategoryTree` / `destroyEditCategoryTree` for search in edit modal
- Replace DaisyUI `loading-spinner` with `setButtonLoading` in `updateFact`

## Closes
Supersedes #453

🤖 Generated with [Claude Code](https://claude.com/claude-code)