### PR TITLE
fix(pwa): prevent duplicate version display in SW update modal

### DIFF
--- a/frontend/web/templates/components/sw_update_modal.html
+++ b/frontend/web/templates/components/sw_update_modal.html
@@ -28,8 +28,8 @@
             <div id="sw-version-info" class="mb-3 p-3 bg-base-200 rounded-lg">
                 <div class="flex flex-wrap items-center justify-center gap-2 text-sm">
                     <span class="opacity-70 whitespace-nowrap">Версия:</span>
-                    <span id="sw-current-version" class="badge badge-ghost badge-sm font-mono break-all">(неизвестно)</span>
-                    <span class="opacity-70">→</span>
+                    <span id="sw-current-version" class="badge badge-ghost badge-sm font-mono break-all hidden"></span>
+                    <span id="sw-version-arrow" class="opacity-70 hidden">→</span>
                     <span id="sw-new-version" class="badge badge-warning badge-sm font-mono break-all">(неизвестно)</span>
                 </div>
             </div>

--- a/frontend/web/templates/scripts/service-worker-registration.html
+++ b/frontend/web/templates/scripts/service-worker-registration.html
@@ -639,8 +639,7 @@
 
             navigator.serviceWorker.register('/sw.min.js')
                 .then(async (registration) => {
-                    // Save current SW version on load
-                    // Skip if update already pending — prevents overwriting old version with new (avoids X → X display)
+                    // Save current SW version on load; skip if update pending (avoids X → X display)
                     if (navigator.serviceWorker.controller) {
                         const updatePending = localStorage.getItem(SW_UPDATE_AVAILABLE_KEY) === 'true';
                         if (!updatePending) {

--- a/frontend/web/templates/scripts/service-worker-registration.html
+++ b/frontend/web/templates/scripts/service-worker-registration.html
@@ -434,6 +434,7 @@
 
             const currentElem = document.getElementById('sw-current-version');
             const newElem = document.getElementById('sw-new-version');
+            const arrowElem = document.getElementById('sw-version-arrow');
 
             // Defensive check: Ensure DOM elements exist
             if (!currentElem || !newElem) {
@@ -442,22 +443,26 @@
                 return;
             }
 
-            // Display current version with fallback
-            const currentText = currentVersion || '(неизвестно)';
-            currentElem.textContent = currentText;
-
-            // Display new version with fallback
+            // Display new version (always shown)
             const newText = newVersion || '(неизвестно)';
             newElem.textContent = newText;
 
-            // Log version transition for debugging
-            if (currentVersion && newVersion) {
-            } else if (!currentVersion && newVersion) {
-                console.warn('[SW_UPDATE] ⚠️ Current version missing (first install or localStorage cleared)');
-            } else if (currentVersion && !newVersion) {
-                console.error('[SW_UPDATE] ❌ ERROR: New version missing from localStorage (should not happen)');
+            // Show current version and arrow only when version is known and different
+            const hasTransition = currentVersion && currentVersion !== newVersion;
+            if (hasTransition) {
+                currentElem.textContent = currentVersion;
+                currentElem.classList.remove('hidden');
+                if (arrowElem) arrowElem.classList.remove('hidden');
             } else {
-                console.error('[SW_UPDATE] ❌ ERROR: Both versions missing from localStorage');
+                currentElem.classList.add('hidden');
+                if (arrowElem) arrowElem.classList.add('hidden');
+                if (!currentVersion) {
+                    console.warn('[SW_UPDATE] ⚠️ Current version missing (first install or localStorage cleared)');
+                }
+            }
+
+            if (!newVersion) {
+                console.error('[SW_UPDATE] ❌ ERROR: New version missing from localStorage (should not happen)');
             }
         }
 
@@ -634,12 +639,16 @@
             navigator.serviceWorker.register('/sw.min.js')
                 .then(async (registration) => {
                     // Сохраняем текущую версию SW при загрузке
+                    // Не перезаписываем если уже есть ожидающее обновление (предотвращает показ X → X)
                     if (navigator.serviceWorker.controller) {
-                        const currentVersion = await getSWVersion(navigator.serviceWorker.controller);
-                        if (currentVersion) {
-                            localStorage.setItem(SW_VERSION_KEY, currentVersion);
-                        } else {
-                            console.warn('[PWA] ⚠️ Failed to get current CACHE_VERSION');
+                        const updatePending = localStorage.getItem(SW_UPDATE_AVAILABLE_KEY) === 'true';
+                        if (!updatePending) {
+                            const currentVersion = await getSWVersion(navigator.serviceWorker.controller);
+                            if (currentVersion) {
+                                localStorage.setItem(SW_VERSION_KEY, currentVersion);
+                            } else {
+                                console.warn('[PWA] ⚠️ Failed to get current CACHE_VERSION');
+                            }
                         }
                     }
 

--- a/frontend/web/templates/scripts/service-worker-registration.html
+++ b/frontend/web/templates/scripts/service-worker-registration.html
@@ -437,7 +437,7 @@
             const arrowElem = document.getElementById('sw-version-arrow');
 
             // Defensive check: Ensure DOM elements exist
-            if (!currentElem || !newElem) {
+            if (!currentElem || !newElem || !arrowElem) {
                 console.warn('[SW_UPDATE] ⚠️ Version display elements not found in modal DOM');
                 console.warn('[SW_UPDATE] Modal will show without version information');
                 return;
@@ -452,10 +452,11 @@
             if (hasTransition) {
                 currentElem.textContent = currentVersion;
                 currentElem.classList.remove('hidden');
-                if (arrowElem) arrowElem.classList.remove('hidden');
+                arrowElem.classList.remove('hidden');
             } else {
+                currentElem.textContent = '';
                 currentElem.classList.add('hidden');
-                if (arrowElem) arrowElem.classList.add('hidden');
+                arrowElem.classList.add('hidden');
                 if (!currentVersion) {
                     console.warn('[SW_UPDATE] ⚠️ Current version missing (first install or localStorage cleared)');
                 }
@@ -638,8 +639,8 @@
 
             navigator.serviceWorker.register('/sw.min.js')
                 .then(async (registration) => {
-                    // Сохраняем текущую версию SW при загрузке
-                    // Не перезаписываем если уже есть ожидающее обновление (предотвращает показ X → X)
+                    // Save current SW version on load
+                    // Skip if update already pending — prevents overwriting old version with new (avoids X → X display)
                     if (navigator.serviceWorker.controller) {
                         const updatePending = localStorage.getItem(SW_UPDATE_AVAILABLE_KEY) === 'true';
                         if (!updatePending) {


### PR DESCRIPTION
## Summary

- Guard `SW_VERSION_KEY` write at page load behind `updatePending` check — prevents the new SW controller from overwriting the stored old version when the user navigates between pages after update detection (root cause of X → X display)
- Hide `#sw-current-version` and `#sw-version-arrow` when versions are identical or current version is unknown; only show transition when both versions are known and different
- Both elements start `hidden` in HTML to prevent flash of stale `(неизвестно)` text

Replaces #459 (had merge conflicts with test branch).

## Test plan

- [ ] Simulate bug: set `pwa_update_available=true`, `pwa_new_version=0.6.76`, `pwa_sw_version=0.6.76` in localStorage → modal shows only `Версия: 0.6.76` (no arrow)
- [ ] Normal update: old version known and different → modal shows `Версия: 0.6.75 → 0.6.76`
- [ ] Missing old version: `pwa_sw_version` absent → modal shows only `Версия: 0.6.76`

🤖 Generated with [Claude Code](https://claude.com/claude-code)