### PR TITLE
fix(facts): incremental table update after transfer creation

### DIFF
--- a/frontend/web/static/js/dashboard/features/modalFact/saveTransfer.ts
+++ b/frontend/web/static/js/dashboard/features/modalFact/saveTransfer.ts
@@ -40,8 +40,17 @@ export async function saveFactTransfer(form: HTMLFormElement): Promise<void> {
   };
 
   // POST /api/v1/transfers
-  await postAPI('/api/v1/transfers', data, 'SaveFactModal');
+  const transferData = await postAPI<{ expense_fact_id?: number; income_fact_id?: number }>(
+    '/api/v1/transfers', data, 'SaveFactModal'
+  );
 
-  // Update UI
+  // Try incremental row injection for facts page; fall back to full reload if unavailable
+  const injectRow = (window as any).FactsManager?.fetchAndInjectRow;
+  if (typeof injectRow === 'function') {
+    const ids = [transferData.expense_fact_id, transferData.income_fact_id].filter(Boolean) as number[];
+    const results = await Promise.all(ids.map(id => injectRow(id, 'create') as Promise<boolean>));
+    if (results.some(Boolean)) return;
+  }
+
   await refreshUIAfterFactSave();
 }

--- a/frontend/web/static/js/facts/adapters/windowExports.ts
+++ b/frontend/web/static/js/facts/adapters/windowExports.ts
@@ -19,6 +19,7 @@ import {
     deleteFromEditModal as deleteFromEditModalAction,
     createFact as createFactAction,
     reloadFacts,
+    fetchAndInjectRow,
     exportFilteredFacts as exportFilteredFactsAction,
     applyFiltersAndReload,
     resetFiltersAndReload,
@@ -81,6 +82,7 @@ export function setupWindowExports(): void {
         getFilters,
         getPagination,
         getSelectedIds,
+        fetchAndInjectRow,
     };
 
     // Transaction operations (delegated to external modules when available)

--- a/frontend/web/static/js/facts/integration/wsEventHandlers.ts
+++ b/frontend/web/static/js/facts/integration/wsEventHandlers.ts
@@ -8,7 +8,7 @@
  * Phase 3: WebSocket Integration
  */
 
-import { loadFacts } from '../operations/factsController';
+import { loadFacts, fetchAndInjectRow } from '../operations/factsController';
 import { buildFilterQuery } from '../operations/filterOperations';
 import { getCurrentPage } from '../core/stateManager';
 import type { BudgetFact } from '../types/models';
@@ -327,10 +327,19 @@ function handleBatchDeleteCompleted(_data: { deleted_count: number; failed_count
 
 /**
  * Handle transfer_created WebSocket event
- * Transfers create two facts, reload table
+ * Incrementally inserts two fact rows (expense + income).
+ * Falls back to full reload if incremental fails or user is not on page 0.
  */
-function handleTransferCreated(_data: any): void {
-    debouncedReloadFacts();
+async function handleTransferCreated(data: { expense_fact_id?: number; income_fact_id?: number }): Promise<void> {
+    if (getCurrentPage() !== 0) {
+        debouncedReloadFacts();
+        return;
+    }
+    const ids = [data.expense_fact_id, data.income_fact_id].filter(Boolean) as number[];
+    const results = await Promise.all(ids.map(id => fetchAndInjectRow(id, 'create')));
+    if (!results.some(Boolean)) {
+        debouncedReloadFacts();
+    }
 }
 
 /**

--- a/frontend/web/static/js/facts/operations/factsController.ts
+++ b/frontend/web/static/js/facts/operations/factsController.ts
@@ -150,7 +150,7 @@ function canInjectRow(): boolean {
  * For 'update': replace existing tr[data-id] and div[data-id].
  * Returns true on success, false if fallback (full reload) is needed.
  */
-async function fetchAndInjectRow(factId: number, operation: 'create' | 'update'): Promise<boolean> {
+export async function fetchAndInjectRow(factId: number, operation: 'create' | 'update'): Promise<boolean> {
     if (!canInjectRow()) {
         return false;
     }

--- a/frontend/web/static/js/facts/types/globals.d.ts
+++ b/frontend/web/static/js/facts/types/globals.d.ts
@@ -60,6 +60,7 @@ declare global {
             showEditModal?: (factId: number) => Promise<void> | void;
             deleteFact?: (factId: number) => Promise<void> | void;
             toggleSelectAll?: (checkbox: HTMLInputElement) => void;
+            fetchAndInjectRow: (factId: number, operation: 'create' | 'update') => Promise<boolean>;
         };
     }
 }


### PR DESCRIPTION
## Summary
- При добавлении перевода на /facts таблица теперь обновляется инкрементально без перезагрузки страницы
- Экспортирована `fetchAndInjectRow` из `factsController` для переиспользования
- `saveTransfer.ts` использует ID фактов из ответа API и инжектирует строки через `window.FactsManager.fetchAndInjectRow`
- `wsEventHandlers.ts` обновлён: параллельное инжектирование двух строк вместо полной перезагрузки таблицы

## Test plan
- [ ] Открыть https://fbd.ikeniborn.ru/facts
- [ ] Добавить перевод (разные счета откуда/куда)
- [ ] После закрытия модалки — убедиться, что 2 строки (расход + доход) появились без page reload
- [ ] Проверить на мобильном и десктопном разрешении

🤖 Generated with [Claude Code](https://claude.com/claude-code)