### PR TITLE
fix(plan): prevent analytics month buttons from being de-highlighted on load

### DIFF
--- a/frontend/web/static/js/plan/filterAnalyticsSync.ts
+++ b/frontend/web/static/js/plan/filterAnalyticsSync.ts
@@ -129,7 +129,7 @@ export function debouncedSyncFiltersToAnalytics(
   // Cancel pending sync
   if (syncDebounceTimer !== null) {
     clearTimeout(syncDebounceTimer);
-    console.log('[FILTER_SYNC] Debounced - canceling pending sync');
+    if (window.DEBUG_MODE) console.log('[FILTER_SYNC] Debounced - canceling pending sync'); // DEBUG_MODE guard
   }
 
   // Schedule new sync
@@ -178,7 +178,7 @@ export async function syncFiltersToAnalytics(options: SyncOptions = {}): Promise
 
   // Prevent infinite loops
   if (isSyncInProgress) {
-    console.log('[syncFiltersToAnalytics] Sync already in progress, skipping');
+    if (window.DEBUG_MODE) console.log('[syncFiltersToAnalytics] Sync already in progress, skipping'); // DEBUG_MODE guard
     return;
   }
 
@@ -194,7 +194,7 @@ export async function syncFiltersToAnalytics(options: SyncOptions = {}): Promise
       const currentAnalyticsMonth = PlanAnalytics.getCurrentAnalyticsMonth();
 
       if (monthFromRange && monthFromRange !== currentAnalyticsMonth) {
-        console.log(
+        if (window.DEBUG_MODE) console.log( // DEBUG_MODE guard
           '[syncFiltersToAnalytics] Month changed:',
           currentAnalyticsMonth,
           '→',
@@ -213,14 +213,6 @@ export async function syncFiltersToAnalytics(options: SyncOptions = {}): Promise
         });
 
         needsReload = true;
-      } else if (!monthFromRange && currentAnalyticsMonth) {
-        console.log('[syncFiltersToAnalytics] Partial/multi-month range detected, clearing month selection');
-        // Partial month or multi-month range - clear all button selections
-        const buttons = document.querySelectorAll<HTMLButtonElement>('#analytics-month-buttons button');
-        buttons.forEach(btn => {
-          btn.classList.remove('btn-primary');
-          btn.classList.add('btn-outline');
-        });
       }
     }
 
