### PR TITLE
fix(modal-plan): fix operation type caching — categories not filtered on reopen

### DIFF
--- a/frontend/web/static/js/dashboard/features/modalPlan/index.ts
+++ b/frontend/web/static/js/dashboard/features/modalPlan/index.ts
@@ -125,9 +125,14 @@ async function loadTransactionTabData(): Promise<void> {
       throw new Error('Article select element not available');
     }
 
-    // Get current plan type (expense/income)
+    // Get current plan type: prefer CSS active button state (persists across form.reset()),
+    // fall back to radio value, then default to 'expense'
+    const activeBtn = document.querySelector('#modal_plan-tab-transaction .transaction-type-btn.btn-active') as HTMLElement | null;
     const typeInput = document.querySelector('#modal_plan-tab-transaction input[name="plan_type"]:checked') as HTMLInputElement | null;
-    const planType = typeInput?.value || 'expense';
+    const planType = (activeBtn?.dataset.type as 'expense' | 'income') || typeInput?.value || 'expense';
+    // Sync radio to match CSS state (form.reset() resets radio but not CSS button classes)
+    const radioToSync = document.querySelector(`#modal_plan-tab-transaction input[name="plan_type"][value="${planType}"]`) as HTMLInputElement | null;
+    if (radioToSync) radioToSync.checked = true;
 
     if ((window as any).BudgetShared?.ChoicesCategoryTree) {
       const planCategoryTree = new (window as any).BudgetShared.ChoicesCategoryTree(


### PR DESCRIPTION
## Summary
- Fixes bug where reopening plan modal shows cached type (e.g. "Income") but account selection shows expense categories
- Root cause: `form.reset()` resets radio buttons but not CSS classes on type toggle buttons; tree was created with radio value ('expense') instead of the visually shown type
- Fix: read type from `.transaction-type-btn.btn-active` CSS state first, sync radio to match

## Affected file
`frontend/web/static/js/dashboard/features/modalPlan/index.ts` — `loadTransactionTabData()`

## Test plan
- [ ] Open plan modal → select "Income" → select account → verify income categories shown
- [ ] Close → reopen → select account → verify income categories still shown (not expense)
- [ ] `npm run type-check` ✅
- [ ] `npm run bundle` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)