### PR TITLE
fix(dashboard): align recurring plan API fields and add separate reminder creation

### DIFF
--- a/frontend/web/static/js/dashboard/features/modalPlan/recurringSettings.ts
+++ b/frontend/web/static/js/dashboard/features/modalPlan/recurringSettings.ts
@@ -301,35 +301,15 @@ export function extractRecurringSettings(form: HTMLFormElement): any {
     frequencyValue = parseInt(monthdayValue); // Day of month (1-28)
   }
 
-  // Determine months_count based on duration
-  let monthsCount: number | null = null;
-  if (durationType === 'count' && occurrencesCount) {
-    const count = parseInt(occurrencesCount);
-    // Convert occurrences to months based on frequency
-    if (frequencyType === 'monthly') {
-      monthsCount = count; // 1 occurrence = 1 month
-    } else if (frequencyType === 'quarterly') {
-      monthsCount = count * 3; // 1 occurrence = 3 months
-    } else if (frequencyType === 'yearly') {
-      monthsCount = count * 12; // 1 occurrence = 12 months
-    }
-  } else if (durationType === 'end_date' && endDate) {
-    // Calculate months from start_month to end_date
-    // This requires start_month to be set
-    // For now, set to large number (backend will calculate)
-    monthsCount = 999; // Backend will calculate actual count
-  }
-
   return {
     frequency_type: frequencyType,
     frequency_value: frequencyValue,
-    months_count: monthsCount,
-    is_active: true,
+    occurrences_count: durationType === 'count' && occurrencesCount ? parseInt(occurrencesCount) : null,
+    end_date: durationType === 'end_date' && endDate ? endDate : null,
     // Reminder settings (if enabled)
     enable_reminder: enableReminder || false,
-    reminder_time: enableReminder && reminderHour && reminderMinute
-      ? `${reminderHour}:${reminderMinute}`
-      : null
+    reminder_hour: enableReminder && reminderHour ? parseInt(reminderHour) : null,
+    reminder_minute: enableReminder && reminderMinute ? parseInt(reminderMinute) : null,
   };
 }
 

--- a/frontend/web/static/js/dashboard/features/modalPlan/saveTransaction.ts
+++ b/frontend/web/static/js/dashboard/features/modalPlan/saveTransaction.ts
@@ -25,8 +25,7 @@ export async function savePlanTransaction(form: HTMLFormElement): Promise<void> 
   if (recurringSettings) {
     // Recurring plan
     planData = {
-      record_type: 'plan', // Always 'plan' for budget plans
-      plan_month: formData.get('plan_month'), // YYYY-MM (start month)
+      record_type: 'plan',
       financial_center_id: parseIntOrNull(formData.get('financial_center_id'))!,
       article_id: parseIntOrNull(formData.get('article_id'))!,
       cost_center_id: parseIntOrNull(formData.get('cost_center_id')),
@@ -35,35 +34,25 @@ export async function savePlanTransaction(form: HTMLFormElement): Promise<void> 
       // Recurring settings
       frequency_type: recurringSettings.frequency_type,
       frequency_value: recurringSettings.frequency_value,
-      months_count: recurringSettings.months_count,
-      start_month: formData.get('plan_month'), // YYYY-MM
-      is_active: recurringSettings.is_active,
+      start_date: (formData.get('plan_month') as string) + '-01', // YYYY-MM-DD
+      occurrences_count: recurringSettings.occurrences_count,
+      end_date: recurringSettings.end_date,
       // Reminder (optional)
       enable_reminder: recurringSettings.enable_reminder,
-      reminder_time: recurringSettings.reminder_time
+      reminder_hour: recurringSettings.reminder_hour,
+      reminder_minute: recurringSettings.reminder_minute,
     };
   } else {
     // One-time plan (regular or reminder mode)
     planData = {
-      record_type: 'plan', // Always 'plan' for budget plans
-      fact_date: formData.get('plan_month') + '-01', // Convert YYYY-MM → YYYY-MM-01 for FactCreate schema
+      record_type: 'plan',
+      fact_date: (formData.get('plan_month') as string) + '-01', // Convert YYYY-MM → YYYY-MM-01 for FactCreate schema
       financial_center_id: parseIntOrNull(formData.get('financial_center_id'))!,
       article_id: parseIntOrNull(formData.get('article_id'))!,
       cost_center_id: parseIntOrNull(formData.get('cost_center_id')),
       amount: parseFloat(formData.get('amount') as string),
       description: formData.get('description') || null,
-      // One-time plan settings
-      frequency_type: 'monthly',
-      frequency_value: null,
-      months_count: 1,
-      start_month: formData.get('plan_month'), // YYYY-MM
-      is_active: true
     };
-
-    // Add reminder if reminder mode
-    if (reminderSettings) {
-      planData.reminder_datetime = reminderSettings.reminder_datetime;
-    }
   }
 
   // POST to appropriate endpoint based on plan mode
@@ -90,6 +79,15 @@ export async function savePlanTransaction(form: HTMLFormElement): Promise<void> 
     // One-time plan (regular/reminder) → /api/v1/facts
     const responseData = await postAPI<any>('/api/v1/facts', planData, 'SavePlanModal');
 
+    // Create reminder if in reminder mode (separate API call)
+    if (reminderSettings) {
+      await postAPI(
+        `/api/v1/reminders/${responseData.id}`,
+        { reminder_datetime: reminderSettings.reminder_datetime },
+        'SavePlanModal'
+      );
+    }
+
     // Write one-time plan to Dexie immediately
     if (isDexieActive()) {
       try {
@@ -106,4 +104,9 @@ export async function savePlanTransaction(form: HTMLFormElement): Promise<void> 
 
   // Update UI
   await refreshUIAfterPlanSave();
+
+  // Refresh recent records to show updated has_reminder state
+  if (typeof (window as any).loadRecentTransactions === 'function') {
+    await (window as any).loadRecentTransactions();
+  }
 }


### PR DESCRIPTION
## Summary
- Fix 422 error: recurring plan now sends `start_date` (YYYY-MM-DD) instead of `start_month`, `occurrences_count` instead of `months_count`, separate `reminder_hour`/`reminder_minute` integers instead of `reminder_time` string
- Fix 🔔 icon: one-time plan with reminder now creates the reminder via separate POST `/api/v1/reminders/{fact_id}` after fact creation, then reloads recent transactions table to show updated `has_reminder` state

Closes #482 (cherry-pick onto current test)