### PR TITLE
fix(plan): align CategoryComparison fields with API response

### DIFF
--- a/frontend/web/static/js/plan/analytics.ts
+++ b/frontend/web/static/js/plan/analytics.ts
@@ -50,8 +50,8 @@ export interface CategoryComparison {
   category_id: number;
   category_name: string;
   category_type: 'expense' | 'income' | 'debit' | 'credit';
-  current_month_total: number;
-  previous_month_total: number;
+  current: number;
+  previous: number;
 }
 
 // Shared number formatter — reused across all chart tooltip formatters
@@ -637,27 +637,27 @@ function buildCategoriesChartConfig(data: MonthlyAnalyticsData): any {
   const TOOLTIP_MAX_DETAIL = 9;
   const OTHER_CATEGORY_NAME = 'Прочее';
 
-  const sorted = [...categories].sort((a, b) => b.current_month_total - a.current_month_total);
+  const sorted = [...categories].sort((a, b) => b.current - a.current);
   const remainingCategories = sorted.slice(CHART_MAX_CATEGORIES);
 
   const displayCategories: CategoryComparison[] = sorted.slice(0, CHART_MAX_CATEGORIES);
   if (remainingCategories.length > 0) {
     const { current: otherCurrentTotal, previous: otherPreviousTotal } = remainingCategories.reduce(
-      (acc, c) => ({ current: acc.current + c.current_month_total, previous: acc.previous + c.previous_month_total }),
+      (acc, c) => ({ current: acc.current + c.current, previous: acc.previous + c.previous }),
       { current: 0, previous: 0 }
     );
     displayCategories.push({
       category_id: -1,
       category_name: OTHER_CATEGORY_NAME,
       category_type: sorted[0].category_type,
-      current_month_total: otherCurrentTotal,
-      previous_month_total: otherPreviousTotal,
+      current: otherCurrentTotal,
+      previous: otherPreviousTotal,
     });
   }
 
   const tooltipOthers = remainingCategories.slice(0, TOOLTIP_MAX_DETAIL);
   const tooltipRest = remainingCategories.slice(TOOLTIP_MAX_DETAIL);
-  const tooltipRestTotal = tooltipRest.reduce((sum, c) => sum + c.current_month_total, 0);
+  const tooltipRestTotal = tooltipRest.reduce((sum, c) => sum + c.current, 0);
 
   const formatter = function(params: any[]) {
     if (!params || params.length === 0) return '';
@@ -670,7 +670,7 @@ function buildCategoriesChartConfig(data: MonthlyAnalyticsData): any {
     if (isOthers) {
       result += '<div style="margin-top:6px;border-top:1px solid #e2e8f0;padding-top:4px"><small style="color:#64748b">Состав:</small><br/>';
       tooltipOthers.forEach((c: CategoryComparison) => {
-        result += `<small>• ${c.category_name}: ${numFmt.format(c.current_month_total)} ₽</small><br/>`;
+        result += `<small>• ${c.category_name}: ${numFmt.format(c.current)} ₽</small><br/>`;
       });
       if (tooltipRest.length > 0) {
         result += `<small>• ${OTHER_CATEGORY_NAME}: ${numFmt.format(tooltipRestTotal)} ₽</small><br/>`;
@@ -723,13 +723,13 @@ function buildCategoriesChartConfig(data: MonthlyAnalyticsData): any {
       {
         name: data.previous_month.month_name,
         type: 'bar',
-        data: displayCategories.map(c => c.previous_month_total),
+        data: displayCategories.map(c => c.previous),
         itemStyle: { color: '#94a3b8', opacity: 0.5 }
       },
       {
         name: data.current_month.month_name,
         type: 'bar',
-        data: displayCategories.map(c => c.current_month_total),
+        data: displayCategories.map(c => c.current),
         itemStyle: { color: '#3b82f6' }
       }
     ]


### PR DESCRIPTION
## Summary

- Rename `current_month_total` -> `current` and `previous_month_total` -> `previous` in the `CategoryComparison` TypeScript interface to match the actual API response shape
- Update all 6 usages of the old field names in `analytics.ts` (sort comparator, reduce accumulator, push literal, tooltip formatter, chart series data mappings)
- `npm run type-check` passes with no errors

## Test plan

- [ ] Open plan page analytics tab — categories chart renders without JS errors
- [ ] Verify previous-month bars and current-month bars display correct values
- [ ] Check "Прочее" tooltip breakdown shows correct per-category amounts

Generated with [Claude Code](https://claude.com/claude-code)