### PR TITLE
feat(facts): incremental row updates for WebSocket events

### DIFF
--- a/backend/app/api/v1/endpoints/facts.py
+++ b/backend/app/api/v1/endpoints/facts.py
@@ -1126,6 +1126,108 @@ async def get_recent_facts_html(
         """
 
 
+@router.get("/{fact_id}/row-html", response_class=HTMLResponse)
+async def get_fact_row_html(
+    fact_id: int,
+    current_user: CurrentUser,
+    session: AsyncSession = Depends(get_session),
+) -> str:
+    """Return HTML for a single fact/plan row (desktop tr + mobile div).
+
+    Used by frontend for incremental WebSocket updates — replaces or prepends
+    a single row without reloading the entire table.
+
+    **Returns:**
+    - HTML fragment: one <tr data-id="..."> + one <div data-id="..."> for mobile
+    - 404 if fact not found
+    """
+    from backend.app.utils.template_filters import amount_color, format_money_recent
+
+    statement = select(BudgetFact).where(BudgetFact.id == fact_id)
+    result = await session.execute(statement)
+    fact = result.scalar_one_or_none()
+
+    if not fact:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Fact with id={fact_id} not found"
+        )
+
+    # Load article, financial center, and cost center in parallel queries
+    article_stmt = select(Article).where(Article.id == fact.article_id)
+    article_result = await session.execute(article_stmt)
+    article = article_result.scalar_one_or_none()
+
+    if not article:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Article for fact id={fact_id} not found"
+        )
+
+    financial_center = None
+    if fact.financial_center_id:
+        fc_stmt = select(FinancialCenter).where(FinancialCenter.id == fact.financial_center_id)
+        fc_result = await session.execute(fc_stmt)
+        financial_center = fc_result.scalar_one_or_none()
+
+    cost_center = None
+    if fact.cost_center_id:
+        cc_stmt = select(CostCenter).where(CostCenter.id == fact.cost_center_id)
+        cc_result = await session.execute(cc_stmt)
+        cost_center = cc_result.scalar_one_or_none()
+
+    amount_formatted = format_money_recent(fact.amount, article.type)
+    article_color_class = amount_color(article.type)
+
+    fact_date_full = fact.fact_date.strftime("%d.%m.%Y")
+    fact_date_short = fact.fact_date.strftime("%d.%m")
+
+    fc_name = financial_center.name if financial_center else "—"
+    cc_name = cost_center.name if cost_center else "—"
+
+    description = fact.description if fact.description else "—"
+    description_truncated = description[:30] + "..." if len(description) > 30 else description
+
+    desktop_row = f"""<tr data-id="{fact.id}">
+        <td><input type="checkbox" class="checkbox checkbox-sm fact-checkbox" data-fact-id="{fact.id}"></td>
+        <td>{fact_date_full}</td>
+        <td><span class="{article_color_class}">{article.name}</span></td>
+        <td class="{article_color_class} font-bold">{amount_formatted}</td>
+        <td class="max-w-xs truncate" title="{fc_name}">{fc_name}</td>
+        <td class="max-w-xs truncate" title="{cc_name}">{cc_name}</td>
+        <td class="max-w-xs truncate" title="{description}">{description_truncated}</td>
+        <td>
+            <div class="flex gap-1">
+                <button class="btn btn-xs btn-primary gap-1" onclick="window.FactsManager?.showEditModal?.({fact.id})">✏️</button>
+                <button class="btn btn-xs btn-error btn-square hidden md:inline-flex" onclick="event.stopPropagation(); window.FactsManager?.deleteFact?.({fact.id})" title="Удалить">
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                    </svg>
+                </button>
+            </div>
+        </td>
+    </tr>"""
+
+    # Mobile card
+    line2_parts = [fact_date_short, fc_name]
+    if description != "—":
+        line2_parts.append(description)
+    line2_text = " • ".join(line2_parts)
+
+    mobile_card = f"""<div class="transaction-item py-2" data-id="{fact.id}" onclick="window.FactsManager?.showEditModal?.({fact.id})">
+        <div class="flex items-center gap-2">
+            <span class="badge badge-primary badge-xs shrink-0">Факт</span>
+            <span class="flex-1 font-medium truncate">{article.name}</span>
+            <span class="{article_color_class} font-bold whitespace-nowrap">{amount_formatted}</span>
+        </div>
+        <div class="text-xs text-base-content/60 mt-1 truncate">
+            {line2_text}
+        </div>
+    </div>"""
+
+    return desktop_row + "\n" + mobile_card
+
+
 @router.get(
     "/summary",
     response_model=FactSummary,

--- a/frontend/web/static/js/facts/integration/wsEventHandlers.ts
+++ b/frontend/web/static/js/facts/integration/wsEventHandlers.ts
@@ -2,12 +2,15 @@
  * Facts Manager - WebSocket Event Handlers
  *
  * Registers WebSocket event handlers for real-time updates.
+ * Uses incremental row updates for fact_created, fact_updated, fact_deleted
+ * to avoid full table reloads on every WebSocket event.
  *
  * Phase 3: WebSocket Integration
  */
 
 import { loadFacts } from '../operations/factsController';
 import { buildFilterQuery } from '../operations/filterOperations';
+import { getCurrentPage } from '../core/stateManager';
 import type { BudgetFact } from '../types/models';
 
 // ============================================================================
@@ -20,6 +23,7 @@ let wsReloadTimeout: NodeJS.Timeout | null = null;
 /**
  * Debounced reload via loadFacts()
  * Prevents multiple reloads within 500ms window
+ * Used as fallback when incremental update fails
  */
 function debouncedReloadFacts(): void {
     if (wsReloadTimeout) {
@@ -100,36 +104,217 @@ function matchesCurrentFilters(fact: Partial<BudgetFact>): boolean {
 }
 
 // ============================================================================
+// Incremental Row Update Helpers
+// ============================================================================
+
+/**
+ * Fetch HTML for a single fact row from the backend
+ *
+ * @param factId - Fact ID to fetch
+ * @returns HTML string (desktop tr + mobile div) or null on error
+ */
+async function fetchRowHtml(factId: number): Promise<string | null> {
+    try {
+        const response = await fetch(`/api/v1/facts/${factId}/row-html`, {
+            headers: { 'Accept': 'text/html' }
+        });
+        if (!response.ok) {
+            return null;
+        }
+        return await response.text();
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Parse HTML fragment into desktop <tr> and mobile <div> elements
+ *
+ * @param html - Raw HTML string from /row-html endpoint
+ * @returns Object with tr and mobileCard elements, or null if parsing fails
+ */
+function parseRowHtml(html: string): { tr: HTMLTableRowElement; mobileCard: HTMLDivElement } | null {
+    const wrapper = document.createElement('div');
+    wrapper.innerHTML = html;
+
+    const tr = wrapper.querySelector('tr[data-id]') as HTMLTableRowElement | null;
+    const mobileCard = wrapper.querySelector('div[data-id]') as HTMLDivElement | null;
+
+    if (!tr || !mobileCard) {
+        return null;
+    }
+
+    return { tr, mobileCard };
+}
+
+/**
+ * Prepend a new row to the facts table (desktop tbody + mobile list)
+ * Only runs when on page 1.
+ *
+ * @param tr - Desktop table row element
+ * @param mobileCard - Mobile card div element
+ */
+function prependRowToTable(tr: HTMLTableRowElement, mobileCard: HTMLDivElement): void {
+    const container = document.getElementById('facts-table-container');
+    if (!container) {
+        return;
+    }
+
+    const tbody = container.querySelector('.facts-desktop-table tbody');
+    if (tbody && tbody.firstChild) {
+        tbody.insertBefore(tr, tbody.firstChild);
+    } else if (tbody) {
+        tbody.appendChild(tr);
+    }
+
+    const mobileList = container.querySelector('.facts-mobile-list');
+    if (mobileList && mobileList.firstChild) {
+        mobileList.insertBefore(mobileCard, mobileList.firstChild);
+    } else if (mobileList) {
+        mobileList.appendChild(mobileCard);
+    }
+}
+
+/**
+ * Replace an existing row in the facts table with updated HTML
+ *
+ * @param factId - ID of the fact to replace
+ * @param tr - New desktop row element
+ * @param mobileCard - New mobile card element
+ * @returns true if row was found and replaced
+ */
+function replaceRowInTable(
+    factId: number,
+    tr: HTMLTableRowElement,
+    mobileCard: HTMLDivElement
+): boolean {
+    const container = document.getElementById('facts-table-container');
+    if (!container) {
+        return false;
+    }
+
+    let replaced = false;
+
+    const existingTr = container.querySelector(`tr[data-id="${factId}"]`);
+    if (existingTr) {
+        existingTr.replaceWith(tr);
+        replaced = true;
+    }
+
+    const existingCard = container.querySelector(`div[data-id="${factId}"]`);
+    if (existingCard) {
+        existingCard.replaceWith(mobileCard);
+        replaced = true;
+    }
+
+    return replaced;
+}
+
+/**
+ * Animate fade-out and remove a row from the facts table
+ *
+ * @param factId - ID of the fact to remove
+ */
+function animateAndRemoveRow(factId: number): void {
+    const container = document.getElementById('facts-table-container');
+    if (!container) {
+        return;
+    }
+
+    const elements = container.querySelectorAll<HTMLElement>(
+        `tr[data-id="${factId}"], div[data-id="${factId}"]`
+    );
+
+    elements.forEach(el => {
+        el.style.transition = 'opacity 0.3s ease';
+        el.style.opacity = '0';
+        setTimeout(() => el.remove(), 300);
+    });
+}
+
+// ============================================================================
 // Event Handlers
 // ============================================================================
 
 /**
  * Handle fact_created WebSocket event
- * Reloads table if fact matches current filters
+ * Fetches row HTML and prepends to table (page 1 only).
+ * Falls back to debounced full reload on error.
  */
-function handleFactCreated(data: Partial<BudgetFact>): void {
-    // Only reload if fact matches current filters
-    if (matchesCurrentFilters(data)) {
-        debouncedReloadFacts();
+async function handleFactCreated(data: Partial<BudgetFact>): Promise<void> {
+    if (!matchesCurrentFilters(data)) {
+        return;
     }
+
+    if (!data.id) {
+        debouncedReloadFacts();
+        return;
+    }
+
+    // Only prepend on page 1 — other pages don't show the newest record
+    if (getCurrentPage() !== 0) {
+        return;
+    }
+
+    const html = await fetchRowHtml(data.id);
+    if (!html) {
+        debouncedReloadFacts();
+        return;
+    }
+
+    const parsed = parseRowHtml(html);
+    if (!parsed) {
+        debouncedReloadFacts();
+        return;
+    }
+
+    prependRowToTable(parsed.tr, parsed.mobileCard);
 }
 
 /**
  * Handle fact_updated WebSocket event
- * Always reloads table (fact might have moved in/out of filter)
+ * Finds the existing row in DOM and replaces it with fresh HTML.
+ * If row not in current view, skips silently.
  */
-function handleFactUpdated(_data: Partial<BudgetFact>): void {
-    // Reload unconditionally (fact might have moved in/out of filters)
-    debouncedReloadFacts();
+async function handleFactUpdated(data: Partial<BudgetFact>): Promise<void> {
+    if (!data.id) {
+        return;
+    }
+
+    const container = document.getElementById('facts-table-container');
+    if (!container) {
+        return;
+    }
+
+    // Only update if the row is currently visible in the DOM
+    const existingTr = container.querySelector(`tr[data-id="${data.id}"]`);
+    if (!existingTr) {
+        return;
+    }
+
+    const html = await fetchRowHtml(data.id);
+    if (!html) {
+        return;
+    }
+
+    const parsed = parseRowHtml(html);
+    if (!parsed) {
+        return;
+    }
+
+    replaceRowInTable(data.id, parsed.tr, parsed.mobileCard);
 }
 
 /**
  * Handle fact_deleted WebSocket event
- * Reloads table to remove deleted fact
+ * Animates and removes the row from DOM.
+ * No API call required.
  */
-function handleFactDeleted(_data: { id: number }): void {
-    // Reload to remove deleted fact
-    debouncedReloadFacts();
+function handleFactDeleted(data: { id: number }): void {
+    if (!data.id) {
+        return;
+    }
+    animateAndRemoveRow(data.id);
 }
 
 /**
@@ -137,7 +322,6 @@ function handleFactDeleted(_data: { id: number }): void {
  * Reloads table after bulk deletion
  */
 function handleBatchDeleteCompleted(_data: { deleted_count: number; failed_count: number }): void {
-    // Reload table after batch deletion
     debouncedReloadFacts();
 }
 
@@ -146,7 +330,6 @@ function handleBatchDeleteCompleted(_data: { deleted_count: number; failed_count
  * Transfers create two facts, reload table
  */
 function handleTransferCreated(_data: any): void {
-    // Transfers create facts, reload table
     debouncedReloadFacts();
 }
 
@@ -155,7 +338,6 @@ function handleTransferCreated(_data: any): void {
  * Reload dropdowns (handled by AdminFactsCommon if available)
  */
 function handleArticleUpdated(_data: any): void {
-    // Reload table to reflect updated article names
     debouncedReloadFacts();
 }
 

--- a/frontend/web/static/js/facts/operations/factsController.ts
+++ b/frontend/web/static/js/facts/operations/factsController.ts
@@ -690,7 +690,7 @@ interface FactRowParts {
 
 function buildFactRowHtml(fact: FactRow, p: FactRowParts): string {
     return `
-        <tr>
+        <tr data-id="${fact.id}">
             <td><input type="checkbox" class="checkbox checkbox-sm fact-checkbox" data-fact-id="${fact.id}"></td>
             <td class="text-base-content/50 text-xs">${fact.id}</td>
             <td>${escapeHtml(p.dateFormatted)}</td>
@@ -749,7 +749,7 @@ export function renderFactMobileCard(fact: FactRow): string {
     const description = commentText ? TableFormatters.truncateText(commentText, 30) : '—';  // Already escaped
 
     return `
-        <div class="transaction-item py-2" onclick="window.FactsManager?.showEditModal?.(${fact.id})">
+        <div class="transaction-item py-2" data-id="${fact.id}" onclick="window.FactsManager?.showEditModal?.(${fact.id})">
             <!-- Line 1: Badge + Category + Amount -->
             <div class="flex items-center gap-2">
                 <span class="badge badge-primary badge-xs shrink-0">Факт</span>


### PR DESCRIPTION
## Summary
- WebSocket `fact_created` → incremental prepend (matches filters, page 1)
- WebSocket `fact_updated` → replace specific `tr[data-id]` with fresh row HTML
- WebSocket `fact_deleted` → fade animation + DOM removal
- Debounced `loadFacts()` fallback preserved for errors
- Add `data-id` to desktop rows for WS selector targeting

## Dependencies
Requires #530 (backend endpoint) to be merged first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)