### PR TITLE
fix(dashboard): export loadRecentTransactions to window for Recent Records refresh

### DIFF
--- a/frontend/web/static/js/dashboard/adapters/windowExports.ts
+++ b/frontend/web/static/js/dashboard/adapters/windowExports.ts
@@ -778,6 +778,7 @@ export function initWindowExports(): void {
   window.refreshRecentTransactions = refreshRecentTransactionsImpl;
   window.refreshQuickStats = refreshQuickStatsImpl;
   window.refreshAccountBalances = refreshAccountBalancesImpl;
+  window.loadRecentTransactions = loadRecentTransactions;
 
   // Expose pending records delete function globally (Phase 2)
   window.deleteFailedRecords = deleteFailedRecords;

--- a/frontend/web/static/js/dashboard/features/modalPlan/saveTransaction.ts
+++ b/frontend/web/static/js/dashboard/features/modalPlan/saveTransaction.ts
@@ -105,8 +105,7 @@ export async function savePlanTransaction(form: HTMLFormElement): Promise<void> 
   // Update UI
   await refreshUIAfterPlanSave();
 
-  // Refresh recent records to show updated has_reminder state
-  if (typeof (window as any).loadRecentTransactions === 'function') {
-    await (window as any).loadRecentTransactions();
+  if (typeof window.loadRecentTransactions === 'function') {
+    await window.loadRecentTransactions();
   }
 }

--- a/frontend/web/static/js/dashboard/types/globals.d.ts
+++ b/frontend/web/static/js/dashboard/types/globals.d.ts
@@ -266,6 +266,9 @@ declare global {
     refreshQuickStats?: () => void;
     refreshAccountBalances?: () => void;
 
+    // Recent Transactions (client-side refresh)
+    loadRecentTransactions?: () => Promise<void>;
+
     // Dashboard-specific (HTML onclick handlers)
     openEditFromDashboard?: (factId: number) => Promise<void>;
     deleteRecordFromDashboard?: (factId: number) => Promise<void>;


### PR DESCRIPTION
## Summary

- `window.loadRecentTransactions` was never assigned in `initWindowExports()`, so `saveTransaction.ts` could never call it — Recent Records never refreshed after saving a plan
- Adds `window.loadRecentTransactions = loadRecentTransactions` in `windowExports.ts`
- Declares `loadRecentTransactions?: () => Promise<void>` in the `Window` interface in `globals.d.ts`
- Removes `(window as any)` cast in `saveTransaction.ts` now that the type is declared

## Bugs fixed

- **Bug 1**: Recent Records не обновляется после добавления плана с регулярным платежом
- **Bug 2**: Признак уведомления (🔔) не отображается в Recent Records после добавления плана с уведомлением

## Test plan

- [ ] Add a plan with a recurring payment — verify Recent Records updates immediately
- [ ] Add a plan with a reminder — verify 🔔 icon appears in Recent Records immediately
- [ ] `npm run type-check` passes (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)