### PR TITLE
fix(plan): disable save button before await in savePlanModal

### DIFF
--- a/frontend/web/static/js/plan/index.ts
+++ b/frontend/web/static/js/plan/index.ts
@@ -412,26 +412,35 @@ export function collapseFiltersAction(): void {
  * @param button - Кнопка с data-form-id и data-modal-id
  */
 export async function savePlanModal(button: HTMLElement): Promise<void> {
-  if ((button as HTMLButtonElement).disabled) return;
+  const btn = button as HTMLButtonElement;
+  if (btn.disabled) return;
+  btn.disabled = true;
 
   const formId = button.dataset.formId;
   const modalId = button.dataset.modalId || 'modal_plan';
   const form = document.getElementById(formId || `form_${modalId}`) as HTMLFormElement | null;
-  if (!form) return;
+  if (!form) {
+    btn.disabled = false;
+    return;
+  }
 
-  if (modalId === 'modal_plan') {
-    // Для основного модала — TS-реализация из PlanCRUD (поддерживает recurring + offline)
-    const event = new Event('submit', { bubbles: true, cancelable: true });
-    Object.defineProperty(event, 'target', { value: form, writable: false });
-    await PlanCRUD.createPlan(event);
-  } else {
-    // Для остальных модалов (например modal_add_plan) — нативная отправка формы,
-    // которая триггерит зарегистрированный submit-обработчик из inline-скрипта
-    if (form.checkValidity()) {
-      form.requestSubmit();
+  try {
+    if (modalId === 'modal_plan') {
+      // Для основного модала — TS-реализация из PlanCRUD (поддерживает recurring + offline)
+      const event = new Event('submit', { bubbles: true, cancelable: true });
+      Object.defineProperty(event, 'target', { value: form, writable: false });
+      await PlanCRUD.createPlan(event);
     } else {
-      form.reportValidity();
+      // Для остальных модалов (например modal_add_plan) — нативная отправка формы,
+      // которая триггерит зарегистрированный submit-обработчик из inline-скрипта
+      if (form.checkValidity()) {
+        form.requestSubmit();
+      } else {
+        form.reportValidity();
+      }
     }
+  } finally {
+    btn.disabled = false;
   }
 }
 


### PR DESCRIPTION
## Summary

- `savePlanModal()` в `plan/index.ts` проверяла `btn.disabled` но НЕ устанавливала его в `true` перед `await PlanCRUD.createPlan()`, позволяя быстрому двойному клику отправить два POST-запроса и создать дубликаты в БД
- Добавлен синхронный `btn.disabled = true` до первого await и `finally { btn.disabled = false }` для восстановления в любом исходе
- Тот же паттерн применён в `dashboard/features/modalPlan/saveOperations.ts` (PR #490)

## Test plan

- [ ] Открыть `/plan`, создать запись, быстро дважды нажать "Сохранить" → только одна запись создаётся
- [ ] `npm run type-check` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)