### PR TITLE
fix(dexie): filter factsCount by record_type in diagnostics

### DIFF
--- a/frontend/shared/db/dexie/DexieManager.ts
+++ b/frontend/shared/db/dexie/DexieManager.ts
@@ -998,7 +998,7 @@ export class DexieManager {
     };
   }> {
     const articlesCount = await this.getDB().articles.count();
-    const factsCount = await this.getDB().budgetFacts.count();
+    const factsCount = await this.getDB().budgetFacts.filter(f => f.record_type === 'fact').count();
     const plansCount = await this.getDB().budgetFacts.filter(f => f.record_type === 'plan').count();
     const shoppingListsCount = await this.getDB().shoppingLists.count();
     const shoppingListItemsCount = await this.getDB().shoppingListItems.count();


### PR DESCRIPTION
## Summary
- Fixes Dexie Diagnostics showing identical values for Facts and Plans
- Root cause: `factsCount = budgetFacts.count()` counted ALL records (both facts and plans)
- Fix: added `.filter(f => f.record_type === 'fact')` — consistent with existing `plansCount` filter

## Changed file
`frontend/shared/db/dexie/DexieManager.ts:1001`

Replaces #489 (stale base branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)