### PR TITLE
fix(facts): align transfer_created WS broadcast field names

### DIFF
--- a/backend/app/api/v1/endpoints/budget_ws.py
+++ b/backend/app/api/v1/endpoints/budget_ws.py
@@ -921,7 +921,7 @@ SAFE_FACT_FIELDS = {
 }
 
 SAFE_TRANSFER_FIELDS = {
-    "id", "source_fact_id", "target_fact_id",
+    "id", "expense_fact_id", "income_fact_id",
     "amount", "transfer_date", "description",
 }
 

--- a/backend/app/api/v1/endpoints/transfers.py
+++ b/backend/app/api/v1/endpoints/transfers.py
@@ -324,8 +324,8 @@ async def create_transfer(
         ws = _get_budget_ws_broadcast()
         transfer_data = {
             "id": transfer_id,
-            "source_fact_id": expense_fact.id,
-            "target_fact_id": income_fact.id,
+            "expense_fact_id": expense_fact.id,
+            "income_fact_id": income_fact.id,
             "amount": float(transfer.amount),
             "transfer_date": str(transfer.transfer_date),
             "description": transfer.description,


### PR DESCRIPTION
## Summary

- Backend was broadcasting `transfer_created` WS event with `source_fact_id`/`target_fact_id`
- Frontend `handleTransferCreated()` in `wsEventHandlers.ts` expected `expense_fact_id`/`income_fact_id`
- Mismatch caused `ids = []` → `fetchAndInjectRow()` never called → no incremental update

## Root Cause

`transfers.py` broadcast dict used non-canonical field names inconsistent with the rest of the codebase (`TransferResponse` schema, HTTP response, frontend handlers all use `expense_fact_id`/`income_fact_id`).

## Changes

- `backend/app/api/v1/endpoints/transfers.py:327-328` — renamed broadcast keys
- `backend/app/api/v1/endpoints/budget_ws.py:924` — updated `SAFE_TRANSFER_FIELDS` whitelist

## Test plan

- [ ] Create a transfer via modal window on `/facts` page
- [ ] Verify two new rows appear in the Facts table without full page reload
- [ ] Check browser DevTools WS messages: `transfer_created` event now contains `expense_fact_id`/`income_fact_id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)