### PR TITLE
fix(deploy): wait for nginx healthcheck after SSL restart

### DIFF
--- a/scripts/lib/ssl.sh
+++ b/scripts/lib/ssl.sh
@@ -91,7 +91,7 @@ setup_ssl_certificates() {
             if compose_cmd ps -q nginx > /dev/null 2>&1; then
                 info "Restarting nginx to pick up certificate..."
                 compose_cmd restart nginx >> "$LOG_FILE" 2>&1 || true
-                sleep 3
+                wait_for_service nginx 60
             fi
             success "SSL certificate valid for $domain - no changes needed"
             return 0
@@ -115,11 +115,11 @@ setup_ssl_certificates() {
         if ! compose_cmd ps -q nginx >/dev/null 2>&1; then
             info "Starting nginx..."
             compose_cmd start nginx >> "$LOG_FILE" 2>&1 || true
-            sleep 5
+            wait_for_service nginx 60
         else
             info "Restarting nginx to pick up new SSL certificate..."
             compose_cmd restart nginx >> "$LOG_FILE" 2>&1 || true
-            sleep 5
+            wait_for_service nginx 60
         fi
 
         success "SSL certificate setup completed!"


### PR DESCRIPTION
## Summary
- Заменил `sleep 3`/`sleep 5` на `wait_for_service nginx 60` в `scripts/lib/ssl.sh`
- После `compose restart nginx` контейнер переходит в `health: starting`, что занимает дольше фиксированного sleep
- `verify_all_services` запускался до завершения healthcheck nginx → ложно помечал nginx unhealthy → деплой падал с ошибкой

**Лог ошибки:**
```
⚠ nginx: starting
Summary: 4 healthy, 1 unhealthy
[ERROR] Deployment completed with errors. 1 service(s) are unhealthy.
```

## Root Cause
В `verify_ssl()` после `compose_cmd restart nginx` стоял `sleep 3` (или `sleep 5`). Nginx healthcheck занимает ~10+ секунд. `verify_all_services` сразу после SSL-верификации видел nginx в состоянии `starting` и считал его unhealthy.

## Fix
Используем `wait_for_service nginx 60` — та же функция, что используется везде в деплое, корректно ждёт перехода в `healthy`.

## Test plan
- [ ] Запустить деплой на test-сервер и убедиться что `verify_all_services` проходит после SSL restart nginx
- [ ] Все 5 сервисов показываются как healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)