### PR TITLE
fix(facts): fix transaction type switching in modal fact form

### DIFF
--- a/frontend/web/static/js/facts/features/modalFact/categoryWidget.ts
+++ b/frontend/web/static/js/facts/features/modalFact/categoryWidget.ts
@@ -49,14 +49,7 @@ export function initTransactionCategoryTree(): void {
         '#modal_fact-tab-transaction input[name="record_type"]:checked'
     ) as HTMLInputElement | null;
     const currentType = (typeInput?.value as 'expense' | 'income') || 'expense';
-    // Sync CSS to match radio state
-    document.querySelectorAll<HTMLElement>(
-        '#modal_fact-tab-transaction .transaction-type-btn'
-    ).forEach(btn => {
-        const isActive = btn.dataset.type === currentType;
-        btn.classList.toggle('btn-active', isActive);
-        btn.classList.toggle('opacity-50', !isActive);
-    });
+    syncTransactionTypeBtnsCSS(currentType);
     syncFactTypeHidden(currentType);
 
     const prev = getCreateCategoryTreeSelect();
@@ -98,11 +91,26 @@ export function initTransactionCategoryTree(): void {
 }
 
 /**
+ * Sync btn-active / opacity-50 CSS on the expense|income type buttons.
+ * Called on modal open (to fix stale CSS after form.reset()) and on type change.
+ */
+function syncTransactionTypeBtnsCSS(type: 'expense' | 'income'): void {
+    document.querySelectorAll<HTMLElement>(
+        '#modal_fact-tab-transaction .transaction-type-btn'
+    ).forEach(btn => {
+        const isActive = btn.dataset.type === type;
+        btn.classList.toggle('btn-active', isActive);
+        btn.classList.toggle('opacity-50', !isActive);
+    });
+}
+
+/**
  * Update ChoicesCategoryTree type when expense/income radio changes.
- * Also syncs the hidden fact_type field.
+ * Also syncs the hidden fact_type field and button CSS state.
  */
 export function updateTransactionCategoryTreeType(type: 'expense' | 'income'): void {
     syncFactTypeHidden(type);
+    syncTransactionTypeBtnsCSS(type);
 
     const instance = getCreateCategoryTreeSelect();
     if (instance?.updateType) {

--- a/frontend/web/static/js/facts/features/modalFact/categoryWidget.ts
+++ b/frontend/web/static/js/facts/features/modalFact/categoryWidget.ts
@@ -43,20 +43,20 @@ export function initTransactionCategoryTree(): void {
     const articleSelect = document.querySelector(TRANSACTION_ARTICLE_SELECTOR);
     if (!articleSelect) return;
 
-    // Get current type: prefer CSS active button state (persists across form.reset()),
-    // fall back to radio value, then default to 'expense'
-    const activeBtn = document.querySelector(
-        '#modal_fact-tab-transaction .transaction-type-btn.btn-active'
-    ) as HTMLElement | null;
+    // Radio is the source of truth (form.reset() correctly resets radio to default).
+    // CSS may be stale after form.reset(), so sync it from the radio state.
     const typeInput = document.querySelector(
         '#modal_fact-tab-transaction input[name="record_type"]:checked'
     ) as HTMLInputElement | null;
-    const currentType = (activeBtn?.dataset.type as 'expense' | 'income') || typeInput?.value || 'expense';
-    // Sync radio and hidden fact_type to match CSS state (form.reset() resets these but not CSS)
-    const radioToSync = document.querySelector(
-        `#modal_fact-tab-transaction input[name="record_type"][value="${currentType}"]`
-    ) as HTMLInputElement | null;
-    if (radioToSync) radioToSync.checked = true;
+    const currentType = (typeInput?.value as 'expense' | 'income') || 'expense';
+    // Sync CSS to match radio state
+    document.querySelectorAll<HTMLElement>(
+        '#modal_fact-tab-transaction .transaction-type-btn'
+    ).forEach(btn => {
+        const isActive = btn.dataset.type === currentType;
+        btn.classList.toggle('btn-active', isActive);
+        btn.classList.toggle('opacity-50', !isActive);
+    });
     syncFactTypeHidden(currentType);
 
     const prev = getCreateCategoryTreeSelect();

--- a/frontend/web/static/js/facts/index.ts
+++ b/frontend/web/static/js/facts/index.ts
@@ -627,7 +627,16 @@ function setupTransactionTypeListener(modal: HTMLElement): void {
     modal.addEventListener('change', (e) => {
         const target = e.target as HTMLInputElement;
         if (target.name === 'record_type' && target.type === 'radio') {
-            updateTransactionCategoryTreeType(target.value as 'expense' | 'income');
+            const newType = target.value as 'expense' | 'income';
+            // Sync CSS on type buttons to match new radio state
+            modal.querySelectorAll<HTMLElement>(
+                '#modal_fact-tab-transaction .transaction-type-btn'
+            ).forEach(btn => {
+                const isActive = btn.dataset.type === newType;
+                btn.classList.toggle('btn-active', isActive);
+                btn.classList.toggle('opacity-50', !isActive);
+            });
+            updateTransactionCategoryTreeType(newType);
         }
     });
 }

--- a/frontend/web/static/js/facts/index.ts
+++ b/frontend/web/static/js/facts/index.ts
@@ -627,16 +627,7 @@ function setupTransactionTypeListener(modal: HTMLElement): void {
     modal.addEventListener('change', (e) => {
         const target = e.target as HTMLInputElement;
         if (target.name === 'record_type' && target.type === 'radio') {
-            const newType = target.value as 'expense' | 'income';
-            // Sync CSS on type buttons to match new radio state
-            modal.querySelectorAll<HTMLElement>(
-                '#modal_fact-tab-transaction .transaction-type-btn'
-            ).forEach(btn => {
-                const isActive = btn.dataset.type === newType;
-                btn.classList.toggle('btn-active', isActive);
-                btn.classList.toggle('opacity-50', !isActive);
-            });
-            updateTransactionCategoryTreeType(newType);
+            updateTransactionCategoryTreeType(target.value as 'expense' | 'income');
         }
     });
 }


### PR DESCRIPTION
## Summary

- **Bug 1**: CSS classes (`btn-active`/`opacity-50`) on transaction type buttons were not updated when radio changed — expense button stayed visually active even after switching to income
- **Bug 2**: `initTransactionCategoryTree()` used CSS `.btn-active` as source of truth, which could be stale after `form.reset()` — switching to radio as canonical source of truth, with CSS synced from it

## Changes

- `frontend/web/static/js/facts/index.ts` — `setupTransactionTypeListener`: sync `btn-active`/`opacity-50` CSS classes on type buttons whenever radio changes
- `frontend/web/static/js/facts/features/modalFact/categoryWidget.ts` — `initTransactionCategoryTree`: read current type from checked radio (not CSS), then sync CSS to match

## Test plan

- [ ] Open `/facts`, click "Add fact" modal
- [ ] Click "Доход" — button becomes active, "Расход" becomes inactive, income categories load
- [ ] Click "Расход" — button becomes active, "Доход" becomes inactive, expense categories load
- [ ] Save a fact, reopen modal — type defaults back to "Расход" with correct CSS and categories

## TypeScript

`npm run type-check` — passes
`npm run bundle` (FORCE_REBUILD) — all 39 bundles built successfully

Generated with [Claude Code](https://claude.com/claude-code)