### PR TITLE
fix: 5 bugs + 2 remarks — plan modal

### DIFF
--- a/frontend/web/static/js/dashboard/features/modalPlan/index.ts
+++ b/frontend/web/static/js/dashboard/features/modalPlan/index.ts
@@ -439,26 +439,8 @@ function formatPeriodYYYYMM(date: Date): string {
  * Setup save button click listener as fallback
  * Ensures save button works even if onclick attribute fails
  */
-function setupSaveButtonListener(): void {
-  const saveButton = document.querySelector('#modal_plan button[onclick*="savePlanModal"]') as HTMLButtonElement;
-
-  if (saveButton && !saveButton.dataset.listenerAttached) {
-    saveButton.addEventListener('click', async function(event) {
-      event.preventDefault();
-      event.stopPropagation();
-
-      // Call the global savePlanModal function
-      if (typeof (window as any).savePlanModal === 'function') {
-        (window as any).savePlanModal(this);
-      } else {
-        debugLog('[ModalPlan] savePlanModal not found on window');
-      }
-    });
-
-    saveButton.dataset.listenerAttached = 'true';
-    debugLog('[ModalPlan] Save button listener attached');
-  }
-}
+// setupSaveButtonListener removed — redundant with inline onclick="savePlanModal(this)" on the save button.
+// Having both caused double POST requests (BUG-3).
 
 /**
  * Open modal plan
@@ -525,8 +507,7 @@ export async function openModalPlan(): Promise<void> {
       (window as any).setPlanTransferPeriod(0); // Transfer tab: 0 = current month
     }
 
-    // Setup save button click handler (fallback if onclick doesn't work)
-    setupSaveButtonListener();
+    // setupSaveButtonListener() removed — caused double POST (BUG-3)
 
     // UX: Setup keyboard shortcuts (Escape to close, Ctrl+Enter to save)
     keyboardShortcutsCleanup = setupModalKeyboardShortcuts(

--- a/frontend/web/static/js/dashboard/features/modalPlan/recurringSettings.ts
+++ b/frontend/web/static/js/dashboard/features/modalPlan/recurringSettings.ts
@@ -54,10 +54,14 @@ export function togglePlanMode(modalId: string): void {
   onetimeReminderSection.classList.add('hidden');
   debugLog('[togglePlanMode] All sections hidden');
 
+  // Toggle required on duration_type (hidden fields block HTML5 validation)
+  const durationTypeSelect = form.querySelector<HTMLSelectElement>('select[name="duration_type"]');
+
   // Show relevant section
   if (selectedMode === 'recurring') {
     recurringSettings.classList.remove('hidden');
     debugLog('[togglePlanMode] Recurring settings shown');
+    if (durationTypeSelect) durationTypeSelect.setAttribute('required', 'required');
     initializeRecurringDefaults(modalId);
   } else if (selectedMode === 'reminder') {
     onetimeReminderSection.classList.remove('hidden');
@@ -81,6 +85,11 @@ export function togglePlanMode(modalId: string): void {
     }
   } else {
     debugLog('[togglePlanMode] Regular mode - no additional sections shown');
+  }
+
+  // Remove required from duration_type when not in recurring mode
+  if (selectedMode !== 'recurring' && durationTypeSelect) {
+    durationTypeSelect.removeAttribute('required');
   }
 
   debugLog('[RecurringSettings] Plan mode changed:', selectedMode);

--- a/frontend/web/static/js/dashboard/features/modalPlan/saveTransaction.ts
+++ b/frontend/web/static/js/dashboard/features/modalPlan/saveTransaction.ts
@@ -58,7 +58,7 @@ export async function savePlanTransaction(form: HTMLFormElement): Promise<void> 
   // POST to appropriate endpoint based on plan mode
   if (recurringSettings) {
     // Recurring plan → /api/v1/recurring-plans
-    const responseData = await postAPI<any>('/api/v1/recurring-plans', planData, 'SavePlanModal');
+    const responseData = await postAPI<any>('/api/v1/recurring-plans/', planData, 'SavePlanModal');
 
     // Write recurring plan to Dexie immediately
     if (isDexieActive()) {

--- a/frontend/web/static/js/dashboard/shared/tabManagerFactory.ts
+++ b/frontend/web/static/js/dashboard/shared/tabManagerFactory.ts
@@ -54,13 +54,22 @@ export function createTabManager(config: TabManagerConfig): TabManager {
     saveCurrentTabData(currentTab);
 
     // Toggle visibility
-    if (newTab === 'transaction') {
-      transactionTab.classList.remove('hidden');
-      transferTab.classList.add('hidden');
-    } else {
-      transactionTab.classList.add('hidden');
-      transferTab.classList.remove('hidden');
-    }
+    const hiddenTab = newTab === 'transaction' ? transferTab : transactionTab;
+    const visibleTab = newTab === 'transaction' ? transactionTab : transferTab;
+
+    visibleTab.classList.remove('hidden');
+    hiddenTab.classList.add('hidden');
+
+    // Disable HTML5 validation on hidden tab fields (browser validates all fields regardless of visibility)
+    hiddenTab.querySelectorAll<HTMLElement>('[required]').forEach(el => {
+      el.removeAttribute('required');
+      el.setAttribute('data-was-required', 'true');
+    });
+    // Restore validation on visible tab fields
+    visibleTab.querySelectorAll<HTMLElement>('[data-was-required]').forEach(el => {
+      el.setAttribute('required', 'required');
+      el.removeAttribute('data-was-required');
+    });
 
     // Update radio buttons
     const tabInputs = document.querySelectorAll<HTMLInputElement>(`[name="${modalId}_tabs"]`);

--- a/frontend/web/static/js/data/DataLayer.ts
+++ b/frontend/web/static/js/data/DataLayer.ts
@@ -1518,7 +1518,7 @@ export class DataLayer {
       params.set('to_date', filters.to_date);
     }
 
-    const response = await fetch(`/api/v1/recurring-plans?${params.toString()}`, {
+    const response = await fetch(`/api/v1/recurring-plans/?${params.toString()}`, {
       credentials: 'include'
     });
     if (!response.ok) {

--- a/frontend/web/static/js/modules/uiComponents/modals/ConfirmDialog.ts
+++ b/frontend/web/static/js/modules/uiComponents/modals/ConfirmDialog.ts
@@ -69,6 +69,12 @@ export class ConfirmDialog {
         return;
       }
 
+      // Cancel any pending dialog before showing new one
+      if (instance.pendingResolve) {
+        instance.pendingResolve(false);
+        instance.pendingResolve = null;
+      }
+
       instance.pendingResolve = resolve;
       titleEl.textContent = title;
       messageEl.textContent = message;
@@ -83,16 +89,17 @@ export class ConfirmDialog {
    */
   static resolve(result: boolean): void {
     const instance = ConfirmDialog.getInstance();
+
+    if (!instance.pendingResolve) return; // Already resolved
+
     const modal = document.getElementById(instance.modalId) as HTMLDialogElement | null;
 
     if (modal) {
       modal.close();
     }
 
-    if (instance.pendingResolve) {
-      instance.pendingResolve(result);
-      instance.pendingResolve = null;
-    }
+    instance.pendingResolve(result);
+    instance.pendingResolve = null;
   }
 }
 