@@ -231,7 +223,7 @@ export async function syncFiltersToAnalytics(options: SyncOptions = {}): Promise
     if (filterArticleType && analyticsArticleType) {
       const newValue = filterArticleType.value || '';
       if (analyticsArticleType.value !== newValue) {
-        console.log(
+        if (window.DEBUG_MODE) console.log( // DEBUG_MODE guard
           '[syncFiltersToAnalytics] Article type changed:',
           analyticsArticleType.value,
           '→',
@@ -253,11 +245,11 @@ export async function syncFiltersToAnalytics(options: SyncOptions = {}): Promise
       // Check if option exists in analytics dropdown
       const optionExists = analyticsArticle.querySelector(`option[value="${newValue}"]`);
       if (optionExists && analyticsArticle.value !== newValue) {
-        console.log('[syncFiltersToAnalytics] Article changed:', analyticsArticle.value, '→', newValue);
+        if (window.DEBUG_MODE) console.log('[syncFiltersToAnalytics] Article changed:', analyticsArticle.value, '→', newValue); // DEBUG_MODE guard
         analyticsArticle.value = newValue;
         needsReload = true;
       } else if (!optionExists && newValue) {
-        console.log('[syncFiltersToAnalytics] Article option not found in analytics dropdown, skipping');
+        if (window.DEBUG_MODE) console.log('[syncFiltersToAnalytics] Article option not found in analytics dropdown, skipping'); // DEBUG_MODE guard
       }
     }
 
@@ -268,7 +260,7 @@ export async function syncFiltersToAnalytics(options: SyncOptions = {}): Promise
     if (filterFC && analyticsCFO) {
       const newValue = filterFC.value || '';
       if (analyticsCFO.value !== newValue) {
-        console.log('[syncFiltersToAnalytics] CFO changed:', analyticsCFO.value, '→', newValue);
+        if (window.DEBUG_MODE) console.log('[syncFiltersToAnalytics] CFO changed:', analyticsCFO.value, '→', newValue); // DEBUG_MODE guard
         analyticsCFO.value = newValue;
         needsReload = true;
       }
@@ -276,7 +268,7 @@ export async function syncFiltersToAnalytics(options: SyncOptions = {}): Promise
 
     // 5. Reload charts if any value changed
     if (needsReload && !skipReload) {
-      console.log('[syncFiltersToAnalytics] Reloading charts...');
+      if (window.DEBUG_MODE) console.log('[syncFiltersToAnalytics] Reloading charts...'); // DEBUG_MODE guard
       await PlanAnalytics.loadPlanAnalytics();
     }
   } catch (error) {
@@ -303,7 +295,7 @@ export async function syncAnalyticsToFilters(options: SyncOptions = {}): Promise
 
   // Prevent infinite loops
   if (isSyncInProgress) {
-    console.log('[syncAnalyticsToFilters] Sync already in progress, skipping');
+    if (window.DEBUG_MODE) console.log('[syncAnalyticsToFilters] Sync already in progress, skipping'); // DEBUG_MODE guard
     return;
   }
 
@@ -319,7 +311,7 @@ export async function syncAnalyticsToFilters(options: SyncOptions = {}): Promise
       const filters = PlanFilters.getFilters();
 
       if (filters.date_from !== from || filters.date_to !== to) {
-        console.log(
+        if (window.DEBUG_MODE) console.log( // DEBUG_MODE guard
           '[syncAnalyticsToFilters] Date range changed:',
           filters.date_from,
           '-',
@@ -356,7 +348,7 @@ export async function syncAnalyticsToFilters(options: SyncOptions = {}): Promise
     if (analyticsArticleType && filterArticleType) {
       const newValue = analyticsArticleType.value || '';
       if (filterArticleType.value !== newValue) {
-        console.log('[syncAnalyticsToFilters] Article type changed:', filterArticleType.value, '→', newValue);
+        if (window.DEBUG_MODE) console.log('[syncAnalyticsToFilters] Article type changed:', filterArticleType.value, '→', newValue); // DEBUG_MODE guard
         filterArticleType.value = newValue;
 
         // Update filters object immediately
@@ -366,7 +358,7 @@ export async function syncAnalyticsToFilters(options: SyncOptions = {}): Promise
         if (filterArticle) {
           filterArticle.value = '';
           PlanFilters.setFilters({ article_id: null });
-          console.log('[syncAnalyticsToFilters] Article filter reset due to type change');
+          if (window.DEBUG_MODE) console.log('[syncAnalyticsToFilters] Article filter reset due to type change'); // DEBUG_MODE guard
         }
 
         needsReload = true;
@@ -381,12 +373,12 @@ export async function syncAnalyticsToFilters(options: SyncOptions = {}): Promise
       // Check if option exists in filter dropdown
       const optionExists = filterArticle.querySelector(`option[value="${newValue}"]`);
       if (optionExists && filterArticle.value !== newValue) {
-        console.log('[syncAnalyticsToFilters] Article changed:', filterArticle.value, '→', newValue);
+        if (window.DEBUG_MODE) console.log('[syncAnalyticsToFilters] Article changed:', filterArticle.value, '→', newValue); // DEBUG_MODE guard
         filterArticle.value = newValue;
         PlanFilters.setFilters({ article_id: parseInt(newValue) || null });
         needsReload = true;
       } else if (!optionExists && newValue) {
-        console.log('[syncAnalyticsToFilters] Article option not found in filter dropdown, skipping');
+        if (window.DEBUG_MODE) console.log('[syncAnalyticsToFilters] Article option not found in filter dropdown, skipping'); // DEBUG_MODE guard
       }
     }
 
@@ -397,7 +389,7 @@ export async function syncAnalyticsToFilters(options: SyncOptions = {}): Promise
     if (analyticsCFO && filterFC) {
       const newValue = analyticsCFO.value || '';
       if (filterFC.value !== newValue) {
-        console.log('[syncAnalyticsToFilters] CFO changed:', filterFC.value, '→', newValue);
+        if (window.DEBUG_MODE) console.log('[syncAnalyticsToFilters] CFO changed:', filterFC.value, '→', newValue); // DEBUG_MODE guard
         filterFC.value = newValue;
         PlanFilters.setFilters({ financial_center_id: parseInt(newValue) || null });
         needsReload = true;
@@ -406,7 +398,7 @@ export async function syncAnalyticsToFilters(options: SyncOptions = {}): Promise
 
     // 5. Reload facts table if any value changed
     if (needsReload && !skipReload) {
-      console.log('[syncAnalyticsToFilters] Reloading facts table with filters:', {
+      if (window.DEBUG_MODE) console.log('[syncAnalyticsToFilters] Reloading facts table with filters:', { // DEBUG_MODE guard
         article_type: filterArticleType?.value || null,
         article_id: filterArticle?.value || null,
         financial_center_id: filterFC?.value || null


### PR DESCRIPTION
## Summary
- Удалён блок `else if (!monthFromRange && currentAnalyticsMonth)` из `syncFiltersToAnalytics`, который снимал `btn-primary` с кнопок месяца при многомесячном диапазоне дат
- Кнопка текущего месяца теперь остаётся выделенной при загрузке страницы
- Все `console.log` обёрнуты в `if (window.DEBUG_MODE)` guard

## Test plan
- [ ] Открыть /plan — кнопка текущего месяца должна быть выделена
- [ ] `npm run type-check` ✅
- [ ] `npm run bundle` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)