### PR TITLE
fix(dashboard): reset reminder/recurring section visibility on modal close

### DIFF
--- a/frontend/web/static/js/dashboard/features/modalPlan/index.ts
+++ b/frontend/web/static/js/dashboard/features/modalPlan/index.ts
@@ -8,7 +8,7 @@
 import { setupTabListeners, clearTabCache, switchTab } from './tabManager';
 import { getState, updateState } from '../../core/DashboardState';
 import './dateHelpers'; // Import for side effects (window exports)
-import { setupRecurringListeners } from './recurringSettings';
+import { setupRecurringListeners, togglePlanMode } from './recurringSettings';
 import { setupPlanTypeToggle } from './typeToggle';
 import { setupPlanPeriodButtons, setupTransferPeriodButtons } from '../addPlan/periodButtons'; // v10.1.51: Period buttons setup
 import { setupModalKeyboardShortcuts } from '../../shared/utils/keyboardShortcuts';
@@ -574,6 +574,12 @@ export function closeModalPlan(): void {
   // Clear form
   const form = document.getElementById('form_modal_plan') as HTMLFormElement;
   form?.reset();
+
+  // Reset plan mode sections visibility (form.reset() restores radio to "regular"
+  // but does not affect CSS classes on the panel sections)
+  if (form) {
+    togglePlanMode('modal_plan');
+  }
 
   // Destroy ChoicesCategoryTree instances so next open starts fresh
   // Prevents "Choices already initialised" double-init error on re-open


### PR DESCRIPTION
## Summary
- After saving a plan with reminder/recurring mode, closing and reopening the modal now correctly hides the reminder/recurring sections when "regular plan" mode is selected
- Fixes: `closeModalPlan()` now calls `togglePlanMode('modal_plan')` after `form.reset()` to reset CSS visibility of panel sections

Closes #481 (cherry-pick onto current test)