### PR TITLE
fix(analytics): remove default month selection and populate filters from plan data

### DIFF
--- a/frontend/web/static/js/plan/analytics.ts
+++ b/frontend/web/static/js/plan/analytics.ts
@@ -13,6 +13,34 @@ import * as PlanHelpers from './helpers';
 declare const echarts: any;
 
 // ============================================================================
+// Filter Options Interface & Cache
+// ============================================================================
+
+/**
+ * Filter options response from /api/v1/analytics/plans/filter-options
+ */
+export interface PlanFilterOptionsResponse {
+  financial_centers: Array<{ id: number; name: string }>;
+  article_types: string[];
+  articles: Array<{ id: number; name: string; type: string; parent_id: number | null }>;
+}
+
+/**
+ * Cached filter options from API
+ */
+let cachedFilterOptions: PlanFilterOptionsResponse | null = null;
+
+/**
+ * Human-readable labels for article types
+ */
+const ARTICLE_TYPE_LABELS: Record<string, string> = {
+  expense: 'Расходы',
+  income: 'Доходы',
+  debit: 'Списание',
+  credit: 'Пополнение'
+};
+
+// ============================================================================
 // TypeScript Interfaces
 // ============================================================================
 
@@ -136,18 +164,13 @@ export function initAnalyticsMonthButtons(): void {
     const label = `${MONTH_NAMES[date.getMonth()]} ${date.getFullYear()}`;
 
     const btn = document.createElement('button');
-    btn.className = offset === 0 ? 'join-item btn btn-primary' : 'join-item btn btn-outline';
+    btn.className = 'join-item btn btn-outline';
     btn.style.height = '3rem';
     btn.textContent = label;
     btn.dataset.month = yearMonth;
     btn.onclick = () => selectAnalyticsMonth(yearMonth, btn);
 
     container.appendChild(btn);
-
-    // Set initial month
-    if (offset === 0) {
-      currentAnalyticsMonth = yearMonth;
-    }
   }
 }
 
@@ -250,20 +273,91 @@ function buildArticleOptions(select: HTMLSelectElement, sortedNodes: PlanHelpers
 }
 
 // ============================================================================
+// Filter Options - Dynamic from API
+// ============================================================================
+
+/**
+ * Load and cache filter options from /api/v1/analytics/plans/filter-options
+ * Returns cached result on subsequent calls
+ *
+ * @returns PlanFilterOptionsResponse or null on error
+ */
+export async function loadAnalyticsFilterOptions(): Promise<PlanFilterOptionsResponse | null> {
+  if (cachedFilterOptions) {
+    return cachedFilterOptions;
+  }
+
+  try {
+    const response = await fetch('/api/v1/analytics/plans/filter-options');
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+    cachedFilterOptions = await response.json();
+    return cachedFilterOptions;
+  } catch (error) {
+    console.error('[PlanAnalytics] Error loading filter options:', error);
+    return null;
+  }
+}
+
+/**
+ * Populate article type select with dynamic values from filter options
+ * @param types - Array of article type strings from API
+ */
+export function populateArticleTypeFilter(types: string[]): void {
+  const select = document.getElementById('analytics-article-type') as HTMLSelectElement | null;
+  if (!select) return;
+
+  // Remove all options except the first "Все типы" default
+  while (select.options.length > 1) {
+    select.remove(1);
+  }
+
+  types.forEach(type => {
+    const option = document.createElement('option');
+    option.value = type;
+    option.textContent = ARTICLE_TYPE_LABELS[type] || type;
+    select.appendChild(option);
+  });
+}
+
+/**
+ * Populate all analytics filter dropdowns using cached filter options
+ * Calls loadAnalyticsFilterOptions() internally; falls back to legacy endpoints on error
+ */
+export async function populateAllAnalyticsFilters(): Promise<void> {
+  const filterOptions = await loadAnalyticsFilterOptions();
+
+  if (filterOptions && filterOptions.article_types.length > 0) {
+    populateArticleTypeFilter(filterOptions.article_types);
+  }
+
+  await Promise.all([
+    loadAnalyticsCFOFilter(filterOptions ? filterOptions.financial_centers : null),
+    loadAnalyticsArticleFilter(null, filterOptions ? filterOptions.articles : null)
+  ]);
+}
+
+// ============================================================================
 // Filter Dropdowns
 // ============================================================================
 
 /**
  * Load CFO (financial center) filter options for analytics
+ * Uses filter-options data if provided; falls back to PlanHelpers.loadFinancialCenters()
+ *
+ * @param centers - Pre-fetched financial centers or null for fallback
  */
