### PR TITLE
fix(dexie): add article_type filter support via client-side join in queryFacts

### DIFF
--- a/frontend/shared/db/dexie/DexieManager.ts
+++ b/frontend/shared/db/dexie/DexieManager.ts
@@ -433,6 +433,13 @@ export class DexieManager {
 
         return true;
       });
+
+      // article_type filter: client-side join — article_type is not stored in LocalBudgetFact
+      if (filters.article_type) {
+        const matchingArticles = await this.queryArticles({ type: filters.article_type });
+        const validArticleIds = new Set(matchingArticles.map(a => a.id));
+        results = results.filter(fact => validArticleIds.has(fact.article_id));
+      }
     }
 
     // Convert amount from cents to dollars

--- a/frontend/shared/db/dexie/operations/factOperations.ts
+++ b/frontend/shared/db/dexie/operations/factOperations.ts
@@ -4,6 +4,7 @@
  */
 
 import { db, toCents } from '../core/database';
+import { queryArticles } from './schemaOperations';
 import { logger } from '../utils/logger';
 import { validateFact } from '../utils/validation';
 import { calculateContentHash, generateUUID } from '../utils/hash';
@@ -234,6 +235,13 @@ export async function queryFacts(filters?: FactFilters): Promise<LocalBudgetFact
 
       return true;
     });
+
+    // article_type filter: client-side join — article_type is not stored in LocalBudgetFact
+    if (filters.article_type) {
+      const matchingArticles = await queryArticles({ type: filters.article_type });
+      const validArticleIds = new Set(matchingArticles.map(a => a.id));
+      results = results.filter(fact => validArticleIds.has(fact.article_id));
+    }
   }
 
   // amount already in rubles (stored via mapAPIFactToLocal without conversion)

--- a/frontend/web/static/js/facts/integration/factsAPI.ts
+++ b/frontend/web/static/js/facts/integration/factsAPI.ts
@@ -194,6 +194,12 @@ export async function loadFacts(options?: DataLayerFetchOptions): Promise<LoadFa
             const userId = localFacts[0].user_id;
             const enrichmentMaps = await loadEnrichmentMaps(userId);
             allFacts = localFacts.map(fact => convertBudgetFact(fact, enrichmentMaps));
+
+            // Apply article_type filter post-enrichment as safety layer
+            // (primary filtering done in DexieManager.queryFacts via article join)
+            if (factFilters.article_type) {
+                allFacts = allFacts.filter(f => f.article_type === factFilters.article_type);
+            }
         } else {
             // Fallback: Dexie inactive — API data with API field names
             allFacts = localFacts.map(fact => convertAPIFact(fact as any));


### PR DESCRIPTION
## Summary

- `DexieManager.queryFacts()` — добавлен client-side join с таблицей `articles` для фильтрации по `article_type` (через существующий `this.queryArticles()`)
- `factOperations.queryFacts()` — аналогичный фикс с импортом `queryArticles` из `schemaOperations`
- `factsAPI.loadFacts()` — защитный пост-фильтр по `article_type` после `convertBudgetFact()`

**Проблема:** `article_type` не хранится в `LocalBudgetFact` (только `article_id`), поэтому фильтр по типу расходов молча игнорировался в офлайн-режиме. Статистика Facts показывала неверный count.

## Test plan
- [ ] TypeScript type-check: `npm run type-check` ✅ (прошёл в pre-commit)
- [ ] Открыть страницу Facts с фильтром "Расходы" — count должен отражать только расходы
- [ ] Dexie Diagnostics — `facts` count не изменился (считает по `record_type`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)