### PR TITLE
fix(facts): add missing reminder fields to recurring plan response

### DIFF
--- a/backend/app/api/v1/endpoints/facts.py
+++ b/backend/app/api/v1/endpoints/facts.py
@@ -130,6 +130,9 @@ async def _load_recurring_plan_data(
             "record_type": plan.record_type, "is_active": plan.is_active,
             "next_generation_date": plan.next_generation_date,
             "last_generated_date": plan.last_generated_date,
+            "enable_reminder": plan.enable_reminder,
+            "reminder_hour": plan.reminder_hour,
+            "reminder_minute": plan.reminder_minute,
             "created_at": plan.created_at, "updated_at": plan.updated_at,
         }
     except (SQLAlchemyError, ValueError, AttributeError) as e:


### PR DESCRIPTION
## Summary
- `_load_recurring_plan_data()` returned a dict without `enable_reminder`, `reminder_hour`, `reminder_minute` fields
- `RecurringPlanResponse` schema requires `enable_reminder: bool` with no default → FastAPI threw `ResponseValidationError` → 500 on `GET /api/v1/facts/{id}` for any fact linked to a recurring plan
- Added the three missing fields to the return dict

## Test plan
- [ ] Open a fact linked to a recurring plan in the edit dialog (`/` → plan record click)
- [ ] Verify no 500 error, dialog opens correctly with plan data

🤖 Generated with [Claude Code](https://claude.com/claude-code)