### PR TITLE
fix: show next payment date for indefinite recurring plans

### DIFF
--- a/backend/app/services/recurring_plan_service.py
+++ b/backend/app/services/recurring_plan_service.py
@@ -718,6 +718,10 @@ class RecurringPlanService:
                 logger.info(
                     f"[RECURRING] Plan {plan.id}: Reached horizon after {generated_count} facts (unbounded plan)"
                 )
+                # Must set next_generation_date here: the break below skips the
+                # normal assignment at line ~773, leaving it None and causing
+                # the UI to show "—" for indefinite plans.
+                plan.next_generation_date = current_date
                 break
 
             # Check if fact already exists for this date


### PR DESCRIPTION
## Summary
- Исправлен баг в `recurring_plan_service.py`: при достижении горизонта генерации (90 дней) для бессрочного плана `next_generation_date` не обновлялась перед `break`
- Теперь дата следующего платежа корректно отображается в UI вместо "—"

## Root cause
Цикл генерации фактов выходит через `break` при достижении горизонта, минуя нормальное присвоение `next_generation_date` в конце цикла. Для бессрочных планов (`end_date=None`, `occurrences_count=None`) это оставляло значение `None`.

## Test plan
- [ ] Создать бессрочный регламентный платёж, дождаться генерации фактов → проверить что "Следующий платёж" показывает реальную дату
- [ ] Backend тесты: `cd tests && ./run-tests.sh backend`

🤖 Generated with [Claude Code](https://claude.com/claude-code)