### PR TITLE
fix(dexie): fix SchemaError and DataError on lists page

### DIFF
--- a/frontend/shared/db/dexie/operations/factOperations.ts
+++ b/frontend/shared/db/dexie/operations/factOperations.ts
@@ -277,9 +277,11 @@ export async function getPendingOperations(): Promise<LocalPendingOperation[]> {
   logger.debug('[Dexie] getPendingOperations');
 
   const now = new Date();
-  const allOperations = await db.pendingOperations
-    .orderBy('created_at')
-    .toArray();
+  const allOperations = await db.pendingOperations.toArray();
+  // Sort by created_at in JS (field is not indexed in Dexie schema)
+  allOperations.sort((a, b) =>
+    new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+  );
 
   // Filter out operations that are waiting for backoff to expire
   const readyOperations = allOperations.filter(op => {

--- a/frontend/web/static/js/data/DataLayer.ts
+++ b/frontend/web/static/js/data/DataLayer.ts
@@ -657,7 +657,13 @@ export class DataLayer {
         // Cache API lists in Dexie so next access (including item FK lookup) works offline
         if (apiResult.length > 0) {
           try {
-            await dexie.getDB().shoppingLists.bulkPut(apiResult);
+            // Ensure temp_id (Dexie primary key) exists — API may not return it
+            const listsWithKeys = apiResult.map((list: any) => ({
+              ...list,
+              temp_id: list.temp_id || list.id?.toString(),
+              sync_status: list.sync_status || 'synced'
+            }));
+            await dexie.getDB().shoppingLists.bulkPut(listsWithKeys);
             console.debug('[DATA_LAYER] Cached API lists in Dexie', { count: apiResult.length });
           } catch (cacheError) {
             console.warn('[DATA_LAYER] Failed to cache lists in Dexie', cacheError);


### PR DESCRIPTION
## Summary
- **SchemaError**: `pendingOperations.orderBy('created_at')` падал т.к. `created_at` не индексирован. Заменён на `.toArray()` + сортировка в JS
- **DataError**: `DataLayer.getShoppingLists()` пытался `bulkPut` API-ответ без `temp_id` (primary key Dexie). Добавлена генерация `temp_id` перед записью

## Test plan
- [ ] Открыть /lists — ошибки SchemaError и DataError не должны появляться в консоли
- [ ] Warning `Missing temp_id` может оставаться (backend не возвращает temp_id), но DataError исчезнет

🤖 Generated with [Claude Code](https://claude.com/claude-code)