### PR TITLE
feat(analytics): add plans/filter-options endpoint for dynamic filter population

### DIFF
--- a/backend/app/api/v1/analytics.py
+++ b/backend/app/api/v1/analytics.py
@@ -3,6 +3,7 @@ Analytics API endpoints.
 
 Provides aggregated data for charts and dashboards.
 """
+import asyncio
 import calendar as cal_module
 import logging
 from datetime import date, datetime, timedelta
@@ -16,8 +17,12 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 from backend.app.core.dependencies import CurrentUser, get_session
 from backend.app.models.article import Article
 from backend.app.models.fact import BudgetFact as Fact
+from backend.app.models.financial_center import FinancialCenter
 from backend.app.schemas.analytics import (
     FactHintsResponse,
+    PlanFilterOptionArticle,
+    PlanFilterOptionFC,
+    PlanFilterOptionsResponse,
     PlanHintsResponse,
     TransactionFilterEnum,
 )
@@ -2330,4 +2335,77 @@ async def get_plan_hints(
         article_id=article_id,
         article_name=article_name,
         article_type=article_type
+    )
+
+
+# ==================== Plan Filter Options ====================
+
+
+@router.get("/plans/filter-options", response_model=PlanFilterOptionsResponse)
+async def get_plans_filter_options(
+    current_user: CurrentUser,
+    session: AsyncSession = Depends(get_session),
+):
+    """
+    Get distinct filter options from plan records.
+
+    Returns unique values present in planning records (record_type='plan').
+    Used to populate filter dropdowns with only real data, not full dictionaries.
+
+    NOTE: Shared Family Budget - NO user_id filter (all users see all data)
+
+    Returns:
+        PlanFilterOptionsResponse with financial_centers, article_types, articles
+    """
+    # Financial centers from plan records (INNER JOIN excludes NULLs implicitly)
+    fc_query = (
+        select(FinancialCenter.id, FinancialCenter.name)
+        .select_from(Fact)
+        .join(FinancialCenter, Fact.financial_center_id == FinancialCenter.id)
+        .where(Fact.record_type == "plan")
+        .distinct()
+        .order_by(FinancialCenter.name)
+    )
+
+    # Article types from plan records
+    article_type_query = (
+        select(Article.type)
+        .select_from(Fact)
+        .join(Article, Fact.article_id == Article.id)
+        .where(Fact.record_type == "plan")
+        .distinct()
+    )
+
+    # Articles from plan records
+    articles_query = (
+        select(Article.id, Article.name, Article.type, Article.parent_id)
+        .select_from(Fact)
+        .join(Article, Fact.article_id == Article.id)
+        .where(Fact.record_type == "plan")
+        .distinct()
+        .order_by(Article.type, Article.name)
+    )
+
+    fc_result, article_type_result, articles_result = await asyncio.gather(
+        session.execute(fc_query),
+        session.execute(article_type_query),
+        session.execute(articles_query),
+    )
+
+    return PlanFilterOptionsResponse(
+        financial_centers=[
+            PlanFilterOptionFC(id=row.id, name=row.name)
+            for row in fc_result.all()
+        ],
+        article_types=[
+            row.type
+            for row in article_type_result.all()
+            if row.type is not None
+        ],
+        articles=[
+            PlanFilterOptionArticle(
+                id=row.id, name=row.name, type=row.type, parent_id=row.parent_id
+            )
+            for row in articles_result.all()
+        ],
     )

--- a/backend/app/schemas/analytics.py
+++ b/backend/app/schemas/analytics.py
@@ -134,3 +134,42 @@ class FactHintsResponse(BaseModel):
         description="Article type: 'expense', 'income', 'debit', or 'credit'",
         examples=["expense", "income", "debit", "credit"]
     )
+
+
+class PlanFilterOptionFC(BaseModel):
+    """Financial center option for plan filter."""
+
+    id: int
+    name: str
+
+
+class PlanFilterOptionArticle(BaseModel):
+    """Article option for plan filter."""
+
+    id: int
+    name: str
+    type: str
+    parent_id: int | None
+
+
+class PlanFilterOptionsResponse(BaseModel):
+    """
+    Response schema for plans/filter-options endpoint.
+
+    Returns distinct filter values present in plan records (record_type='plan').
+    Used to populate filter dropdowns with only real data (not full dictionaries).
+
+    Example Usage:
+        GET /api/v1/analytics/plans/filter-options
+
+        Response:
+        {
+            "financial_centers": [{"id": 1, "name": "Sberbank"}],
+            "article_types": ["expense", "income"],
+            "articles": [{"id": 45, "name": "Продукты", "type": "expense", "parent_id": 10}]
+        }
+    """
+
+    financial_centers: list[PlanFilterOptionFC]
+    article_types: list[str]
+    articles: list[PlanFilterOptionArticle]


### PR DESCRIPTION
## Summary
- Новый endpoint `GET /api/v1/analytics/plans/filter-options`
- Возвращает уникальные значения из записей планирования (`record_type='plan'`)
- Поля ответа: `financial_centers`, `article_types`, `articles`
- Добавлены Pydantic schemas: `PlanFilterOptionFC`, `PlanFilterOptionArticle`, `PlanFilterOptionsResponse`

## Test plan
- [ ] `GET /api/v1/analytics/plans/filter-options` возвращает 200
- [ ] Список счётов содержит только те, что используются в планах
- [ ] Список типов содержит только реально существующие в планах
- [ ] Список категорий содержит только используемые в планах

🤖 Generated with [Claude Code](https://claude.com/claude-code)