### PR TITLE
fix(plan): export loadFacts to window to fix ReferenceError on CRUD

### DIFF
--- a/frontend/web/static/js/dashboard/types/globals.d.ts
+++ b/frontend/web/static/js/dashboard/types/globals.d.ts
@@ -271,6 +271,7 @@ declare global {
     openFactTransferModal?: () => Promise<void>;
 
     // Plan page (HTML onclick handlers)
+    loadFacts?: () => Promise<void>;
     openAddPlanModal?: () => void;
     createPlan?: (event: Event) => Promise<void>;
     batchDeleteRecurringPlans?: () => Promise<void>;

--- a/frontend/web/static/js/plan/adapters/windowExports.ts
+++ b/frontend/web/static/js/plan/adapters/windowExports.ts
@@ -59,6 +59,7 @@ export function setupWindowExports(
   // -----------------------------------------------------------------------
   // Table / Pagination operations
   // -----------------------------------------------------------------------
+  window.loadFacts = planApp.loadFacts;
   window.previousPage = planApp.previousPage;
   window.nextPage = planApp.nextPage;
   window.toggleSelectAll = planApp.FactsTable.toggleSelectAll;

--- a/frontend/web/static/js/plan/crud.ts
+++ b/frontend/web/static/js/plan/crud.ts
@@ -67,7 +67,6 @@ declare function resetRecurringSettings(modalId: string): void;
 declare function resetReminderFields(modalId: string): void;
 declare function setupCreatePlanPeriodButtons(): void;
 declare function setSubmitLoading(form: HTMLFormElement, isLoading: boolean): void;
-declare function loadFacts(): Promise<void>;
 declare function showToast(message: string, type: string): void;
 declare function loadRecurringPlans(): Promise<void>;
 declare function updateBatchDeleteRecurringPlansButtonState(): void;
@@ -1457,7 +1456,7 @@ export async function createPlan(event: Event): Promise<void> {
         const reminderSettings = document.getElementById('reminder-settings-modal_plan');
         if (reminderSettings) reminderSettings.classList.add('hidden');
         resetReminderFields(modalId);
-        await loadFacts();
+        await PlanFactsTable.loadFacts();
         setupCreatePlanPeriodButtons();
       } else {
         // Fallback to direct fetch if OfflineManager not available
@@ -1484,7 +1483,7 @@ export async function createPlan(event: Event): Promise<void> {
           const reminderSettings = document.getElementById('reminder-settings-modal_plan');
           if (reminderSettings) reminderSettings.classList.add('hidden');
           resetReminderFields(modalId);
-          await loadFacts();
+          await PlanFactsTable.loadFacts();
           setupCreatePlanPeriodButtons();
         } else {
           const error = await response.json();
@@ -1539,7 +1538,7 @@ export async function createPlan(event: Event): Promise<void> {
       const reminderSettings = document.getElementById('reminder-settings-modal_plan');
       if (reminderSettings) reminderSettings.classList.add('hidden');
       resetReminderFields('modal_plan');
-      await loadFacts(); // Перезагрузить список планов
+      await PlanFactsTable.loadFacts(); // Перезагрузить список планов
 
       // Переинициализировать кнопки периода
       setupCreatePlanPeriodButtons();
@@ -1575,7 +1574,7 @@ export async function createPlan(event: Event): Promise<void> {
         const reminderSettings = document.getElementById('reminder-settings-modal_plan');
         if (reminderSettings) reminderSettings.classList.add('hidden');
         resetReminderFields('modal_plan');
-        await loadFacts(); // Перезагрузить список планов
+        await PlanFactsTable.loadFacts(); // Перезагрузить список планов
 
         // Переинициализировать кнопки периода
         setupCreatePlanPeriodButtons();
@@ -1768,7 +1767,7 @@ export async function updateFact(event: Event): Promise<void> {
     }
 
     closeEditModal();
-    await loadFacts();
+    await PlanFactsTable.loadFacts();
     showNotification(successMessage, 'success');
   } catch (error) {
     logCrud.error('Error updating fact:', error);
@@ -1839,7 +1838,7 @@ export async function batchDeleteFacts(): Promise<void> {
     }
 
     const result = await response.json();
-    await loadFacts();
+    await PlanFactsTable.loadFacts();
     showNotification(`✅ Удалено транзакций: ${result.deleted_count}`, 'success');
   } catch (error) {
     logCrud.error('Error batch deleting facts:', error);
@@ -1931,7 +1930,7 @@ export async function batchDeleteRecurringPlans(): Promise<void> {
 
     // Reload data
     await loadRecurringPlans();
-    await loadFacts(); // Reload plan facts table
+    await PlanFactsTable.loadFacts(); // Reload plan facts table
 
     // Success notification (SINGLE)
     const message = result.failed && result.failed.length > 0


### PR DESCRIPTION
## Problem

На странице \`/plan\` при создании, редактировании и удалении записей бросался необработанный ReferenceError:
\`\`\`
ReferenceError: loadFacts is not defined
    at ft (plan.bundle.js?v=0.6.71:209)   // updateFact
    at Pe (plan.bundle.js?v=0.6.71:209)   // createPlan
\`\`\`

## Root Cause

В \`crud.ts\` вызывался глобальный \`loadFacts()\`, но функция не была экспортирована в \`window\` через \`windowExports.ts\`. \`planApp.loadFacts\` существовал в \`index.ts\` (строка 464), но до \`window\` не доходил.

## Changes

| Файл | Изменение |
|------|-----------|
| \`plan/adapters/windowExports.ts\` | \`window.loadFacts = planApp.loadFacts;\` |
| \`dashboard/types/globals.d.ts\` | Тип \`loadFacts?: () => Promise<void>\` в \`Window\` |
| \`plan/crud.ts\` | Все 8 вызовов \`loadFacts()\` → \`PlanFactsTable.loadFacts()\`, удалена \`declare function loadFacts()\` |

**Попутный рефакторинг:** \`crud.ts\` уже импортирует \`PlanFactsTable\` напрямую, поэтому внутренние вызовы переведены на прямой импорт модуля вместо обращения через \`window\`. \`window.loadFacts\` остаётся для onclick-обработчиков в \`plan.html\`.

## CI Checks

- [x] \`npm run type-check\` — passed
- [x] Pre-commit hooks (console.log + type-check) — passed
- [ ] CI/CD pipeline

## Runtime Checklist

> Проверить на https://fbd.ikeniborn.ru/plan после деплоя

### Создание записи
- [ ] Открыть модал создания → заполнить форму → сохранить
- [ ] Таблица фактов обновляется (новая запись появляется)
- [ ] В консоли нет \`ReferenceError: loadFacts is not defined\`

### Редактирование записи
- [ ] Открыть модал редактирования → изменить поле → сохранить
- [ ] Таблица фактов обновляется (изменения видны)
- [ ] В консоли нет \`ReferenceError: loadFacts is not defined\`

### Удаление записи
- [ ] Удалить одиночную запись (кнопка удаления в строке)
- [ ] Таблица фактов обновляется (запись исчезает)
- [ ] В консоли нет \`ReferenceError: loadFacts is not defined\`

### Batch-операции
- [ ] Выбрать несколько записей → batch delete → таблица обновляется
- [ ] Удаление регулярных планов → таблица обновляется

🤖 Generated with [Claude Code](https://claude.com/claude-code)