### PR TITLE
fix(facts): fix modal form bugs — date buttons, form validation, same-account transfer

### DIFF
--- a/frontend/web/static/js/facts/adapters/windowExports.ts
+++ b/frontend/web/static/js/facts/adapters/windowExports.ts
@@ -27,6 +27,8 @@ import {
 import { setFactDate as setFactDateAction, setFactTransferDate as setFactTransferDateAction } from '../index';
 import { initTransferCategoryTrees } from '../features/modalFact/categoryWidget';
 import { setButtonLoading } from '../../dashboard/shared/utils/buttonState';
+import { parseIntOrNull } from '../../dashboard/shared/utils/apiHelpers';
+import { getFilters, getPagination, getSelectedIds } from '../core/stateManager';
 
 // Window interface declarations are in:
 // - facts/types/globals.d.ts (facts-specific functions)
@@ -74,9 +76,9 @@ export function setupWindowExports(): void {
         showEditModal: (id: number) => showEditModal(id),
         deleteFact: (id: number) => deleteFact(id),
         toggleSelectAll: (checkbox: HTMLInputElement) => toggleSelectAll(checkbox),
-        getFilters: () => ({}),
-        getPagination: () => ({}),
-        getSelectedIds: () => new Set<number>(),
+        getFilters,
+        getPagination,
+        getSelectedIds,
     };
 
     // Transaction operations (delegated to external modules when available)
@@ -538,8 +540,17 @@ async function saveFactModalFacts(button: HTMLElement): Promise<void> {
     // Set button loading state
     setButtonLoading(button, true);
 
-    // Validate form before save
-    if (!form.checkValidity()) {
+    // Validate active tab only — inactive tab fields are hidden and must not block submission
+    const inactiveTabName = activeTab === 'transfer' ? 'transaction' : 'transfer';
+    const inactiveContainer = form.querySelector<HTMLElement>(`[data-tab="${inactiveTabName}"]`);
+    const inactiveRequired = inactiveContainer
+        ? Array.from(inactiveContainer.querySelectorAll<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>('[required]'))
+        : [];
+    inactiveRequired.forEach(f => { f.required = false; });
+    const isValid = form.checkValidity();
+    inactiveRequired.forEach(f => { f.required = true; });
+
+    if (!isValid) {
         setButtonLoading(button, false);
         form.reportValidity();
         if (typeof (window as any).showToast === 'function') {
@@ -561,12 +572,6 @@ async function saveFactModalFacts(button: HTMLElement): Promise<void> {
             const apiDate = BudgetShared?.DateFormatter.formatForAPI(displayDate);
             if (!apiDate) throw new Error('Failed to convert date to API format');
 
-            const parseIntOrNull = (v: FormDataEntryValue | null): number | null => {
-                if (!v) return null;
-                const n = parseInt(v as string);
-                return isNaN(n) ? null : n;
-            };
-
             const data = {
                 record_type: 'fact',
                 transfer_date: apiDate,
@@ -577,6 +582,18 @@ async function saveFactModalFacts(button: HTMLElement): Promise<void> {
                 amount: parseFloat(amountInput?.value || '0'),
                 description: descriptionInput?.value || null
             };
+
+            // Client-side validation: FROM and TO accounts must differ
+            if (data.from_financial_center_id && data.to_financial_center_id &&
+                data.from_financial_center_id === data.to_financial_center_id) {
+                const toSelect = transferTab?.querySelector<HTMLSelectElement>('select[name="to_financial_center_id"]');
+                if (toSelect) toSelect.value = '';
+                if (typeof (window as any).showToast === 'function') {
+                    (window as any).showToast('Счёт «Откуда» и «Куда» не могут совпадать', 'warning');
+                }
+                setButtonLoading(button, false);
+                return;
+            }
 
             const response = await fetch('/api/v1/transfers', {
                 method: 'POST',

--- a/frontend/web/static/js/facts/index.ts
+++ b/frontend/web/static/js/facts/index.ts
@@ -633,6 +633,20 @@ function setupTransactionTypeListener(modal: HTMLElement): void {
 }
 
 /**
+ * Highlight the quick-date button that corresponds to daysOffset.
+ * Buttons are ordered: index 0 = today (0), 1 = yesterday (-1), 2 = day-before (-2).
+ */
+function updateDateButtonState(tabSelector: string, daysOffset: number): void {
+    const activeIndex = Math.abs(daysOffset);
+    document.querySelectorAll<HTMLButtonElement>(
+        `${tabSelector} .flex.gap-1.mb-1 button`
+    ).forEach((btn, index) => {
+        btn.classList.toggle('btn-active', index === activeIndex);
+        btn.classList.toggle('btn-outline', index !== activeIndex);
+    });
+}
+
+/**
  * Set fact date (relative to today) - for transaction tab
  * Used by onclick buttons in modal_fact transaction tab
  * @param daysOffset - Number of days relative to today (0 = today, -1 = yesterday, etc.)
@@ -657,6 +671,8 @@ export function setFactDate(daysOffset: number): void {
         dateInput.dispatchEvent(new Event('change', { bubbles: true }));
         logger.log(' Transaction date set:', dateStr, '(offset:', daysOffset, ')');
     }
+
+    updateDateButtonState('#modal_fact-tab-transaction', daysOffset);
 }
 
 /**
@@ -684,6 +700,8 @@ export function setFactTransferDate(daysOffset: number): void {
         dateInput.dispatchEvent(new Event('change', { bubbles: true }));
         logger.log(' Transfer date set:', dateStr, '(offset:', daysOffset, ')');
     }
+
+    updateDateButtonState('#modal_fact-tab-transfer', daysOffset);
 }
 
 /**


### PR DESCRIPTION
## Summary

- **Date buttons**: кнопки Сегодня/Вчера/Позавчера теперь подсвечиваются при клике и при открытии модала (`updateDateButtonState` helper)
- **Form validation**: замена наивного `form.checkValidity()` на активно-вкладочную проверку — временно снимаем `required` у полей скрытой вкладки, устраняя ошибки консоли "invalid form control not focusable"
- **Same-account transfer**: client-side проверка до POST; при FROM === TO очищается поле "Куда" и показывается понятный toast

Closes #460, closes #461

## Additional fixes (simplify review)

- `parseIntOrNull` импортируется из shared `apiHelpers` вместо inline closure
- `window.FactsManager.getFilters/getPagination/getSelectedIds` делегируют в реальный `stateManager` вместо стабов

## Test plan

- [ ] Открыть модал — кнопка "Сегодня" подсвечена
- [ ] Кликнуть "Вчера" — подсветка переходит на "Вчера"
- [ ] Вкладка "Перевод": попытаться сохранить с пустыми полями — нет ошибок в консоли, есть toast
- [ ] Выбрать одинаковый счет в FROM и TO, нажать сохранить — toast "Счёт «Откуда» и «Куда» не могут совпадать", поле TO очищается

🤖 Generated with [Claude Code](https://claude.com/claude-code)