### PR TITLE
fix(plan): fix recurring plan card overflow on screens < 420px

### DIFF
--- a/frontend/web/static/css/plan.css
+++ b/frontend/web/static/css/plan.css
@@ -143,3 +143,17 @@
         height: 1.25rem;
     }
 }
+
+/* Extra-small screens (< 420px): prevent card overflow */
+@media (max-width: 419px) {
+    .recurring-mobile-cards .recurring-card-item {
+        padding-left: 0.25rem;
+        padding-right: 0.25rem;
+    }
+    .recurring-mobile-cards .recurring-card-item .flex-1.min-w-0 > div:first-child {
+        flex-wrap: wrap;
+    }
+    .recurring-mobile-cards .recurring-card-item .font-mono {
+        font-size: 0.7rem;
+    }
+}


### PR DESCRIPTION
## Summary
- Add `@media (max-width: 419px)` CSS block to `plan.css` targeting `.recurring-mobile-cards`
- Reduces left/right padding on cards from `px-1` to `0.25rem` for very narrow viewports
- Allows the title+amount row to `flex-wrap: wrap` so the amount drops below the title instead of overflowing
- Shrinks `.font-mono` amount font size to `0.7rem` on screens < 420px

## Test plan
- [ ] Open plan page on a device or emulator with viewport width < 420px
- [ ] Verify recurring plan cards render without horizontal scroll/overflow
- [ ] Verify amount wraps below article name on very narrow screens
- [ ] Verify screens 420px–767px are unaffected (existing breakpoint behaviour unchanged)
- [ ] Verify desktop layout is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)