### PR TITLE
fix(fab): swap Plan/Fact button order on desktop speed dial

### DIFF
--- a/frontend/web/templates/components/fab_toolbar.html
+++ b/frontend/web/templates/components/fab_toolbar.html
@@ -78,21 +78,6 @@
     <div class="desktop-fab-wrapper fab-common-wrapper closed" id="desktop-fab-wrapper">
         <!-- Speed Dial Menu Items (shown above FAB button) -->
         <div class="fab-menu-item fab-common-menu-item">
-            <span class="badge badge-neutral mr-2 fab-common-badge hidden lg:inline">Добавить план</span>
-            <button
-                onclick="window.openModalPlan(); window.closeDesktopFabMenu();"
-                class="btn btn-sm btn-circle btn-primary shadow-lg fab-common-action-btn"
-                aria-label="Добавить плановую транзакцию"
-                title="Добавить план">
-                <svg class="fab-common-icon w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                    <!-- Calendar icon -->
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                          d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/>
-                </svg>
-            </button>
-        </div>
-
-        <div class="fab-menu-item fab-common-menu-item">
             <span class="badge badge-neutral mr-2 fab-common-badge hidden lg:inline">Добавить факт</span>
             <button
                 onclick="window.openModalFact(); window.closeDesktopFabMenu();"
@@ -103,6 +88,21 @@
                     <!-- Document icon -->
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                           d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
+                </svg>
+            </button>
+        </div>
+
+        <div class="fab-menu-item fab-common-menu-item">
+            <span class="badge badge-neutral mr-2 fab-common-badge hidden lg:inline">Добавить план</span>
+            <button
+                onclick="window.openModalPlan(); window.closeDesktopFabMenu();"
+                class="btn btn-sm btn-circle btn-primary shadow-lg fab-common-action-btn"
+                aria-label="Добавить плановую транзакцию"
+                title="Добавить план">
+                <svg class="fab-common-icon w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <!-- Calendar icon -->
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                          d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"/>
                 </svg>
             </button>
         </div>


### PR DESCRIPTION
## Summary
- Меняет порядок кнопок в Desktop Speed Dial FAB (≥1024px)
- Кнопка **Добавить план** теперь отображается сверху, **Добавить факт** снизу
- Причина: контейнер использует `flex-direction: column-reverse`, поэтому для нужного визуального порядка достаточно поменять DOM-порядок блоков

## Test plan
- [ ] Открыть https://fbd.ikeniborn.ru/ на десктопе (≥1024px)
- [ ] Нажать FAB (+) в правом нижнем углу
- [ ] Убедиться: «Добавить план» сверху, «Добавить факт» снизу
- [ ] Проверить что обе кнопки открывают правильные модальные окна

🤖 Generated with [Claude Code](https://claude.com/claude-code)