### PR TITLE
fix(dexie): prevent deleted/pending records from reappearing after sync

### DIFF
--- a/frontend/shared/db/dexie/operations/factSync.ts
+++ b/frontend/shared/db/dexie/operations/factSync.ts
@@ -130,10 +130,26 @@ async function uploadOperation(op: LocalPendingOperation): Promise<void> {
     if (op.temp_id) {
       await confirmPendingOperation(op.temp_id, serverId);
     }
-  } else {
-    // Для update/delete просто удаляем из pending queue
+  } else if (op.operation === 'update') {
     if (op.temp_id) {
-      await db.pendingOperations.where('temp_id').equals(op.temp_id).delete();
+      const tempId = op.temp_id;
+      // Atomically mark synced and remove from pending queue
+      await db.transaction('rw', [db.budgetFacts, db.pendingOperations], async () => {
+        await db.pendingOperations.where('temp_id').equals(tempId).delete();
+        await db.budgetFacts.where('temp_id').equals(tempId).modify({
+          sync_status: 'synced',
+          synced_at: new Date()
+        });
+      });
+    }
+  } else if (op.operation === 'delete') {
+    if (op.temp_id) {
+      const tempId = op.temp_id;
+      // Atomically hard-delete from Dexie and remove pending op (server confirmed deletion)
+      await db.transaction('rw', [db.budgetFacts, db.pendingOperations], async () => {
+        await db.pendingOperations.where('temp_id').equals(tempId).delete();
+        await db.budgetFacts.where('temp_id').equals(tempId).delete();
+      });
     }
   }
 
@@ -205,8 +221,17 @@ export async function downloadFacts(
       });
     }
 
+    // Server facts whose local counterpart has unsent edits/deletes must not be overwritten
+    const protectedFacts = await db.budgetFacts
+      .where('sync_status').anyOf(['pending', 'deleted'])
+      .toArray();
+    const protectedServerIds = new Set(
+      protectedFacts.filter(f => f.id != null).map(f => f.id!)
+    );
+    const safeToInsert = mappedFacts.filter(f => !f.id || !protectedServerIds.has(f.id));
+
     // Bulk insert (amount уже в cents от сервера)
