### PR TITLE
fix(facts): add pagination handlers to event delegation

### DIFF
--- a/frontend/web/static/js/facts/adapters/eventDelegation.ts
+++ b/frontend/web/static/js/facts/adapters/eventDelegation.ts
@@ -8,7 +8,8 @@
  */
 
 import { applyFiltersAction, resetFiltersAction, collapseFilters } from '../operations/filterOperations';
-import { batchDelete, exportFilteredFacts, applyFiltersAndReload, resetFiltersAndReload } from '../operations/factsController';
+import { batchDelete, exportFilteredFacts, applyFiltersAndReload, resetFiltersAndReload, goToPreviousPage, goToNextPage } from '../operations/factsController';
+import { previousPage, nextPage } from '../operations/paginationOperations';
 
 /**
  * Setup event delegation for all clickable elements
@@ -62,6 +63,18 @@ function handleClick(event: Event): void {
 
         case 'batch-delete':
             batchDelete();
+            break;
+
+        case 'previous-page':
+            if (previousPage()) {
+                goToPreviousPage();
+            }
+            break;
+
+        case 'next-page':
+            if (nextPage()) {
+                goToNextPage();
+            }
             break;
 
         default:


### PR DESCRIPTION
## Summary
- Pagination buttons on `/facts` used `data-action='previous-page'` / `'next-page'` attributes
- The `handleClick()` switch in `eventDelegation.ts` had no matching cases → clicks silently ignored
- Added `previous-page` and `next-page` cases with proper boundary guards via `previousPage()`/`nextPage()`

## Test plan
- [ ] Go to `/facts`, navigate to page 2+
- [ ] Click "← Пред." and "След. →" buttons — verify page changes
- [ ] Click "← Пред." on page 1 — verify nothing happens (boundary guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)