### PR TITLE
fix(plan): skip loadFacts() on online saves — WS handles incremental update

### DIFF
--- a/frontend/web/static/js/plan/crud.ts
+++ b/frontend/web/static/js/plan/crud.ts
@@ -1564,7 +1564,10 @@ export async function createPlan(event: Event): Promise<void> {
       const reminderSettings = document.getElementById('reminder-settings-modal_plan');
       if (reminderSettings) reminderSettings.classList.add('hidden');
       resetReminderFields('modal_plan');
-      await PlanFactsTable.loadFacts(); // Перезагрузить список планов
+      if (result._offline) {
+        await PlanFactsTable.loadFacts(); // только для offline (нет WS-события)
+      }
+      // для online: WS-событие plan_created обновит таблицу инкрементально
 
       // Переинициализировать кнопки периода
       setupCreatePlanPeriodButtons();
@@ -1600,7 +1603,7 @@ export async function createPlan(event: Event): Promise<void> {
         const reminderSettings = document.getElementById('reminder-settings-modal_plan');
         if (reminderSettings) reminderSettings.classList.add('hidden');
         resetReminderFields('modal_plan');
-        await PlanFactsTable.loadFacts(); // Перезагрузить список планов
+        // WS-событие plan_created обновит таблицу инкрементально
 
         // Переинициализировать кнопки периода
         setupCreatePlanPeriodButtons();


### PR DESCRIPTION
## Summary
- `crud.ts`: `loadFacts()` теперь вызывается только для offline-сохранений; для online WS-событие `plan_created` обновляет таблицу инкрементально
- Убраны явные вызовы `loadFacts()` из fallback fetch-пути (всегда online)

Closes #541

🤖 Generated with [Claude Code](https://claude.com/claude-code)