### PR TITLE
fix(facts): refresh facts table after transfer save in modal_fact

### DIFF
--- a/frontend/web/static/js/facts/adapters/windowExports.ts
+++ b/frontend/web/static/js/facts/adapters/windowExports.ts
@@ -18,6 +18,7 @@ import {
     updateFact as updateFactAction,
     deleteFromEditModal as deleteFromEditModalAction,
     createFact as createFactAction,
+    reloadFacts,
     exportFilteredFacts as exportFilteredFactsAction,
     applyFiltersAndReload,
     resetFiltersAndReload,
@@ -61,6 +62,7 @@ export function setupWindowExports(): void {
     window.deleteFromEditModal = deleteFromEditModal;
     window.exportFilteredFacts = exportFilteredFacts;
     window.createFact = createFact;
+    window.reloadFacts = reloadFacts;
 
     // Modal operations
     window.openCreateModal = openCreateModal;

--- a/frontend/web/static/js/facts/types/globals.d.ts
+++ b/frontend/web/static/js/facts/types/globals.d.ts
@@ -42,6 +42,7 @@ declare global {
         openCreateModal?: () => void;
         createFact?: (event: Event) => Promise<void>;
         createTransfer?: (event: Event) => Promise<void>;
+        reloadFacts?: () => Promise<void>;
         filterEditCostCenters?: (financialCenterId: string) => Promise<void>;
         saveFactModal?: (button: HTMLElement) => Promise<void>;
 


### PR DESCRIPTION
## Summary

- Зарегистрирован `window.reloadFacts` в `setupWindowExports()` — функция вызывалась, но не была доступна глобально
- Добавлен тип `reloadFacts` в `facts/types/globals.d.ts`

## Root Cause

`saveFactTransfer` вызывал `window.reloadFacts()` после сохранения перевода, но эта функция никогда не регистрировалась в `window` объекте — вызов молча игнорировался и таблица оставалась устаревшей.

## Test plan

- [ ] Открыть /facts, добавить перевод (Transfer tab) — таблица должна обновиться сразу после закрытия модального окна
- [ ] Добавить транзакцию (Transaction tab) — поведение не изменилось

🤖 Generated with [Claude Code](https://claude.com/claude-code)