### PR TITLE
fix(ui): fix mobile pagination overflow on 375px screens

### DIFF
--- a/frontend/web/templates/components/plan/pagination.html
+++ b/frontend/web/templates/components/plan/pagination.html
@@ -7,9 +7,9 @@
 #}
 
 {% macro pagination_controls() %}
-    <div class="flex justify-center items-center gap-4 mt-4" id="pagination-controls" style="display: none;">
-        <button class="btn btn-sm btn-outline" id="prev-btn" onclick="previousPage()" disabled>← Предыдущая</button>
-        <span class="font-medium" id="page-info">Страница 1</span>
-        <button class="btn btn-sm btn-outline" id="next-btn" onclick="nextPage()" disabled>Следующая →</button>
+    <div class="flex flex-wrap justify-center items-center gap-2 sm:gap-4 mt-4" id="pagination-controls" style="display: none;">
+        <button class="btn btn-sm btn-outline" id="prev-btn" onclick="previousPage()" disabled>← Пред.</button>
+        <span class="font-medium text-sm" id="page-info">Страница 1</span>
+        <button class="btn btn-sm btn-outline" id="next-btn" onclick="nextPage()" disabled>След. →</button>
     </div>
 {% endmacro %}

--- a/frontend/web/templates/facts.html
+++ b/frontend/web/templates/facts.html
@@ -186,14 +186,10 @@
             {% include "partials/facts/facts_table_container.html" %}
 
             <!-- Pagination -->
-            <div class="flex justify-center items-center gap-4 mt-4" id="pagination-controls" style="display: none;">
-                <button class="btn btn-sm btn-outline" id="prev-btn" data-action="previous-page" disabled>
-                    ← Предыдущая
-                </button>
-                <span class="font-medium" id="page-info">Страница 1</span>
-                <button class="btn btn-sm btn-outline" id="next-btn" data-action="next-page" disabled>
-                    Следующая →
-                </button>
+            <div class="flex flex-wrap justify-center items-center gap-2 sm:gap-4 mt-4" id="pagination-controls" style="display: none;">
+                <button class="btn btn-sm btn-outline" id="prev-btn" data-action="previous-page" disabled>← Пред.</button>
+                <span class="font-medium text-sm" id="page-info">Страница 1</span>
+                <button class="btn btn-sm btn-outline" id="next-btn" data-action="next-page" disabled>След. →</button>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- Pagination container lacked `flex-wrap` → buttons overflow on 375px screens
- Reduced gap: `gap-2 sm:gap-4` (was fixed `gap-4`)
- Added `text-sm` to page-info span
- Shortened button labels: `← Предыдущая` → `← Пред.`, `Следующая →` → `След. →`
- Applied to both `facts.html` and `components/plan/pagination.html`

Replaces #511 (rebased on test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)