### PR TITLE
fix(plan): prevent duplicate plan records on save

### DIFF
--- a/frontend/web/static/js/dashboard/features/modalPlan/saveOperations.ts
+++ b/frontend/web/static/js/dashboard/features/modalPlan/saveOperations.ts
@@ -42,12 +42,18 @@ function restoreRequiredValidation(): void {
  * Save plan modal (router function)
  */
 export async function savePlanModal(button: HTMLElement): Promise<void> {
-  if ((button as HTMLButtonElement).disabled) return;
+  const btn = button as HTMLButtonElement;
+  if (btn.disabled) return;
+
+  // Disable immediately (synchronous) to prevent duplicate calls
+  // when both onclick attribute and event listener fire simultaneously
+  btn.disabled = true;
 
   const form = document.getElementById('form_modal_plan') as HTMLFormElement;
 
   if (!form) {
     debugLog('[SavePlanModal] Form not found');
+    btn.disabled = false;
     return;
   }
 


### PR DESCRIPTION
## Summary
- Fixes duplicate plan records created on each save (two simultaneous POST /api/v1/facts)
- Root cause: `onclick` attribute and `setupSaveButtonListener` event handler both fire on same click; the `disabled` guard fired too late (after first `await`)
- Fix: `btn.disabled = true` as first synchronous statement in `savePlanModal`, before any other code runs

## Changed file
`frontend/web/static/js/dashboard/features/modalPlan/saveOperations.ts`

## Test plan
- [ ] Open plan modal, click Save once — verify only one record is created in DB
- [ ] Verify button shows loading spinner during save (via `setButtonLoading`)
- [ ] Verify button re-enables after save completes (success or error)
- [ ] `npm run type-check` — passed ✅

Replaces #488 (which had merge conflicts due to stale base branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)