### PR TITLE
feat(facts): add mutual exclusion for transfer accounts

### DIFF
--- a/frontend/web/static/js/facts/features/modalFact/categoryWidget.ts
+++ b/frontend/web/static/js/facts/features/modalFact/categoryWidget.ts
@@ -18,6 +18,7 @@ import {
     setEditCategoryTreeSelect
 } from '../../core/stateManager';
 import { setupMobileModalPositioning } from '../../../utils/mobileModalPositioning';
+import { setupTransferFCExclusion, cleanupExclusionFlag } from '../../../dashboard/shared/utils/transferFCExclusion';
 
 const TRANSACTION_ARTICLE_SELECTOR = '#modal_fact-tab-transaction select[name="article_id"]';
 const TRANSACTION_FC_SELECTOR      = '#modal_fact-tab-transaction select[name="financial_center_id"]';
@@ -271,6 +272,20 @@ function setupTransferFCListeners(): void {
         });
         toFcSelect.dataset.listenerAttached = 'true';
     }
+
+    if (fromFcSelect && toFcSelect) {
+        setupTransferFCExclusion({
+            fromSelect: fromFcSelect,
+            toSelect: toFcSelect,
+            onToClear: () => {
+                const toTree = getCreateTransferToTree();
+                if (toTree) {
+                    toTree.clearSelection();
+                    toTree.disable();
+                }
+            }
+        });
+    }
 }
 
 // ============================================================================
@@ -314,6 +329,9 @@ export function destroyEditCategoryTree(): void {
  * Destroy all category tree instances (called on modal close if needed).
  */
 export function destroyCategoryTrees(): void {
+    const fromFcEl = document.querySelector<HTMLSelectElement>(FROM_FC_SELECTOR);
+    cleanupExclusionFlag(fromFcEl);
+
     const transaction = getCreateCategoryTreeSelect();
     if (transaction) {
         try { transaction.destroy(); } catch (_) {}


### PR DESCRIPTION
## Summary
- When a user selects an account in the FROM field of the transfer form on the facts page (`/facts`), that account is now removed from the TO dropdown options
- Mirrors the behaviour already present on the dashboard/plan pages
- Uses the existing `setupTransferFCExclusion` / `cleanupExclusionFlag` utilities from `dashboard/shared/utils/transferFCExclusion`

## Changes
- `frontend/web/static/js/facts/features/modalFact/categoryWidget.ts`:
  - Added import for `setupTransferFCExclusion` and `cleanupExclusionFlag`
  - Called `setupTransferFCExclusion` at the end of `setupTransferFCListeners()` with an `onToClear` that clears and disables the TO category tree
  - Called `cleanupExclusionFlag` at the start of `destroyCategoryTrees()` to remove the listener on modal close

## Test plan
- [ ] `npm run type-check` — passes (verified)
- [ ] `npm run bundle` — all 39 bundles build successfully (verified)
- [ ] Open `/facts`, click Add Transfer, select an account in FROM — verify that account is absent from the TO dropdown
- [ ] Change FROM selection — verify TO updates accordingly
- [ ] Close and reopen the modal — verify the exclusion resets correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)