-    await bulkInsertFacts(mappedFacts);
+    await bulkInsertFacts(safeToInsert);
 
     // Update sync metadata
     await db.syncMetadata.put({
@@ -216,7 +241,11 @@ export async function downloadFacts(
       total_records: mappedFacts.length
     });
 
-    logger.info('[factSync] ✅ Facts downloaded', { count: mappedFacts.length });
+    logger.info('[factSync] ✅ Facts downloaded', {
+      count: mappedFacts.length,
+      inserted: safeToInsert.length,
+      skipped: mappedFacts.length - safeToInsert.length
+    });
     return { success: true, count: mappedFacts.length };
   } catch (error) {
     logger.error('[factSync] ❌ Facts download failed:', error);

--- a/frontend/shared/db/dexie/operations/referenceSync.ts
+++ b/frontend/shared/db/dexie/operations/referenceSync.ts
@@ -22,7 +22,7 @@ import type {
   LocalSyncMetadata,
   LocalShoppingListItem
 } from '../types/models';
-import { mapAPIFactToLocal } from '../utils/apiMapper';
+import { mapAPIFactToLocal, validateMappedFact } from '../utils/apiMapper';
 
 /**
  * Sync articles from server
@@ -452,21 +452,21 @@ export async function syncPlans(
     const data = await response.json();
     const rawPlans = data.facts || data.items || [];
 
-    // Map API response → LocalBudgetFact (generates temp_id, normalises field names)
-    // IMPORTANT: API returns objects with server `id` but NO `temp_id`.
-    // Without this mapping bulkPut throws:
-    //   "DataError: Evaluating the object store's key path did not yield a value"
-    // because `budgetFacts` uses `temp_id` as its primary key.
-    // mapAPIFactToLocal generates temp_id = "server-{id}" for stable re-sync identity.
-    const plans: LocalBudgetFact[] = rawPlans.map((plan: Record<string, unknown>) =>
-      mapAPIFactToLocal(plan)
-    );
-
-    // Convert amounts to cents before storing
-    const plansWithCents = plans.map((plan: LocalBudgetFact) => ({
-      ...plan,
-      amount: toCents(plan.amount)
-    }));
+    // Map API response → LocalBudgetFact (generates temp_id, normalises field names, validates)
+    // Per-item error handling: skip malformed plans instead of failing the whole sync
+    const mappedPlans: LocalBudgetFact[] = [];
+    for (const rawPlan of rawPlans) {
+      try {
+        const mapped = mapAPIFactToLocal(rawPlan as Record<string, unknown>);
+        validateMappedFact(mapped);
+        mappedPlans.push({ ...mapped, amount: toCents(mapped.amount) });
+      } catch (err) {
+        logger.warn('[referenceSync] Skipping malformed plan', {
+          id: (rawPlan as any).id,
+          error: (err as Error).message
+        });
+      }
+    }
 
     // Collect server IDs of locally pending/deleted plans before modifying DB
     // These must not be overwritten by stale server data
@@ -494,7 +494,7 @@ export async function syncPlans(
         .delete();
 
       // Skip plans whose local version has unsent edits or pending deletion
-      const safePlans = plansWithCents.filter(
+      const safePlans = mappedPlans.filter(
         (p: LocalBudgetFact) => !p.id || !protectedPlanIds.has(p.id)
       );
       if (safePlans.length > 0) {
@@ -502,10 +502,10 @@ export async function syncPlans(
       }
     });
 
-    await updateSyncMetadata('plans', plans.length);
+    await updateSyncMetadata('plans', mappedPlans.length);
 
-    logger.info('[referenceSync] ✅ Plans synced', { count: plans.length, fromDate, toDate });
-    return { success: true, count: plans.length };
+    logger.info('[referenceSync] ✅ Plans synced', { count: mappedPlans.length, fromDate, toDate });
+    return { success: true, count: mappedPlans.length };
   } catch (error) {
     logger.error('[referenceSync] ❌ Plans sync failed:', error);
     return { success: false, count: 0 };

--- a/frontend/shared/db/dexie/operations/referenceSync.ts
+++ b/frontend/shared/db/dexie/operations/referenceSync.ts
@@ -279,6 +279,14 @@ export async function syncShoppingLists(userId: number): Promise<{ success: bool
         .map(l => [l.id!, l.temp_id])
     );
 
+    // Collect server IDs of pending/deleted lists — they must not be overwritten
+    const pendingOrDeletedLists = existingListsInDexie.filter(
+      l => l.sync_status === 'pending' || l.sync_status === 'deleted'
+    );
+    const pendingListServerIds = new Set(
+      pendingOrDeletedLists.filter(l => l.id != null).map(l => l.id!)
+    );
+
     // Transform API data: preserve existing temp_id if list already exists locally
     const transformedLists = lists.map((list: any) => ({
       ...list,
@@ -291,12 +299,18 @@ export async function syncShoppingLists(userId: number): Promise<{ success: bool
       updated_at: list.updated_at ? new Date(list.updated_at) : new Date()
     }));
 
-    // Clear existing user's lists (after preserving temp_ids)
-    await db.shoppingLists.where('creator_id').equals(userId).delete();
+    // Only delete synced lists — pending/deleted ones are awaiting upload
+    await db.shoppingLists
+      .where('creator_id').equals(userId)
+      .filter(l => l.sync_status === 'synced')
+      .delete();
 
-    // Bulk insert
-    if (transformedLists.length > 0) {
-      await db.shoppingLists.bulkPut(transformedLists);
+    // Skip lists whose local version has unsent edits or pending deletion
+    const safeToInsert = transformedLists.filter(
+      (l: any) => !l.id || !pendingListServerIds.has(l.id)
+    );
+    if (safeToInsert.length > 0) {
+      await db.shoppingLists.bulkPut(safeToInsert);
     }
 
     // Sync shopping list items for each list (v11.6.1+)
@@ -322,7 +336,18 @@ export async function syncShoppingLists(userId: number): Promise<{ success: bool
         }
 
         const itemsData = await itemsResponse.json();
-        const items = itemsData.items || [];
+        // Filter soft-deleted items (API already excludes them, but guard defensively)
+        const items = (itemsData.items || []).filter((item: any) => !item.deleted_at);
+
+        // Preserve existing temp_ids so items keep stable primary keys across re-syncs
+        const existingItems = await db.shoppingListItems
+          .where('shopping_list_temp_id').equals(list.temp_id)
+          .toArray();
+        const existingTempIdByItemServerId = new Map(
+          existingItems
+            .filter((i: LocalShoppingListItem) => i.id != null)
+            .map((i: LocalShoppingListItem) => [i.id!, i.temp_id])
+        );
 
         // Clear only SYNCED items for this list (preserve pending/unsent items)
         await db.shoppingListItems
@@ -335,7 +360,7 @@ export async function syncShoppingLists(userId: number): Promise<{ success: bool
         if (items.length > 0) {
           const transformedItems: LocalShoppingListItem[] = items.map((item: any) => ({
             ...item,
-            temp_id: item.temp_id || `item_${item.id}_${Date.now()}`,
+            temp_id: existingTempIdByItemServerId.get(item.id) || item.temp_id || `server-item-${item.id}`,
             shopping_list_temp_id: list.temp_id, // Link to the Dexie list by temp_id
             sync_status: 'synced',
             synced_at: new Date(),
@@ -443,19 +468,37 @@ export async function syncPlans(
       amount: toCents(plan.amount)
     }));
 
-    // Replace server-synced plans in the date window; preserve pending/conflict local records
+    // Collect server IDs of locally pending/deleted plans before modifying DB
+    // These must not be overwritten by stale server data
+    const protectedPlans = await db.budgetFacts
+      .where('[user_id+date]')
+      .between([userId, fromDate], [userId, toDate + '\uffff'])
+      .filter((f: LocalBudgetFact) =>
+        f.record_type === 'plan' &&
+        (f.sync_status === 'pending' || f.sync_status === 'deleted')
+      )
+      .toArray();
+    const protectedPlanIds = new Set(
+      protectedPlans.filter((p: LocalBudgetFact) => p.id != null).map((p: LocalBudgetFact) => p.id!)
+    );
+
+    // Replace server-synced plans in the date window; preserve pending/deleted local records
     await db.transaction('rw', db.budgetFacts, async () => {
+      // Only delete synced plans — deleted ones are awaiting upload and must stay invisible
       await db.budgetFacts
         .where('[user_id+date]')
         .between([userId, fromDate], [userId, toDate + '\uffff'])
         .filter((f: LocalBudgetFact) =>
-          f.record_type === 'plan' &&
-          (f.sync_status === 'synced' || f.sync_status === 'deleted')
+          f.record_type === 'plan' && f.sync_status === 'synced'
         )
         .delete();
 
-      if (plansWithCents.length > 0) {
-        await db.budgetFacts.bulkPut(plansWithCents);
+      // Skip plans whose local version has unsent edits or pending deletion
+      const safePlans = plansWithCents.filter(
+        (p: LocalBudgetFact) => !p.id || !protectedPlanIds.has(p.id)
+      );
+      if (safePlans.length > 0) {
+        await db.budgetFacts.bulkPut(safePlans);
       }
     });
 
@@ -555,6 +598,16 @@ export async function initialReferenceSync(
     logger.info('[referenceSync] Pending shopping operations uploaded before sync');
   } catch (uploadError) {
     logger.warn('[referenceSync] Failed to upload pending shopping operations (continuing sync)', uploadError);
+  }
+
+  // Upload pending fact operations (create/update/delete) before downloading server data
+  // Ensures local deletions and edits reach server before plans/facts are refreshed
+  try {
+    const { uploadPendingOperations } = await import('./factSync');
+    await uploadPendingOperations();
+    logger.info('[referenceSync] Pending fact operations uploaded before sync');
+  } catch (uploadError) {
+    logger.warn('[referenceSync] Failed to upload pending fact operations (continuing sync)', uploadError);
   }
 
   const results = {


### PR DESCRIPTION
## Summary

- **factSync**: фильтрация серверных записей по pending/deleted server IDs перед `bulkInsert` — не перезаписываем локальные несинхронизированные изменения
- **factSync**: после успешного UPDATE upload атомарно ставим `sync_status: 'synced'` (раньше оставалось `'pending'` навсегда)
- **factSync**: после успешного DELETE upload атомарно жёстко удаляем запись из Dexie (раньше оставалась как soft-deleted навсегда)
- **referenceSync/syncPlans**: удаляем только `'synced'` планы перед re-download; защищаем pending/deleted планы от перезаписи сервером
- **referenceSync/initialReferenceSync**: upload pending fact operations перед скачиванием планов
- **referenceSync/syncShoppingLists**: selective delete (только `'synced'` списки), защита pending/deleted list IDs
- **referenceSync/syncShoppingLists**: стабильный item `temp_id` через `server-item-{id}` (раньше `Date.now()` создавал дубликаты при каждой синхронизации)
- **referenceSync/syncShoppingLists**: пропускаем items с `deleted_at` из ответа сервера

## Root causes fixed

| Баг | Причина | Фикс |
|-----|---------|------|
| Удалённые записи возвращаются | `bulkPut` перезаписывал deleted/pending записи | Фильтруем по protectedServerIds |
| Планы возвращаются после sync | `syncPlans` удалял `sync_status: 'deleted'` записи | Удаляем только `'synced'` |
| Списки покупок возвращаются | Полный wipe перед bulk insert | Selective delete + ID protection |
| Дубликаты items при каждом sync | `Date.now()` в temp_id | Детерминированный `server-item-{id}` |
| UPDATE не сохраняется | Запись оставалась `pending` после upload | Атомарно ставим `synced` |
| DELETE утечка | Soft-deleted запись оставалась в Dexie | Атомарный hard-delete после upload |
| Порядок синхронизации | `syncPlans` до upload pending facts | Upload facts перед plans |

## Test plan

- [ ] Создать факт → удалить → перезагрузить страницу → запись не появляется
- [ ] Создать план → удалить → дождаться sync → план не возвращается
- [ ] Отредактировать факт → sync → значение остаётся изменённым
- [ ] Добавить товар в список покупок → удалить → sync → товар не возвращается
- [ ] `npm run type-check` — пройден ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)