### PR TITLE
fix(plan): auto-select current month in analytics on page load

### DIFF
--- a/frontend/web/static/js/plan/analytics.ts
+++ b/frontend/web/static/js/plan/analytics.ts
@@ -164,13 +164,17 @@ export function initAnalyticsMonthButtons(): void {
     const label = `${MONTH_NAMES[date.getMonth()]} ${date.getFullYear()}`;
 
     const btn = document.createElement('button');
-    btn.className = 'join-item btn btn-outline';
+    btn.className = offset === 0 ? 'join-item btn btn-primary' : 'join-item btn btn-outline';
     btn.style.height = '3rem';
     btn.textContent = label;
     btn.dataset.month = yearMonth;
     btn.onclick = () => selectAnalyticsMonth(yearMonth, btn);
 
     container.appendChild(btn);
+
+    if (offset === 0) {
+      setCurrentAnalyticsMonth(yearMonth);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- `initAnalyticsMonthButtons()` теперь вызывает `setCurrentAnalyticsMonth()` для первой кнопки (текущий месяц) и устанавливает класс `btn-primary`
- Устраняет `console.warn [PlanAnalytics] No analytics month selected` при каждом открытии страницы плана
- `loadPlanAnalytics()` получает непустой месяц при инициализации

## Test plan
- [ ] Открыть `/plan` → console без предупреждения `[PlanAnalytics] No analytics month selected`
- [ ] Текущий месяц визуально выделен при загрузке
- [ ] Клик на другой месяц обновляет данные аналитики

🤖 Generated with [Claude Code](https://claude.com/claude-code)