### PR TITLE
fix(plan): show reminder date/time form when switching to reminder mode

### DIFF
--- a/frontend/web/static/js/dashboard/features/modalPlan/recurringSettings.ts
+++ b/frontend/web/static/js/dashboard/features/modalPlan/recurringSettings.ts
@@ -6,7 +6,7 @@
  */
 
 import { getState, updateState } from '../../core/DashboardState';
-import { initReminderCalendarWidget } from '../addPlan/reminderSettings';
+import { initReminderCalendarWidget, getCurrentTimeRounded, updateReminderDatetime } from '../addPlan/reminderSettings';
 
 declare const debugLog: (...args: any[]) => void;
 
@@ -64,6 +64,21 @@ export function togglePlanMode(modalId: string): void {
     debugLog('[togglePlanMode] Reminder section shown');
     // Initialize CalendarWidget for reminder date field
     initReminderCalendarWidget(modalId);
+
+    // Explicitly show inner container (in case it was hidden)
+    const reminderSettings = document.getElementById(`reminder-settings-${modalId}`);
+    if (reminderSettings) {
+      reminderSettings.classList.remove('hidden');
+    }
+
+    const hourSelect = document.getElementById(`reminder_hour_${modalId}`) as HTMLSelectElement | null;
+    const minuteSelect = document.getElementById(`reminder_minute_${modalId}`) as HTMLSelectElement | null;
+    if (hourSelect && minuteSelect) {
+      const defaultTime = getCurrentTimeRounded();
+      hourSelect.value = defaultTime.hour;
+      minuteSelect.value = defaultTime.minute;
+      updateReminderDatetime(modalId);
+    }
   } else {
     debugLog('[togglePlanMode] Regular mode - no additional sections shown');
   }


### PR DESCRIPTION
## Summary
- При переключении на режим «Напоминание» в `modal_plan` форма даты/времени теперь корректно инициализируется
- Явно показывает внутренний `reminder-settings-{modalId}` (мог быть скрыт после закрытия)
- Устанавливает значения часа/минуты по умолчанию (текущее время + 1 час, округлённое до 5 мин)
- Обновляет скрытое поле `reminder_datetime` сразу при переключении

## Root cause
`togglePlanMode` в `dashboard/features/modalPlan/recurringSettings.ts` вызывал `initReminderCalendarWidget()` но не заполнял поля времени и не показывал внутренний div `reminder-settings-*`.

## Files changed
- `frontend/web/static/js/dashboard/features/modalPlan/recurringSettings.ts`

## Test plan
- [ ] Открыть `/plan`, нажать «Добавить»
- [ ] Переключить режим плана → «Напоминание»
- [ ] Проверить что блок даты/времени виден и часы/минуты предзаполнены
- [ ] Сохранить план — напоминание должно создаться успешно

🤖 Generated with [Claude Code](https://claude.com/claude-code)