### PR TITLE
fix(dexie): fix shopping list items not deleted on sync

### DIFF
--- a/frontend/shared/db/dexie/DexieManager.ts
+++ b/frontend/shared/db/dexie/DexieManager.ts
@@ -1024,7 +1024,9 @@ export class DexieManager {
     const factsCount = await this.getDB().budgetFacts.filter(f => f.record_type === 'fact').count();
     const plansCount = await this.getDB().budgetFacts.filter(f => f.record_type === 'plan').count();
     const shoppingListsCount = await this.getDB().shoppingLists.count();
-    const shoppingListItemsCount = await this.getDB().shoppingListItems.count();
+    const shoppingListItemsCount = await this.getDB().shoppingListItems
+      .where('sync_status').notEqual('deleted')
+      .count();
     const financialCentersCount = await this.getDB().financialCenters.count();
     const costCentersCount = await this.getDB().costCenters.count();
     const recurringPlansCount = await this.getDB().recurringPlans.count();

--- a/frontend/shared/db/dexie/operations/referenceSync.ts
+++ b/frontend/shared/db/dexie/operations/referenceSync.ts
@@ -349,6 +349,14 @@ export async function syncShoppingLists(userId: number): Promise<{ success: bool
             .map((i: LocalShoppingListItem) => [i.id!, i.temp_id])
         );
 
+        // Server IDs of items with pending/deleted status — must not be overwritten by server data
+        const protectedItemIds = new Set<number>(
+          existingItems
+            .filter((i: LocalShoppingListItem) =>
+              (i.sync_status === 'pending' || i.sync_status === 'deleted') && i.id != null)
+            .map((i: LocalShoppingListItem) => i.id!)
+        );
+
         // Clear only SYNCED items for this list (preserve pending/unsent items)
         await db.shoppingListItems
           .where('shopping_list_temp_id')
@@ -356,7 +364,6 @@ export async function syncShoppingLists(userId: number): Promise<{ success: bool
           .filter(item => item.sync_status === 'synced')
           .delete();
 
-        // Transform and store items
         if (items.length > 0) {
           const transformedItems: LocalShoppingListItem[] = items.map((item: any) => ({
             ...item,
@@ -374,8 +381,14 @@ export async function syncShoppingLists(userId: number): Promise<{ success: bool
             last_modified_by: item.last_modified_by || null,
             conflict_data: undefined
           }));
-          await db.shoppingListItems.bulkPut(transformedItems);
-          totalItems += transformedItems.length;
+          // Skip items whose local version has unsent edits or pending deletion
+          const safeItems = transformedItems.filter((i: LocalShoppingListItem) =>
+            !i.id || !protectedItemIds.has(i.id)
+          );
+          if (safeItems.length > 0) {
+            await db.shoppingListItems.bulkPut(safeItems);
+          }
+          totalItems += safeItems.length;
         }
       } catch (itemError) {
         logger.warn('[referenceSync] Error fetching items for list (non-critical)', {

--- a/frontend/shared/db/dexie/operations/shoppingSync.ts
+++ b/frontend/shared/db/dexie/operations/shoppingSync.ts
@@ -23,7 +23,7 @@ export async function uploadPendingShoppingOperations(): Promise<{
 
   // Get pending shopping list items
   const pendingItems = await db.shoppingListItems
-    .where('sync_status').equals('pending')
+    .where('sync_status').anyOf(['pending', 'deleted'])
     .toArray();
 
   if (pendingItems.length === 0) {
@@ -63,6 +63,29 @@ async function uploadShoppingItem(item: LocalShoppingListItem): Promise<void> {
     temp_id: item.temp_id,
     id: item.id
   });
+
+  // Handle soft-deleted items — send DELETE to server then hard-delete locally
+  if (item.sync_status === 'deleted') {
+    if (item.id === null) {
+      // Never synced to server — just remove locally
+      await db.shoppingListItems.where('temp_id').equals(item.temp_id).delete();
+      logger.info('[shoppingSync] ✅ Local-only item removed', { temp_id: item.temp_id });
+      return;
+    }
+    const response = await fetchWithTimeout(`/api/v1/shopping-list-items/${item.id}`, {
+      method: 'DELETE',
+      credentials: 'include'
+    });
+    if (!response.ok && response.status !== 404) {
+      throw new Error(`Server error: ${response.status}`);
+    }
+    await db.shoppingListItems.where('temp_id').equals(item.temp_id).delete();
+    logger.info('[shoppingSync] ✅ Item deleted on server and locally', {
+      temp_id: item.temp_id,
+      id: item.id
+    });
+    return;
+  }
 
   let endpoint: string;
   let method: string;


### PR DESCRIPTION
## Summary

- **shoppingSync**: `uploadPendingShoppingOperations` теперь включает `sync_status='deleted'` items (`anyOf(['pending', 'deleted'])`)
- **shoppingSync**: `uploadShoppingItem` обрабатывает DELETE — отправляет `DELETE /api/v1/shopping-list-items/{id}`, затем hard-delete из Dexie
- **referenceSync**: `syncShoppingLists` защищает pending/deleted items от перезаписи через `bulkPut` (через `protectedItemIds`)
- **DexieManager**: счётчик диагностики исключает `sync_status='deleted'` items

## Root causes fixed

| Баг | Причина | Фикс |
|-----|---------|------|
| Удалённые товары появляются снова | Upload не отправлял DELETE на сервер | `anyOf(['pending','deleted'])` + DELETE-ветка |
| Items восстанавливаются через bulkPut | `syncShoppingLists` перезаписывал deleted items | `protectedItemIds` фильтр |
| Счётчик в Diagnostics не уменьшается | `count()` считал все включая deleted | `.notEqual('deleted').count()` |

## Test plan

- [ ] `npm run type-check` — пройден ✅
- [ ] Удалить товар из списка → счётчик Dexie Diagnostics уменьшается
- [ ] Обновить страницу → удалённый товар не появляется
- [ ] DevTools → IndexedDB → `shoppingListItems` → deleted записи исчезают после sync

Closes #547, #548, #549

🤖 Generated with [Claude Code](https://claude.com/claude-code)