### PR TITLE
fix(plan): fix infinite spinner in recurring payments section

### DIFF
--- a/frontend/web/static/js/budget/incrementalUpdates.js
+++ b/frontend/web/static/js/budget/incrementalUpdates.js
@@ -499,7 +499,7 @@
             if (window.HTMXWidgets && typeof window.HTMXWidgets.refreshWidget === 'function') {
                 window.HTMXWidgets.refreshWidget(widgetId);
             } else {
-                console.warn('[IncrementalUpdates] HTMXWidgets not available for fallback');
+                console.debug('[IncrementalUpdates] HTMXWidgets not available for fallback');
             }
         },
 

--- a/frontend/web/static/js/dashboard/integration/wsEventHandlers.ts
+++ b/frontend/web/static/js/dashboard/integration/wsEventHandlers.ts
@@ -149,7 +149,7 @@ let _loadRecurringPlansTimer: ReturnType<typeof setTimeout> | null = null;
 function debouncedLoadRecurringPlans(): void {
   if (_loadRecurringPlansTimer) clearTimeout(_loadRecurringPlansTimer);
   _loadRecurringPlansTimer = setTimeout(() => {
-    (window as any).loadRecurringPlans?.();
+    window.loadRecurringPlans?.();
     _loadRecurringPlansTimer = null;
   }, 300);
 }

--- a/frontend/web/static/js/dashboard/integration/wsEventHandlers.ts
+++ b/frontend/web/static/js/dashboard/integration/wsEventHandlers.ts
@@ -154,6 +154,8 @@ function registerPlanHandlers(hasIncrementalUpdates: boolean): void {
     } else {
       refreshQuickStats();
     }
+    // Refresh recurring plans list on plan page
+    (window as any).loadRecurringPlans?.();
   });
 
   window.budgetWSClient.on('plan_updated', (data: FactEventData) => {

--- a/frontend/web/static/js/dashboard/integration/wsEventHandlers.ts
+++ b/frontend/web/static/js/dashboard/integration/wsEventHandlers.ts
@@ -144,6 +144,16 @@ function registerFactHandlers(hasIncrementalUpdates: boolean): void {
 // Plan Event Handlers
 // ============================================================================
 
+let _loadRecurringPlansTimer: ReturnType<typeof setTimeout> | null = null;
+
+function debouncedLoadRecurringPlans(): void {
+  if (_loadRecurringPlansTimer) clearTimeout(_loadRecurringPlansTimer);
+  _loadRecurringPlansTimer = setTimeout(() => {
+    (window as any).loadRecurringPlans?.();
+    _loadRecurringPlansTimer = null;
+  }, 300);
+}
+
 function registerPlanHandlers(hasIncrementalUpdates: boolean): void {
   if (!window.budgetWSClient) return;
 
@@ -154,8 +164,7 @@ function registerPlanHandlers(hasIncrementalUpdates: boolean): void {
     } else {
       refreshQuickStats();
     }
-    // Refresh recurring plans list on plan page
-    (window as any).loadRecurringPlans?.();
+    debouncedLoadRecurringPlans();
   });
 
   window.budgetWSClient.on('plan_updated', (data: FactEventData) => {

--- a/frontend/web/static/js/dashboard/types/globals.d.ts
+++ b/frontend/web/static/js/dashboard/types/globals.d.ts
@@ -242,6 +242,9 @@ declare global {
     updateRecurringPreview?: (modalId: string) => void;
     collectRecurringSettings?: (modalId: string) => RecurringSettings | null;
 
+    // Recurring plans management (plan page)
+    loadRecurringPlans?: () => Promise<void>;
+
     // Edit modal
     openEditModal?: (recordType: 'fact' | 'plan', recordId: number) => Promise<void>;
     openEditPendingRecord?: (pendingId: number, entity: string) => Promise<void>;

--- a/frontend/web/static/js/plan/index.ts
+++ b/frontend/web/static/js/plan/index.ts
@@ -110,7 +110,7 @@ declare global {
  * Called on DOMContentLoaded from inline script
  */
 export async function initialize(): Promise<void> {
-  log.info('Initializing plan page (Phase 2: Complete)...');
+  log.info('Initializing plan page...');
 
   try {
     // Инициализация делегирования событий (data-action вместо inline onclick)
@@ -137,16 +137,19 @@ export async function initialize(): Promise<void> {
     log.debug('Applying initial filters...');
     await applyFiltersAndLoadData();
 
-    // Load analytics
-    log.debug('Loading analytics...');
-    await PlanAnalytics.loadPlanAnalytics();
+    // Load analytics and recurring plans in parallel
+    log.debug('Loading analytics and recurring plans...');
+    await Promise.all([
+      PlanAnalytics.loadPlanAnalytics(),
+      window.loadRecurringPlans?.(),
+    ]);
 
     // Update filter indicator
     PlanFilters.updateFilterIndicator();
 
-    log.info('✅ Plan page initialized successfully');
+    log.info('Plan page initialized successfully');
   } catch (error) {
-    log.error('❌ Error initializing plan page:', error);
+    log.error('Error initializing plan page:', error);
     PlanHelpers.showNotification('Ошибка инициализации страницы: ' + (error as Error).message, 'error');
   }
 }


### PR DESCRIPTION
## Summary

Fixes infinite spinner in "Управление регламентными платежами" section on /plan page.

- **Root cause:** `loadRecurringPlans()` was never called on page initialization — spinner was hardcoded in HTML and only replaced when the function runs
- **Secondary fix:** WebSocket `plan_created` event now triggers debounced reload of recurring plans list (300ms, prevents rapid-fire API calls)
- **Console noise fix:** `console.warn` → `console.debug` in `fallbackRefresh` — HTMXWidgets absence is expected on non-dashboard pages
- **Type safety:** `loadRecurringPlans` declared in `Window` interface (`globals.d.ts`)

## Changes

| File | Change |
|------|--------|
| `plan/index.ts` | Call `loadRecurringPlans()` on init, parallel with `loadPlanAnalytics()` |
| `wsEventHandlers.ts` | Add `debouncedLoadRecurringPlans()` on `plan_created` WS event |
| `incrementalUpdates.js` | `console.warn` → `console.debug` for missing HTMXWidgets |
| `globals.d.ts` | Add `loadRecurringPlans?: () => Promise<void>` to Window interface |

## Test plan
- [ ] Open https://fbd.ikeniborn.ru/plan
- [ ] Expand "Управление регламентными платежами" section — should show table (or empty state), NOT infinite spinner
- [ ] Check browser console — no `[IncrementalUpdates] HTMXWidgets not available` warnings
- [ ] Create a new plan → recurring plans list should auto-refresh after 300ms

Closes #476, #477

🤖 Generated with [Claude Code](https://claude.com/claude-code)