### PR TITLE
fix: prevent duplicate DELETE requests on facts page

### DIFF
--- a/frontend/web/static/js/facts/operations/factsController.ts
+++ b/frontend/web/static/js/facts/operations/factsController.ts
@@ -230,20 +230,28 @@ function removeRowFromTable(factId: number): boolean {
 // CRUD Operations
 // ============================================================================
 
+const deletingFactIds = new Set<number>();
+
 /**
  * Delete single fact with confirmation
  */
 export async function deleteFact(factId: number): Promise<void> {
-    const confirmed = await showConfirmDialog(
-        'Вы уверены, что хотите удалить этот факт?',
-        'Подтверждение удаления'
-    );
-
-    if (!confirmed) {
+    if (deletingFactIds.has(factId)) {
+        logger.warn('[FACTS] Delete already in progress for fact:', factId);
         return;
     }
+    deletingFactIds.add(factId);
 
     try {
+        const confirmed = await showConfirmDialog(
+            'Вы уверены, что хотите удалить этот факт?',
+            'Подтверждение удаления'
+        );
+
+        if (!confirmed) {
+            return;
+        }
+
         // Import dynamically to avoid circular dependency
         const { deleteFact: deleteFn } = await import('../integration/factsAPI');
 
@@ -260,6 +268,8 @@ export async function deleteFact(factId: number): Promise<void> {
         logger.error(' Error deleting fact:', error);
         const errorMessage = error instanceof Error ? error.message : String(error);
         showToast(`Ошибка удаления: ${errorMessage}`, 'error');
+    } finally {
+        deletingFactIds.delete(factId);
     }
 }
 


### PR DESCRIPTION
## Summary
- Добавлен module-level Set guard `deletingFactIds` в `facts/operations/factsController.ts` для предотвращения конкурентных DELETE-запросов для одного и того же факта
- Паттерн идентичен уже существующей защите в `plan/crud.ts:122`
- Guard добавлен до открытия диалога подтверждения, чтобы блокировать повторные вызовы ещё до async-ожидания

## Test plan
- [ ] Открыть /facts, быстро двойным кликом нажать "Удалить" на записи → проверить в Network tab что ушёл ровно 1 DELETE запрос
- [ ] Удаление обычным образом работает корректно (без регрессий)
- [ ] `npm run type-check` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)