### PR TITLE
fix(plan): fix TypeError when deleting plan entry

### DIFF
--- a/frontend/web/static/js/plan/crud.ts
+++ b/frontend/web/static/js/plan/crud.ts
@@ -19,15 +19,6 @@ declare const BudgetShared: {
     isValidDisplayFormat: (displayDate: string) => boolean;
   };
   CalendarWidget: any; // Constructor
-  ConfirmDialog: {
-    show: (options: {
-      title: string;
-      message: string;
-      confirmText?: string;
-      cancelText?: string;
-      confirmClass?: string;
-    }) => Promise<boolean>;
-  };
   ChoicesCategoryTree: any; // Constructor
 };
 
@@ -844,20 +835,17 @@ function escapeHtml(unsafe: string): string {
 
 /**
  * Show confirmation dialog
- * Wrapper around BudgetShared.ConfirmDialog
+ * Wrapper around window.showConfirmDialog with native confirm fallback
  *
  * @param message - Confirmation message
  * @param title - Dialog title
  * @returns Promise that resolves to true if confirmed, false otherwise
  */
 async function showConfirmDialog(message: string, title: string): Promise<boolean> {
-  return await BudgetShared.ConfirmDialog.show({
-    title,
-    message,
-    confirmText: 'Удалить',
-    cancelText: 'Отмена',
-    confirmClass: 'btn-error'
-  });
+  if (typeof (window as any).showConfirmDialog === 'function') {
+    return await (window as any).showConfirmDialog(message, title);
+  }
+  return confirm(message);
 }
 
 /**


### PR DESCRIPTION
## Summary
- `BudgetShared.ConfirmDialog` не существует — `ConfirmDialog` экспортируется отдельно через `confirm-dialog-bundle.ts` как `window.showConfirmDialog`
- Заменён вызов `BudgetShared.ConfirmDialog.show({...})` на `window.showConfirmDialog(message, title)` с fallback на `confirm()` по паттерну `factsController.ts`
- Удалена некорректная типизация `ConfirmDialog` из `declare const BudgetShared`

## Test plan
- [ ] Перейти на страницу плана, удалить запись — диалог подтверждения должен появиться без ошибки
- [ ] Попробовать удалить регламентную запись — диалог выбора (единичная/все) должен работать

🤖 Generated with [Claude Code](https://claude.com/claude-code)