### PR TITLE
fix(facts): fix stats section always showing 0

### DIFF
--- a/frontend/web/static/js/data/DataLayer.ts
+++ b/frontend/web/static/js/data/DataLayer.ts
@@ -1330,7 +1330,7 @@ export class DataLayer {
     }
 
     const data = await response.json();
-    return data.count || 0;
+    return data.total || 0;
   }
 
   // =============================================================================


### PR DESCRIPTION
## Проблема

На странице `/facts` секция **Stats Section** ("Всего фактов", "Текущая страница") всегда показывала `0` и `0-0 из 0` при загрузке страницы.

## Root Cause

Несоответствие ключей в `DataLayer.ts`:

```typescript
// БЫЛО (баг): читал data.count — всегда undefined → 0
return data.count || 0;
```

Backend `/api/v1/facts/count` возвращает `{"total": N}`, а не `{"count": N}`.

## Исправление

```typescript
// СТАЛО:
return data.total || 0;
```

## Затронутые файлы

- `frontend/web/static/js/data/DataLayer.ts` — одна строка

## Проверка

После деплоя на dev открыть `/facts` → секция Stats должна показывать реальное количество фактов.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)