### PR TITLE
fix(plan): add missing analytics filter handlers (CFO, article type, category, collapse)

### DIFF
--- a/frontend/web/static/js/plan/analytics.ts
+++ b/frontend/web/static/js/plan/analytics.ts
@@ -173,9 +173,9 @@ export async function selectAnalyticsMonth(month: string, clickedBtn: HTMLButton
   // Reload analytics
   await loadPlanAnalytics();
 
-  // Sync to filters section (imported at runtime to avoid circular dependency)
-  if (typeof (window as any).syncAnalyticsToFilters === 'function') {
-    await (window as any).syncAnalyticsToFilters();
+  // Sync to filters section via PlanApp (avoids circular dependency)
+  if (typeof window.PlanApp?.syncAnalyticsToFilters === 'function') {
+    await window.PlanApp.syncAnalyticsToFilters();
   }
 }
 
@@ -746,4 +746,40 @@ function updateCategoriesChart(data: MonthlyAnalyticsData): void {
   const option = buildCategoriesChartConfig(data);
   const categories = data.categories_comparison || [];
   analyticsCategoriesChart.setOption(option, categories.length === 0);
+}
+
+// ============================================================================
+// Analytics Filter Handlers (called from analytics_section.html onchange)
+// ============================================================================
+
+/**
+ * Sync analytics state to filters without updating date range.
+ * Avoids circular dependency by routing through window.PlanApp.
+ */
+async function syncToFiltersNoDateUpdate(): Promise<void> {
+  if (typeof window.PlanApp?.syncAnalyticsToFilters === 'function') {
+    await window.PlanApp.syncAnalyticsToFilters({ updateDateRange: false });
+  }
+}
+
+export async function onAnalyticsCFOChange(): Promise<void> {
+  await loadPlanAnalytics();
+  await syncToFiltersNoDateUpdate();
+}
+
+export async function onAnalyticsArticleTypeChange(): Promise<void> {
+  const typeSelect = document.getElementById('analytics-article-type') as HTMLSelectElement | null;
+  await loadAnalyticsArticleFilter(typeSelect?.value || null);
+  await loadCategoriesChartData();
+  await syncToFiltersNoDateUpdate();
+}
+
+export async function onAnalyticsArticleChange(): Promise<void> {
+  await loadCategoriesChartData();
+  await syncToFiltersNoDateUpdate();
+}
+
+export function collapseAnalytics(): void {
+  const toggle = document.getElementById('analytics-toggle') as HTMLInputElement | null;
+  if (toggle) toggle.checked = false;
 }

--- a/frontend/web/static/js/plan/index.ts
+++ b/frontend/web/static/js/plan/index.ts
@@ -64,6 +64,12 @@ interface PlanAppGlobal {
   // Analytics Actions (exposed for onclick handlers)
   selectAnalyticsMonth: (month: string, btn: HTMLButtonElement) => Promise<void>;
 
+  // Analytics filter change handlers
+  onAnalyticsCFOChange: () => Promise<void>;
+  onAnalyticsArticleTypeChange: () => Promise<void>;
+  onAnalyticsArticleChange: () => Promise<void>;
+  collapseAnalytics: () => void;
+
   // Sync Actions (exposed for onclick handlers)
   syncFiltersToAnalytics: (options?: FilterAnalyticsSync.SyncOptions) => Promise<void>;
   syncAnalyticsToFilters: (options?: FilterAnalyticsSync.SyncOptions) => Promise<void>;
@@ -479,6 +485,12 @@ const planApp: typeof window.PlanApp = {
 
   // Analytics Actions (for onclick handlers)
   selectAnalyticsMonth: PlanAnalytics.selectAnalyticsMonth,
+
+  // Analytics filter change handlers
+  onAnalyticsCFOChange: PlanAnalytics.onAnalyticsCFOChange,
+  onAnalyticsArticleTypeChange: PlanAnalytics.onAnalyticsArticleTypeChange,
+  onAnalyticsArticleChange: PlanAnalytics.onAnalyticsArticleChange,
+  collapseAnalytics: PlanAnalytics.collapseAnalytics,
 
   // Sync Actions (for onclick handlers)
   syncFiltersToAnalytics: FilterAnalyticsSync.syncFiltersToAnalytics,


### PR DESCRIPTION
## Summary
- Добавлены `onAnalyticsCFOChange`, `onAnalyticsArticleTypeChange`, `onAnalyticsArticleChange`, `collapseAnalytics` в `analytics.ts`
- Экспортированы через `window.PlanApp` в `index.ts`
- Исправлен вызов `window.syncAnalyticsToFilters` → `window.PlanApp.syncAnalyticsToFilters` в `selectAnalyticsMonth`

## Test plan
- [ ] Открыть /plan → изменить счёт в аналитике → график перезагружается
- [ ] Изменить тип категории → список категорий фильтруется, график обновляется
- [ ] Изменить категорию → категориальный график обновляется
- [ ] Кнопка «Свернуть» в аналитике работает
- [ ] Клик по кнопке месяца обновляет Filters Section
- [ ] `npm run type-check` ✅ / `npm run bundle` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)