-export async function loadAnalyticsCFOFilter(): Promise<void> {
+export async function loadAnalyticsCFOFilter(
+  centers: Array<{ id: number; name: string }> | null = null
+): Promise<void> {
   try {
-    const centers = await PlanHelpers.loadFinancialCenters();
-    const select = document.getElementById('analytics-cfo-filter') as HTMLSelectElement | null;
+    const centerList = centers !== null ? centers : await PlanHelpers.loadFinancialCenters();
 
+    const select = document.getElementById('analytics-cfo-filter') as HTMLSelectElement | null;
     if (!select) return;
 
-    centers.forEach(center => {
+    centerList.forEach(center => {
       const option = document.createElement('option');
       option.value = String(center.id);
       option.textContent = center.name;
@@ -276,25 +370,41 @@ export async function loadAnalyticsCFOFilter(): Promise<void> {
 
 /**
  * Load article filter options for analytics
- * Filters by article type if provided
+ * Filters by article type if provided.
+ * Uses filter-options articles if provided; falls back to /api/v1/articles
  *
- * @param articleType - Article type filter ('expense' | 'income' | 'debit' | 'credit')
+ * @param articleType - Article type filter ('expense' | 'income' | 'debit' | 'credit') or null
+ * @param allArticles - Pre-fetched articles from filter-options or null for fallback
  */
-export async function loadAnalyticsArticleFilter(articleType: string | null = null): Promise<void> {
+export async function loadAnalyticsArticleFilter(
+  articleType: string | null = null,
+  allArticles: Array<{ id: number; name: string; type: string; parent_id: number | null }> | null = null
+): Promise<void> {
   try {
-    let url = '/api/v1/articles?limit=1000&sort_by=usage_count';
-    if (articleType) {
-      url += `&type=${articleType}`;
-    }
+    let articles: PlanHelpers.Article[];
 
-    const response = await fetch(url);
-    if (!response.ok) {
-      console.warn('[PlanAnalytics] Failed to load articles:', response.status);
-      return;
-    }
+    if (allArticles !== null) {
+      // Use pre-fetched articles, filter by type if needed
+      const filtered = articleType
+        ? allArticles.filter(a => a.type === articleType)
+        : allArticles;
+      articles = filtered as PlanHelpers.Article[];
+    } else {
+      // Fallback: fetch from /api/v1/articles
+      let url = '/api/v1/articles?limit=1000&sort_by=usage_count';
+      if (articleType) {
+        url += `&type=${articleType}`;
+      }
 
-    const data = await response.json();
-    const articles: PlanHelpers.Article[] = Array.isArray(data) ? data : data.articles || [];
+      const response = await fetch(url);
+      if (!response.ok) {
+        console.warn('[PlanAnalytics] Failed to load articles:', response.status);
+        return;
+      }
+
+      const data = await response.json();
+      articles = Array.isArray(data) ? data : data.articles || [];
+    }
 
     const select = document.getElementById('analytics-article') as HTMLSelectElement | null;
     if (!select) return;
@@ -508,13 +618,6 @@ function initCategoriesChart(): void {
  * @returns ECharts option object
  */
 function buildComparisonChartConfig(data: MonthlyAnalyticsData): any {
-  const typeLabels: Record<string, string> = {
-    expense: 'Расходы',
-    income: 'Доходы',
-    debit: 'Списание',
-    credit: 'Пополнение'
-  };
-
   const typeColors: Record<string, string> = {
     expense: '#ef4444',
     income: '#22c55e',
@@ -551,7 +654,7 @@ function buildComparisonChartConfig(data: MonthlyAnalyticsData): any {
     },
     xAxis: {
       type: 'category',
-      data: types.map(t => typeLabels[t]),
+      data: types.map(t => ARTICLE_TYPE_LABELS[t]),
       axisLine: { lineStyle: { color: '#e5e7eb' } },
       axisTick: { lineStyle: { color: '#e5e7eb' } },
       axisLabel: { color: '#374151' }

--- a/frontend/web/static/js/plan/filterAnalyticsSync.ts
+++ b/frontend/web/static/js/plan/filterAnalyticsSync.ts
@@ -129,7 +129,6 @@ export function debouncedSyncFiltersToAnalytics(
   // Cancel pending sync
   if (syncDebounceTimer !== null) {
     clearTimeout(syncDebounceTimer);
-    if (window.DEBUG_MODE) console.log('[FILTER_SYNC] Debounced - canceling pending sync'); // DEBUG_MODE guard
   }
 
   // Schedule new sync
@@ -178,7 +177,6 @@ export async function syncFiltersToAnalytics(options: SyncOptions = {}): Promise
 
   // Prevent infinite loops
   if (isSyncInProgress) {
-    if (window.DEBUG_MODE) console.log('[syncFiltersToAnalytics] Sync already in progress, skipping'); // DEBUG_MODE guard
     return;
   }
 
@@ -194,13 +192,6 @@ export async function syncFiltersToAnalytics(options: SyncOptions = {}): Promise
       const currentAnalyticsMonth = PlanAnalytics.getCurrentAnalyticsMonth();
 
       if (monthFromRange && monthFromRange !== currentAnalyticsMonth) {
-        if (window.DEBUG_MODE) console.log( // DEBUG_MODE guard
-          '[syncFiltersToAnalytics] Month changed:',
-          currentAnalyticsMonth,
-          '→',
-          monthFromRange
-        );
-
         // Update month selection
         PlanAnalytics.setCurrentAnalyticsMonth(monthFromRange);
 
@@ -213,6 +204,13 @@ export async function syncFiltersToAnalytics(options: SyncOptions = {}): Promise
         });
 
         needsReload = true;
+      } else if (!monthFromRange && currentAnalyticsMonth) {
+        // Partial month or multi-month range — clear all button selections
+        const buttons = document.querySelectorAll<HTMLButtonElement>('#analytics-month-buttons button');
+        buttons.forEach(btn => {
+          btn.classList.remove('btn-primary');
+          btn.classList.add('btn-outline');
+        });
       }
     }
 
@@ -223,15 +221,9 @@ export async function syncFiltersToAnalytics(options: SyncOptions = {}): Promise
     if (filterArticleType && analyticsArticleType) {
       const newValue = filterArticleType.value || '';
       if (analyticsArticleType.value !== newValue) {
-        if (window.DEBUG_MODE) console.log( // DEBUG_MODE guard
-          '[syncFiltersToAnalytics] Article type changed:',
-          analyticsArticleType.value,
-          '→',
-          newValue
-        );
         analyticsArticleType.value = newValue;
-        // Reload article dropdown for analytics (filtered by type)
-        await PlanAnalytics.loadAnalyticsArticleFilter(newValue || null);
+        const cached = await PlanAnalytics.loadAnalyticsFilterOptions();
+        await PlanAnalytics.loadAnalyticsArticleFilter(newValue || null, cached ? cached.articles : null);
         needsReload = true;
       }
     }
@@ -245,11 +237,8 @@ export async function syncFiltersToAnalytics(options: SyncOptions = {}): Promise
       // Check if option exists in analytics dropdown
       const optionExists = analyticsArticle.querySelector(`option[value="${newValue}"]`);
       if (optionExists && analyticsArticle.value !== newValue) {
-        if (window.DEBUG_MODE) console.log('[syncFiltersToAnalytics] Article changed:', analyticsArticle.value, '→', newValue); // DEBUG_MODE guard
         analyticsArticle.value = newValue;
         needsReload = true;
-      } else if (!optionExists && newValue) {
-        if (window.DEBUG_MODE) console.log('[syncFiltersToAnalytics] Article option not found in analytics dropdown, skipping'); // DEBUG_MODE guard
       }
     }
 
@@ -260,7 +249,6 @@ export async function syncFiltersToAnalytics(options: SyncOptions = {}): Promise
     if (filterFC && analyticsCFO) {
       const newValue = filterFC.value || '';
       if (analyticsCFO.value !== newValue) {
-        if (window.DEBUG_MODE) console.log('[syncFiltersToAnalytics] CFO changed:', analyticsCFO.value, '→', newValue); // DEBUG_MODE guard
         analyticsCFO.value = newValue;
         needsReload = true;
       }
@@ -268,7 +256,6 @@ export async function syncFiltersToAnalytics(options: SyncOptions = {}): Promise
 
     // 5. Reload charts if any value changed
     if (needsReload && !skipReload) {
-      if (window.DEBUG_MODE) console.log('[syncFiltersToAnalytics] Reloading charts...'); // DEBUG_MODE guard
       await PlanAnalytics.loadPlanAnalytics();
     }
   } catch (error) {
@@ -295,7 +282,6 @@ export async function syncAnalyticsToFilters(options: SyncOptions = {}): Promise
 
   // Prevent infinite loops
   if (isSyncInProgress) {
-    if (window.DEBUG_MODE) console.log('[syncAnalyticsToFilters] Sync already in progress, skipping'); // DEBUG_MODE guard
     return;
   }
 
@@ -311,17 +297,6 @@ export async function syncAnalyticsToFilters(options: SyncOptions = {}): Promise
       const filters = PlanFilters.getFilters();
 
       if (filters.date_from !== from || filters.date_to !== to) {
-        if (window.DEBUG_MODE) console.log( // DEBUG_MODE guard
-          '[syncAnalyticsToFilters] Date range changed:',
-          filters.date_from,
-          '-',
-          filters.date_to,
-          '→',
-          from,
-          '-',
-          to
-        );
-
         // Update filters object
         PlanFilters.setFilters({ date_from: from, date_to: to });
 
@@ -348,7 +323,6 @@ export async function syncAnalyticsToFilters(options: SyncOptions = {}): Promise
     if (analyticsArticleType && filterArticleType) {
       const newValue = analyticsArticleType.value || '';
       if (filterArticleType.value !== newValue) {
-        if (window.DEBUG_MODE) console.log('[syncAnalyticsToFilters] Article type changed:', filterArticleType.value, '→', newValue); // DEBUG_MODE guard
         filterArticleType.value = newValue;
 
         // Update filters object immediately
@@ -358,7 +332,6 @@ export async function syncAnalyticsToFilters(options: SyncOptions = {}): Promise
         if (filterArticle) {
           filterArticle.value = '';
           PlanFilters.setFilters({ article_id: null });
-          if (window.DEBUG_MODE) console.log('[syncAnalyticsToFilters] Article filter reset due to type change'); // DEBUG_MODE guard
         }
 
         needsReload = true;
@@ -373,12 +346,9 @@ export async function syncAnalyticsToFilters(options: SyncOptions = {}): Promise
       // Check if option exists in filter dropdown
       const optionExists = filterArticle.querySelector(`option[value="${newValue}"]`);
       if (optionExists && filterArticle.value !== newValue) {
-        if (window.DEBUG_MODE) console.log('[syncAnalyticsToFilters] Article changed:', filterArticle.value, '→', newValue); // DEBUG_MODE guard
         filterArticle.value = newValue;
         PlanFilters.setFilters({ article_id: parseInt(newValue) || null });
         needsReload = true;
-      } else if (!optionExists && newValue) {
-        if (window.DEBUG_MODE) console.log('[syncAnalyticsToFilters] Article option not found in filter dropdown, skipping'); // DEBUG_MODE guard
       }
     }
 
@@ -389,7 +359,6 @@ export async function syncAnalyticsToFilters(options: SyncOptions = {}): Promise
     if (analyticsCFO && filterFC) {
       const newValue = analyticsCFO.value || '';
       if (filterFC.value !== newValue) {
-        if (window.DEBUG_MODE) console.log('[syncAnalyticsToFilters] CFO changed:', filterFC.value, '→', newValue); // DEBUG_MODE guard
         filterFC.value = newValue;
         PlanFilters.setFilters({ financial_center_id: parseInt(newValue) || null });
         needsReload = true;
@@ -398,11 +367,6 @@ export async function syncAnalyticsToFilters(options: SyncOptions = {}): Promise
 
     // 5. Reload facts table if any value changed
     if (needsReload && !skipReload) {
-      if (window.DEBUG_MODE) console.log('[syncAnalyticsToFilters] Reloading facts table with filters:', { // DEBUG_MODE guard
-        article_type: filterArticleType?.value || null,
-        article_id: filterArticle?.value || null,
-        financial_center_id: filterFC?.value || null
-      });
       PlanFactsTable.setCurrentPage(0);
       await PlanFactsTable.loadFacts();
       PlanFilters.updateFilterIndicator();

--- a/frontend/web/static/js/plan/index.ts
+++ b/frontend/web/static/js/plan/index.ts
@@ -135,8 +135,7 @@ export async function initialize(): Promise<void> {
       loadArticlesDropdown(),
       loadFinancialCentersDropdown(),
       loadCostCentersDropdown(),
-      PlanAnalytics.loadAnalyticsCFOFilter(),
-      PlanAnalytics.loadAnalyticsArticleFilter()
+      PlanAnalytics.populateAllAnalyticsFilters()
     ]);
 
     // Apply filters and load initial data

--- a/frontend/web/templates/components/plan/analytics_section.html
+++ b/frontend/web/templates/components/plan/analytics_section.html
@@ -47,10 +47,7 @@
                     </label>
                     <select id="analytics-article-type" class="select select-bordered h-12 w-full" onchange="window.PlanApp.onAnalyticsArticleTypeChange()">
                         <option value="">Все типы</option>
-                        <option value="expense">Расходы</option>
-                        <option value="income">Доходы</option>
-                        <option value="debit">Списание</option>
-                        <option value="credit">Пополнение</option>
+                        <!-- Options populated dynamically from plan records -->
                     </select>
                 </div>
 


### PR DESCRIPTION
## Summary
- Убран дефолтный выбор месяца — кнопки стартуют без выделения (`btn-outline`)
- Добавлен `loadAnalyticsFilterOptions()` с кешем, обращается к `/api/v1/analytics/plans/filter-options`
- Фильтры счёта и категорий заполняются только из реальных записей планирования
- Тип операции (`article-type`) теперь заполняется динамически через `populateArticleTypeFilter()`
- Параллельная загрузка CFO и article фильтров через `Promise.all`
- Fallback к legacy API при недоступности filter-options endpoint

## Dependencies
Требует мерджа PR #504 (backend endpoint) перед деплоем.

## Test plan
- [ ] При открытии аналитики ни один месяц не выбран
- [ ] Фильтр «Счёт» показывает только счета из планов
- [ ] Фильтр «Тип операции» показывает только типы из планов
- [ ] Фильтр «Категория» показывает только категории из планов
- [ ] TypeScript: `npm run type-check` — без ошибок ✓
- [ ] Bundle: `npm run bundle` — собирается без ошибок ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)