### PR TITLE
fix(lists): restore FAB buttons and fix double confirmation after cache reset

### DIFF
--- a/frontend/web/static/js/data/DataLayer.ts
+++ b/frontend/web/static/js/data/DataLayer.ts
@@ -801,12 +801,13 @@ export class DataLayer {
       const list = await dexie.getDB().shoppingLists.where('id').equals(listId).first();
       if (!list || !list.temp_id) {
         console.warn('[DATA_LAYER] List not found in Dexie or missing temp_id, using API fallback');
-        const result = await this.getShoppingListItemsFromAPI(listId, filters);
+        const apiResult = await this.fetchEnrichAndCacheItems(listId, undefined, filters);
         performanceMonitor.trackAPICall('getShoppingListItems', performance.now() - startTime);
-        return result;
+        console.debug('[DATA_LAYER] API fallback returned (no list temp_id)', { count: apiResult.length });
+        return apiResult;
       }
 
-      const listTempId = list.temp_id;  // ← Use Dexie temp_id for FK query
+      const listTempId = list.temp_id;
       let result = await dexie.queryShoppingListItems(listTempId);
       const duration = performance.now() - startTime;
 
@@ -858,26 +859,7 @@ export class DataLayer {
 
       if (result.length === 0) {
         console.debug('[DATA_LAYER] Dexie returned empty, using API fallback');
-        let apiResult = await this.getShoppingListItemsFromAPI(listId, filters);
-
-        // CRITICAL FIX: Ensure temp_id exists for all API items (for bulk delete compatibility)
-        apiResult = apiResult.map(item => ({
-          ...item,
-          temp_id: item.temp_id || `item_${item.id}_${Date.now()}`,
-          shopping_list_temp_id: item.shopping_list_temp_id || listTempId,
-          sync_status: item.sync_status || 'synced',
-        }));
-
-        // Cache API items in Dexie so next offline access doesn't lose data
-        if (apiResult.length > 0) {
-          try {
-            await dexie.getDB().shoppingListItems.bulkPut(apiResult);
-            console.debug('[DATA_LAYER] Cached API items in Dexie', { count: apiResult.length });
-          } catch (cacheError) {
-            console.warn('[DATA_LAYER] Failed to cache API items in Dexie', cacheError);
-          }
-        }
-
+        const apiResult = await this.fetchEnrichAndCacheItems(listId, listTempId, filters);
         performanceMonitor.trackAPICall('getShoppingListItems', performance.now() - startTime);
         console.debug('[DATA_LAYER] API fallback returned', { count: apiResult.length });
         return apiResult;
@@ -893,6 +875,41 @@ export class DataLayer {
       performanceMonitor.trackAPICall('getShoppingListItems', performance.now() - startTime);
       return result;
     }
+  }
+
+  /**
+   * Fetch items from API, enrich with temp_ids, and cache in Dexie.
+   * Used for both "list not in Dexie" and "Dexie returned empty" fallback paths.
+   *
+   * @param listId - Shopping list numeric ID
+   * @param listTempId - Known temp_id for the list; derived from items if absent
+   * @param filters - Optional filters
+   */
+  private async fetchEnrichAndCacheItems(
+    listId: number,
+    listTempId: string | undefined,
+    filters?: ShoppingListItemFilters
+  ): Promise<LocalShoppingListItem[]> {
+    let items = await this.getShoppingListItemsFromAPI(listId, filters);
+    const resolvedListTempId = listTempId
+      || items.find(i => i.shopping_list_temp_id)?.shopping_list_temp_id
+      || `list_${listId}_temp`;
+    items = items.map(item => ({
+      ...item,
+      temp_id: item.temp_id || `item_${item.id}_${Date.now()}`,
+      shopping_list_temp_id: item.shopping_list_temp_id || resolvedListTempId,
+      sync_status: item.sync_status || 'synced',
+    }));
+    if (items.length > 0) {
+      try {
+        const dexie = await this.getDexie();
+        await dexie.getDB().shoppingListItems.bulkPut(items);
+        console.debug('[DATA_LAYER] Cached API items in Dexie', { count: items.length });
+      } catch (cacheError) {
+        console.warn('[DATA_LAYER] Failed to cache API items in Dexie', cacheError);
+      }
+    }
+    return items;
   }
 
   /**

--- a/frontend/web/static/js/lists/listsManager/core/listOperations.ts
+++ b/frontend/web/static/js/lists/listsManager/core/listOperations.ts
@@ -486,16 +486,19 @@ export async function deleteItem(itemId: number, skipConfirm: boolean = false): 
  * Dexie-first with API fallback (task-015 Phase 4.2)
  *
  * @param itemIds - Array of item IDs to delete
+ * @param skipConfirm - Skip confirmation dialog (default: false)
  */
-export async function deleteMultipleItems(itemIds: number[]): Promise<void> {
+export async function deleteMultipleItems(itemIds: number[], skipConfirm: boolean = false): Promise<void> {
   if (itemIds.length === 0) return;
 
-  const confirmed = await showConfirmDialog(
-    `Удалить выбранные товары (${itemIds.length})?\nЭто действие необратимо.`,
-    '🗑️ Удаление товаров'
-  );
-  if (!confirmed) {
-    return;
+  if (!skipConfirm) {
+    const confirmed = await showConfirmDialog(
+      `Удалить выбранные товары (${itemIds.length})?\nЭто действие необратимо.`,
+      '🗑️ Удаление товаров'
+    );
+    if (!confirmed) {
+      return;
+    }
   }
 
   const state = getState();

--- a/frontend/web/static/js/lists/listsManager/features/bulkActions.ts
+++ b/frontend/web/static/js/lists/listsManager/features/bulkActions.ts
@@ -64,7 +64,7 @@ export async function deleteCompleted(): Promise<void> {
   }
 
   const itemIds = completedItems.map((i) => i.id);
-  await deleteMultipleItems(itemIds);
+  await deleteMultipleItems(itemIds, true);  // caller already confirmed
 
   renderCurrentView();
   showToast(`Удалено: ${completedItems.length}`, 'success');

--- a/frontend/web/static/js/lists/listsManager/rendering/listRenderer.ts
+++ b/frontend/web/static/js/lists/listsManager/rendering/listRenderer.ts
@@ -11,7 +11,7 @@
 import { getState, updateState } from '../core/ListsState';
 import { loadShoppingLists, loadShoppingListItems } from '../core/stateManager';
 import { renderCurrentView } from './tableBuilder';
-import { updateHideCompletedButton } from '../features/searchFilter';
+import { updateHideCompletedButton, updateFABButtons } from '../features/searchFilter';
 
 // ============================================================================
 // Type Definitions
@@ -543,6 +543,7 @@ export async function renderDetailView(listId: number): Promise<void> {
 
   // Update FAB visibility after rendering
   updateFABVisibility();
+  updateFABButtons();  // re-evaluate with populated items: updateHideCompletedButton() ran earlier with empty state
 
   // Initialize Choices.js for store and product group selectors in modal
   // NOTE: These should be moved to modalManager.ts in Phase 3.3


### PR DESCRIPTION
## Summary
- Fixes a caching gap in `DataLayer.getShoppingListItems()` where the `!list || !list.temp_id` branch returned API items without enriching them with `temp_id`/`shopping_list_temp_id` or caching them in Dexie
- Extracted shared `fetchEnrichAndCacheItems()` private helper to eliminate duplication between the "list not in Dexie" and "Dexie returned empty" fallback paths
- Both fallback paths now consistently enrich items and cache in Dexie for future offline use

## Test plan
- [ ] Open shopping list page when list record is missing from Dexie — items should load and be cached
- [ ] Open shopping list page when list record exists but has no `temp_id` — items should load, be enriched with temp_ids, and be cached
- [ ] Go offline after initial load — items should be available from Dexie cache
- [ ] Bulk delete should work correctly on items loaded via the fallback path (temp_ids present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)