### PR TITLE
fix(plan): simplify ID and category column styling in facts table

### DIFF
--- a/frontend/web/static/js/plan/factsTable.ts
+++ b/frontend/web/static/js/plan/factsTable.ts
@@ -349,11 +349,11 @@ function renderFactsTable(facts: BudgetFact[]): void {
     tableHtml += `
       <tr data-plan-id="${fact.id}">
         <td><input type="checkbox" class="checkbox checkbox-sm fact-checkbox" value="${fact.id}" onchange="window.PlanApp.FactsTable.updateBatchDeleteButton()"></td>
-        <td><code class="badge badge-ghost">${fact.id}</code></td>
+        <td class="text-base-content/50 text-xs">${fact.id}</td>
         <td>${formattedDate}</td>
         <td class="max-w-xs truncate" title="${financialCenter}">${financialCenter}</td>
         <td class="max-w-xs truncate" title="${costCenter}">${costCenter}</td>
-        <td><span class="${articleColorClass}">${articleName}</span></td>
+        <td>${articleName}</td>
         <td class="${articleColorClass} font-bold">${TableFormatters.formatAmount(fact.amount, fact.article_type)}</td>
         <td class="max-w-xs truncate" title="${description}">${descriptionTruncated}</td>
         <td>${userName}</td>


### PR DESCRIPTION
## Summary

- Remove `<code class="badge badge-ghost">` wrapper from ID column; replace with plain `<td class="text-base-content/50 text-xs">` for a subtler muted style
- Remove color class span from Category column — `articleColorClass` (text-error/text-success/text-info/text-warning) now applies only to the Amount column (`font-bold`) as intended

## Test plan

- [ ] Navigate to `/plan` page and verify ID column shows plain muted small text instead of a badge chip
- [ ] Verify Category column text is no longer colored (red/green/blue/yellow)
- [ ] Verify Amount column still shows colored bold text
- [ ] Test on mobile, tablet, and desktop viewports

🤖 Generated with [Claude Code](https://claude.com/claude-code)