### PR TITLE
fix(plan): fix batch-delete recurring plans button not resetting after deletion

### DIFF
--- a/frontend/web/static/js/plan/crud.ts
+++ b/frontend/web/static/js/plan/crud.ts
@@ -1927,7 +1927,6 @@ export async function batchDeleteRecurringPlans(): Promise<void> {
   const btn = document.getElementById('batch-delete-recurring-plans-btn') as HTMLButtonElement | null;
   if (!btn) return;
 
-  const originalText = btn.textContent || '';
   btn.disabled = true;
   btn.classList.add('loading', 'loading-spinner');
   btn.textContent = `Удаление... (${count})`;
@@ -1975,8 +1974,7 @@ export async function batchDeleteRecurringPlans(): Promise<void> {
     showNotification(`❌ Ошибка массового удаления: ${(error as any)?.message}`, 'error');
   } finally {
     btn.classList.remove('loading', 'loading-spinner');
-    btn.textContent = originalText;
-    btn.disabled = false;
+    updateBatchDeleteRecurringPlansButtonState();
   }
 }
 


### PR DESCRIPTION
## Summary

- Фикс бага в `batchDeleteRecurringPlans()`: блок `finally` восстанавливал устаревший текст кнопки и снова включал её, перезаписывая правильное состояние установленное `updateBatchDeleteRecurringPlansButtonState()`
- Заменено на вызов `updateBatchDeleteRecurringPlansButtonState()` в `finally` — теперь кнопка корректно отражает состояние выбора после удаления
- Удалена мёртвая переменная `originalText` которая стала неиспользуемой после фикса

## Root Cause

`finally` блок всегда выполнялся после `try` и перезаписывал `btn.textContent` и `btn.disabled` значениями до операции, даже когда `updateBatchDeleteRecurringPlansButtonState()` уже выставил правильные значения.

## Test plan

- [ ] Открыть https://fbd.ikeniborn.ru/plan
- [ ] Раскрыть "Управление регламентными платежами"
- [ ] Отметить чекбокс → кнопка показывает "(1)"
- [ ] Нажать "Удалить выбранные (1)", подтвердить
- [ ] После удаления кнопка должна вернуться к "🗑️ Удалить выбранные" и быть disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)