### PR TITLE
fix(dexie): trigger immediate server sync after shopping item delete

### DIFF
--- a/frontend/web/static/js/lists/listsManager/core/listOperations.ts
+++ b/frontend/web/static/js/lists/listsManager/core/listOperations.ts
@@ -448,6 +448,12 @@ export async function deleteItem(itemId: number, skipConfirm: boolean = false): 
       await deleteShoppingListItem(item.temp_id);
       debugLog('[LIST_OPS] Item deleted in Dexie', { temp_id: item.temp_id });
 
+      // Background upload: push delete to server before any cache reset
+      // Fire-and-forget — UI already reflects local state from Dexie
+      dexie.uploadPendingShoppingData().catch((err: unknown) => {
+        console.warn('[LIST_OPS] Background delete upload failed:', err);
+      });
+
       // Reload items from Dexie
       if (state.currentListId) {
         await loadShoppingListItems(state.currentListId);
@@ -537,6 +543,12 @@ export async function deleteMultipleItems(itemIds: number[], skipConfirm: boolea
       // Delete each item in Dexie (parallel)
       await Promise.all(tempIds.map(temp_id => deleteShoppingListItem(temp_id)));
       debugLog('[LIST_OPS] Bulk deleted items in Dexie', { count: tempIds.length });
+
+      // Background upload: push deletes to server before any cache reset
+      // Fire-and-forget — UI already reflects local state from Dexie
+      dexie.uploadPendingShoppingData().catch((err: unknown) => {
+        console.warn('[LIST_OPS] Background bulk delete upload failed:', err);
+      });
 
       // Reload items from Dexie
       if (state.currentListId) {


### PR DESCRIPTION
## Summary
- `deleteItem()` и `deleteMultipleItems()` делали soft-delete в Dexie (`sync_status = 'deleted'`), но не вызывали `uploadPendingShoppingData()` для отправки DELETE на сервер
- При сбросе кэша Dexie очищался, и при следующей синхронизации "удалённые" товары скачивались обратно с сервера
- Добавлены fire-and-forget вызовы `uploadPendingShoppingData()` после удаления — по аналогии с `addItem()` (строка 138)

## Test plan
- [ ] Удалить товар из списка
- [ ] Сбросить кэш и куки браузера
- [ ] Перезагрузить страницу — удалённый товар НЕ должен появиться

🤖 Generated with [Claude Code](https://claude.com/claude-code)