### PR TITLE
fix(modal-fact): fix operation type caching — wrong categories on account select after reopen

### DIFF
--- a/frontend/web/static/js/dashboard/features/addTransaction/categoryLoader.ts
+++ b/frontend/web/static/js/dashboard/features/addTransaction/categoryLoader.ts
@@ -42,9 +42,16 @@ export async function loadTransactionCategories(): Promise<void> {
       return;
     }
 
-    // Get current transaction type
+    // Get current transaction type: prefer CSS active button state (persists across form.reset()),
+    // fall back to radio value, then default to 'expense'
+    const activeBtn = document.querySelector('#modal_fact-tab-transaction .transaction-type-btn.btn-active') as HTMLElement | null;
     const typeInput = document.querySelector('#modal_fact-tab-transaction input[name="record_type"]:checked') as HTMLInputElement | null;
-    const transactionType = typeInput?.value || 'expense';
+    const transactionType = (activeBtn?.dataset.type as 'expense' | 'income') || typeInput?.value || 'expense';
+    // Sync radio and hidden fact_type to match CSS state (form.reset() resets these but not CSS)
+    const radioToSync = document.querySelector(`#modal_fact-tab-transaction input[name="record_type"][value="${transactionType}"]`) as HTMLInputElement | null;
+    if (radioToSync) radioToSync.checked = true;
+    const hiddenFactType = document.querySelector('#modal_fact-tab-transaction input[name="fact_type"]') as HTMLInputElement | null;
+    if (hiddenFactType) hiddenFactType.value = transactionType;
 
     const state = getState();
 

--- a/frontend/web/static/js/dashboard/features/modalFact/typeToggle.ts
+++ b/frontend/web/static/js/dashboard/features/modalFact/typeToggle.ts
@@ -22,7 +22,9 @@ export function setupTransactionTypeToggle(): void {
   );
 
   typeButtons.forEach((button) => {
-    // Add click listener to label
+    // Guard: prevent duplicate listeners on modal re-open
+    if (button.dataset.toggleListenerAttached === 'true') return;
+
     button.addEventListener('click', (e) => {
       e.preventDefault(); // Prevent default label behavior
 
@@ -37,6 +39,8 @@ export function setupTransactionTypeToggle(): void {
 
       debugLog('[TypeToggle] Transaction type changed to:', type);
     });
+
+    button.dataset.toggleListenerAttached = 'true';
   });
 
   debugLog('[TypeToggle] Transaction type toggle listeners setup');

--- a/frontend/web/static/js/dashboard/features/modalPlan/typeToggle.ts
+++ b/frontend/web/static/js/dashboard/features/modalPlan/typeToggle.ts
@@ -22,7 +22,9 @@ export function setupPlanTypeToggle(): void {
   );
 
   typeButtons.forEach((button) => {
-    // Add click listener to label
+    // Guard: prevent duplicate listeners on modal re-open
+    if (button.dataset.toggleListenerAttached === 'true') return;
+
     button.addEventListener('click', (e) => {
       e.preventDefault(); // Prevent default label behavior
 
@@ -37,6 +39,8 @@ export function setupPlanTypeToggle(): void {
 
       debugLog('[TypeToggle Plan] Plan type changed to:', type);
     });
+
+    button.dataset.toggleListenerAttached = 'true';
   });
 
   debugLog('[TypeToggle Plan] Plan type toggle listeners setup');

--- a/frontend/web/static/js/facts/features/modalFact/categoryWidget.ts
+++ b/frontend/web/static/js/facts/features/modalFact/categoryWidget.ts
@@ -43,11 +43,21 @@ export function initTransactionCategoryTree(): void {
     const articleSelect = document.querySelector(TRANSACTION_ARTICLE_SELECTOR);
     if (!articleSelect) return;
 
-    // Read current type from record_type radio (matches dashboard convention)
+    // Get current type: prefer CSS active button state (persists across form.reset()),
+    // fall back to radio value, then default to 'expense'
+    const activeBtn = document.querySelector(
+        '#modal_fact-tab-transaction .transaction-type-btn.btn-active'
+    ) as HTMLElement | null;
     const typeInput = document.querySelector(
         '#modal_fact-tab-transaction input[name="record_type"]:checked'
     ) as HTMLInputElement | null;
-    const currentType = typeInput?.value || 'expense';
+    const currentType = (activeBtn?.dataset.type as 'expense' | 'income') || typeInput?.value || 'expense';
+    // Sync radio and hidden fact_type to match CSS state (form.reset() resets these but not CSS)
+    const radioToSync = document.querySelector(
+        `#modal_fact-tab-transaction input[name="record_type"][value="${currentType}"]`
+    ) as HTMLInputElement | null;
+    if (radioToSync) radioToSync.checked = true;
+    syncFactTypeHidden(currentType);
 
     const prev = getCreateCategoryTreeSelect();
     if (prev) {


### PR DESCRIPTION
## Summary
- Fixes bug where reopening fact/plan modals shows cached type (e.g. "Income") but account selection shows expense categories
- Root cause: `form.reset()` resets radio buttons but not CSS classes; category trees were created with wrong type on reopen
- Fix applied in 4 files: `categoryLoader.ts`, `categoryWidget.ts` (facts page), `modalFact/typeToggle.ts`, `modalPlan/typeToggle.ts`

## Changes
| File | Change |
|------|--------|
| `categoryLoader.ts` | Read type from `.btn-active` CSS state; sync radio + hidden `fact_type` |
| `categoryWidget.ts` (facts page) | Same fix in `initTransactionCategoryTree()` |
| `modalFact/typeToggle.ts` | Guard to prevent duplicate listener registration on re-open |
| `modalPlan/typeToggle.ts` | Same guard for plan type toggle |

## Test plan
- [ ] Open fact modal → select "Income" → select account → verify income categories shown
- [ ] Close → reopen → select account → verify income categories still shown
- [ ] Same for plan modal on `/plan` page
- [ ] `npm run type-check` ✅
- [ ] `npm run bundle` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)