### PR TITLE
fix(dexie): fix budgetFacts total count and downloadFacts response parsing

### DIFF
--- a/frontend/shared/db/dexie/DexieManager.ts
+++ b/frontend/shared/db/dexie/DexieManager.ts
@@ -1031,7 +1031,7 @@ export class DexieManager {
       dbSizeKB: dbSize / 1024,
       tables: {
         articles: articlesCount,
-        budgetFacts: factsCount,
+        budgetFacts: factsCount + plansCount,
         shoppingLists: shoppingListsCount,
         financialCenters: financialCentersCount,
         costCenters: costCentersCount

--- a/frontend/shared/db/dexie/operations/factSync.ts
+++ b/frontend/shared/db/dexie/operations/factSync.ts
@@ -171,7 +171,8 @@ export async function downloadFacts(
       throw new Error(`Failed to fetch facts: ${response.status}`);
     }
 
-    const apiFacts: any[] = await response.json();
+    const responseData = await response.json();
+    const apiFacts: any[] = responseData.facts || [];
 
     // MAP API FIELDS → DEXIE SCHEMA (with error handling)
     const mappedFacts: LocalBudgetFact[] = [];


### PR DESCRIPTION
## Summary

- **DexieManager.ts**: `tables.budgetFacts` теперь показывает `factsCount + plansCount` (итого записей в таблице) вместо только `factsCount`, что после PR #491 показывало 0 вместо реального числа
- **factSync.ts**: `downloadFacts()` теперь правильно читает `responseData.facts || []` из `FactListResponse` вместо того чтобы обрабатывать wrapper-объект как массив (что вызывало пропуск всех фактов при синке)

## Test plan

- [ ] Открыть `/plan` → Dexie диагностика → строка `budgetFacts` показывает сумму facts+plans
- [ ] `npm run type-check` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)