### PR TITLE
feat(frontend): sort categories chart and aggregate overflow into Прочее

### DIFF
--- a/frontend/web/static/js/plan/analytics.ts
+++ b/frontend/web/static/js/plan/analytics.ts
@@ -631,21 +631,60 @@ function buildCategoriesChartConfig(data: MonthlyAnalyticsData): any {
     };
   }
 
-  // Take top 10 categories
-  const topCategories = categories.slice(0, 10);
+  // Sort by current_month_total descending
+  const sorted = [...categories].sort((a, b) => b.current_month_total - a.current_month_total);
+
+  const MAX_VISIBLE = 9;
+  const topCategories = sorted.slice(0, MAX_VISIBLE);
+  const remainingCategories = sorted.slice(MAX_VISIBLE);
+
+  const displayCategories: CategoryComparison[] = [...topCategories];
+  if (remainingCategories.length > 0) {
+    const otherCurrentTotal = remainingCategories.reduce((sum, c) => sum + c.current_month_total, 0);
+    const otherPreviousTotal = remainingCategories.reduce((sum, c) => sum + c.previous_month_total, 0);
+    displayCategories.push({
+      category_id: -1,
+      category_name: 'Прочее',
+      category_type: sorted[0].category_type,
+      current_month_total: otherCurrentTotal,
+      previous_month_total: otherPreviousTotal,
+    });
+  }
+
+  // Pre-compute "Прочее" tooltip breakdown (remainingCategories is stable)
+  const tooltipOthers = remainingCategories.slice(0, MAX_VISIBLE);
+  const tooltipRest = remainingCategories.slice(MAX_VISIBLE);
+  const tooltipRestTotal = tooltipRest.reduce((sum, c) => sum + c.current_month_total, 0);
+
+  const formatter = function(params: any[]) {
+    if (!params || params.length === 0) return '';
+    const isOthers = params[0]?.axisValue === 'Прочее';
+    let result = `<b>${params[0]?.axisValue}</b><br/>`;
+    params.forEach((param: any) => {
+      const value = new Intl.NumberFormat('ru-RU').format(param.value);
+      result += `${param.marker} ${param.seriesName}: ${value} ₽<br/>`;
+    });
+
+    if (isOthers && remainingCategories.length > 0) {
+      result += '<div style="margin-top:6px;border-top:1px solid #e2e8f0;padding-top:4px"><small style="color:#64748b">Состав:</small><br/>';
+      tooltipOthers.forEach((c: CategoryComparison) => {
+        const value = new Intl.NumberFormat('ru-RU').format(c.current_month_total);
+        result += `<small>• ${c.category_name}: ${value} ₽</small><br/>`;
+      });
+      if (tooltipRest.length > 0) {
+        const value = new Intl.NumberFormat('ru-RU').format(tooltipRestTotal);
+        result += `<small>• Прочее: ${value} ₽</small><br/>`;
+      }
+      result += '</div>';
+    }
+    return result;
+  };
 
   return {
     tooltip: {
       trigger: 'axis',
       axisPointer: { type: 'shadow' },
-      formatter: function (params: any[]) {
-        let result = params[0].axisValue + '<br/>';
-        params.forEach(param => {
-          const value = new Intl.NumberFormat('ru-RU').format(param.value);
-          result += `${param.marker} ${param.seriesName}: ${value} ₽<br/>`;
-        });
-        return result;
-      }
+      formatter
     },
     legend: {
       data: [data.previous_month.month_name, data.current_month.month_name],
@@ -660,7 +699,7 @@ function buildCategoriesChartConfig(data: MonthlyAnalyticsData): any {
     },
     xAxis: {
       type: 'category',
-      data: topCategories.map(c => c.category_name),
+      data: displayCategories.map(c => c.category_name),
       axisLabel: {
         rotate: 30,
         interval: 0,
@@ -684,13 +723,13 @@ function buildCategoriesChartConfig(data: MonthlyAnalyticsData): any {
       {
         name: data.previous_month.month_name,
         type: 'bar',
-        data: topCategories.map(c => c.previous_month_total),
+        data: displayCategories.map(c => c.previous_month_total),
         itemStyle: { color: '#94a3b8', opacity: 0.5 }
       },
       {
         name: data.current_month.month_name,
         type: 'bar',
-        data: topCategories.map(c => c.current_month_total),
+        data: displayCategories.map(c => c.current_month_total),
         itemStyle: { color: '#3b82f6' }
       }
     ]

--- a/frontend/web/static/js/plan/analytics.ts
+++ b/frontend/web/static/js/plan/analytics.ts
@@ -54,6 +54,9 @@ export interface CategoryComparison {
   previous_month_total: number;
 }
 
+// Shared number formatter — reused across all chart tooltip formatters
+const numFmt = new Intl.NumberFormat('ru-RU');
+
 // ============================================================================
 // State Management
 // ============================================================================
@@ -530,8 +533,7 @@ function buildComparisonChartConfig(data: MonthlyAnalyticsData): any {
       formatter: function (params: any[]) {
         let result = params[0].axisValue + '<br/>';
         params.forEach(param => {
-          const value = new Intl.NumberFormat('ru-RU').format(param.value);
-          result += `${param.marker} ${param.seriesName}: ${value} ₽<br/>`;
+          result += `${param.marker} ${param.seriesName}: ${numFmt.format(param.value)} ₽<br/>`;
         });
         return result;
       }
@@ -634,13 +636,11 @@ function buildCategoriesChartConfig(data: MonthlyAnalyticsData): any {
   const CHART_MAX_CATEGORIES = 9;
   const TOOLTIP_MAX_DETAIL = 9;
   const OTHER_CATEGORY_NAME = 'Прочее';
-  const numFmt = new Intl.NumberFormat('ru-RU');
 
   const sorted = [...categories].sort((a, b) => b.current_month_total - a.current_month_total);
-  const topCategories = sorted.slice(0, CHART_MAX_CATEGORIES);
   const remainingCategories = sorted.slice(CHART_MAX_CATEGORIES);
 
-  const displayCategories: CategoryComparison[] = [...topCategories];
+  const displayCategories: CategoryComparison[] = sorted.slice(0, CHART_MAX_CATEGORIES);
   if (remainingCategories.length > 0) {
     const { current: otherCurrentTotal, previous: otherPreviousTotal } = remainingCategories.reduce(
       (acc, c) => ({ current: acc.current + c.current_month_total, previous: acc.previous + c.previous_month_total }),
@@ -667,7 +667,7 @@ function buildCategoriesChartConfig(data: MonthlyAnalyticsData): any {
       result += `${param.marker} ${param.seriesName}: ${numFmt.format(param.value)} ₽<br/>`;
     });
 
-    if (isOthers && remainingCategories.length > 0) {
+    if (isOthers) {
       result += '<div style="margin-top:6px;border-top:1px solid #e2e8f0;padding-top:4px"><small style="color:#64748b">Состав:</small><br/>';
       tooltipOthers.forEach((c: CategoryComparison) => {
         result += `<small>• ${c.category_name}: ${numFmt.format(c.current_month_total)} ₽</small><br/>`;

--- a/frontend/web/static/js/plan/analytics.ts
+++ b/frontend/web/static/js/plan/analytics.ts
@@ -631,49 +631,49 @@ function buildCategoriesChartConfig(data: MonthlyAnalyticsData): any {
     };
   }
 
-  // Sort by current_month_total descending
-  const sorted = [...categories].sort((a, b) => b.current_month_total - a.current_month_total);
+  const CHART_MAX_CATEGORIES = 9;
+  const TOOLTIP_MAX_DETAIL = 9;
+  const OTHER_CATEGORY_NAME = 'Прочее';
+  const numFmt = new Intl.NumberFormat('ru-RU');
 
-  const MAX_VISIBLE = 9;
-  const topCategories = sorted.slice(0, MAX_VISIBLE);
-  const remainingCategories = sorted.slice(MAX_VISIBLE);
+  const sorted = [...categories].sort((a, b) => b.current_month_total - a.current_month_total);
+  const topCategories = sorted.slice(0, CHART_MAX_CATEGORIES);
+  const remainingCategories = sorted.slice(CHART_MAX_CATEGORIES);
 
   const displayCategories: CategoryComparison[] = [...topCategories];
   if (remainingCategories.length > 0) {
-    const otherCurrentTotal = remainingCategories.reduce((sum, c) => sum + c.current_month_total, 0);
-    const otherPreviousTotal = remainingCategories.reduce((sum, c) => sum + c.previous_month_total, 0);
+    const { current: otherCurrentTotal, previous: otherPreviousTotal } = remainingCategories.reduce(
+      (acc, c) => ({ current: acc.current + c.current_month_total, previous: acc.previous + c.previous_month_total }),
+      { current: 0, previous: 0 }
+    );
     displayCategories.push({
       category_id: -1,
-      category_name: 'Прочее',
+      category_name: OTHER_CATEGORY_NAME,
       category_type: sorted[0].category_type,
       current_month_total: otherCurrentTotal,
       previous_month_total: otherPreviousTotal,
     });
   }
 
-  // Pre-compute "Прочее" tooltip breakdown (remainingCategories is stable)
-  const tooltipOthers = remainingCategories.slice(0, MAX_VISIBLE);
-  const tooltipRest = remainingCategories.slice(MAX_VISIBLE);
+  const tooltipOthers = remainingCategories.slice(0, TOOLTIP_MAX_DETAIL);
+  const tooltipRest = remainingCategories.slice(TOOLTIP_MAX_DETAIL);
   const tooltipRestTotal = tooltipRest.reduce((sum, c) => sum + c.current_month_total, 0);
 
   const formatter = function(params: any[]) {
     if (!params || params.length === 0) return '';
-    const isOthers = params[0]?.axisValue === 'Прочее';
+    const isOthers = params[0]?.axisValue === OTHER_CATEGORY_NAME;
     let result = `<b>${params[0]?.axisValue}</b><br/>`;
     params.forEach((param: any) => {
-      const value = new Intl.NumberFormat('ru-RU').format(param.value);
-      result += `${param.marker} ${param.seriesName}: ${value} ₽<br/>`;
+      result += `${param.marker} ${param.seriesName}: ${numFmt.format(param.value)} ₽<br/>`;
     });
 
     if (isOthers && remainingCategories.length > 0) {
       result += '<div style="margin-top:6px;border-top:1px solid #e2e8f0;padding-top:4px"><small style="color:#64748b">Состав:</small><br/>';
       tooltipOthers.forEach((c: CategoryComparison) => {
-        const value = new Intl.NumberFormat('ru-RU').format(c.current_month_total);
-        result += `<small>• ${c.category_name}: ${value} ₽</small><br/>`;
+        result += `<small>• ${c.category_name}: ${numFmt.format(c.current_month_total)} ₽</small><br/>`;
       });
       if (tooltipRest.length > 0) {
-        const value = new Intl.NumberFormat('ru-RU').format(tooltipRestTotal);
-        result += `<small>• Прочее: ${value} ₽</small><br/>`;
+        result += `<small>• ${OTHER_CATEGORY_NAME}: ${numFmt.format(tooltipRestTotal)} ₽</small><br/>`;
       }
       result += '</div>';
     }


### PR DESCRIPTION
## Summary

- Sort categories chart by `current_month_total` descending, show top 9, aggregate the rest into a dynamic 10th bar "Прочее"
- Tooltip for "Прочее" shows breakdown: up to 9 sub-categories sorted by amount, with nested "Прочее" if more than 9 remain
- Extract `CHART_MAX_CATEGORIES`, `TOOLTIP_MAX_DETAIL`, `OTHER_CATEGORY_NAME` constants
- Hoist `Intl.NumberFormat` instance to module scope (shared across both chart tooltip formatters)
- Single `reduce` pass to compute both totals

## Test plan

- [ ] Navigate to `/plan` → analytics section → category chart shows max 10 bars
- [ ] If > 9 categories, last bar is "Прочее" with aggregated sum
- [ ] Hover "Прочее" → tooltip shows sub-categories sorted largest to smallest
- [ ] Hover any other bar → tooltip works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)