--- a/frontend/web/static/js/plan/crud.ts
+++ b/frontend/web/static/js/plan/crud.ts
@@ -689,6 +689,9 @@ export async function deleteFact(factId: number): Promise<void> {
     return;
   }
 
+  // Mark as deleting BEFORE async confirm dialog to prevent race condition on double-click
+  deletingFactIds.add(factId);
+
   // Find fact in factsData to check if it's recurring
   const factsData = PlanFactsTable.getFactsData();
   const fact = factsData.find(f => f.id === factId);
@@ -699,7 +702,8 @@ export async function deleteFact(factId: number): Promise<void> {
     const choice = await showRecurringDeleteDialog();
 
     if (!choice) {
-      // User cancelled
+      // User cancelled — release guard
+      deletingFactIds.delete(factId);
       return;
     }
 
@@ -712,15 +716,14 @@ export async function deleteFact(factId: number): Promise<void> {
     );
 
     if (!confirmed) {
+      // User cancelled — release guard
+      deletingFactIds.delete(factId);
       return;
     }
   }
 
   // Find button by data-fact-id attribute
   const button = document.querySelector(`button[data-fact-id="${factId}"]`) as HTMLButtonElement | null;
-
-  // Mark fact as being deleted
-  deletingFactIds.add(factId);
 
   // Disable button and show loading state
   if (button) {
@@ -1466,7 +1469,7 @@ export async function createPlan(event: Event): Promise<void> {
         setupCreatePlanPeriodButtons();
       } else {
         // Fallback to direct fetch if OfflineManager not available
-        const response = await fetch('/api/v1/recurring-plans', {
+        const response = await fetch('/api/v1/recurring-plans/', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(recurringData)

--- a/frontend/web/static/js/plan/factsTable.ts
+++ b/frontend/web/static/js/plan/factsTable.ts
@@ -600,10 +600,22 @@ export async function fetchAndInjectPlanRow(
     if (desktopTbody) {
       const trEl = parseHtml(desktopRow);
       if (trEl) desktopTbody.prepend(trEl);
+
+      // Trim excess rows beyond pageSize
+      const allRows = desktopTbody.querySelectorAll('tr');
+      for (let i = allRows.length - 1; i >= pageSize; i--) {
+        allRows[i].remove();
+      }
     }
     if (mobileList) {
       const divEl = parseHtml(mobileRow);
       if (divEl) mobileList.prepend(divEl);
+
+      // Trim excess items beyond pageSize
+      const allItems = mobileList.querySelectorAll('.transaction-item');
+      for (let i = allItems.length - 1; i >= pageSize; i--) {
+        allItems[i].remove();
+      }
     }
     return true;
   }

--- a/frontend/web/static/js/plan/index.ts
+++ b/frontend/web/static/js/plan/index.ts
@@ -422,14 +422,17 @@ export function collapseFiltersAction(): void {
  *
  * @param button - Кнопка с data-form-id и data-modal-id
  */
+let isSubmitting = false;
+
 export async function savePlanModal(button: HTMLElement): Promise<void> {
   const btn = button as HTMLButtonElement;
-  if (btn.disabled) return;
+  if (btn.disabled || isSubmitting) return;
+  isSubmitting = true;
 
   const formId = button.dataset.formId;
   const modalId = button.dataset.modalId || 'modal_plan';
   const form = document.getElementById(formId || `form_${modalId}`) as HTMLFormElement | null;
-  if (!form) return;
+  if (!form) { isSubmitting = false; return; }
 
   setButtonLoading(btn, true);
 
@@ -459,6 +462,9 @@ export async function savePlanModal(button: HTMLElement): Promise<void> {
         const event = new Event('submit', { bubbles: true, cancelable: true });
         Object.defineProperty(event, 'target', { value: form, writable: false });
         await PlanCRUD.createPlan(event);
+        // Ensure modal is closed after save (backup for edge cases)
+        const modal = document.getElementById(modalId) as HTMLDialogElement | null;
+        if (modal?.open) modal.close();
       }
     } else {
       // Для остальных модалов (например modal_add_plan) — нативная отправка формы,
@@ -470,6 +476,7 @@ export async function savePlanModal(button: HTMLElement): Promise<void> {
       }
     }
   } finally {
+    isSubmitting = false;
     setButtonLoading(btn, false);
   }
 }


### PR DESCRIPTION
## Summary

- **BUG-1**: Required-поля на скрытых вкладках блокируют submit — toggle `required`/`data-was-required` в `tabManagerFactory.switchTab()`
- **BUG-2**: `duration_type` остаётся required при режиме "Напоминание" — убираем required в `recurringSettings.togglePlanMode()` для не-recurring режимов
- **BUG-3**: Двойной POST при сохранении — удалён дублирующий `setupSaveButtonListener()` + `isSubmitting` guard
- **BUG-4**: Двойной DELETE — `deletingFactIds.add()` перемещён до confirm dialog, `ConfirmDialog.resolve()` защищён от повторного вызова
- **BUG-5**: 307 redirect на POST `/api/v1/recurring-plans` — добавлен trailing slash в 3 файлах
- **Замечание 1**: Incremental update добавляет строки сверх pageSize — trim после prepend
- **Замечание 2**: Модалка не закрывается после сохранения — backup `modal.close()` в finally

## Test plan

- [ ] Открыть модалку "Добавить план", переключить на вкладку "Перевод", нажать "Сохранить" — форма должна валидировать только видимые поля
- [ ] Выбрать режим "Напоминание" — форма не должна требовать `duration_type`
- [ ] Сохранить перевод — один POST запрос в Network, модалка закрывается
- [ ] Удалить запись — один DELETE запрос, без дубликатов
- [ ] Создать регулярный план — нет 307 redirect, прямой 200/201
- [ ] Создать >50 записей — после 50й записи последняя строка удаляется

🤖 Generated with [Claude Code](https://claude.com/claude-code)