### PR TITLE
fix: resolve pointer events blocking modal buttons on mobile 375px

### DIFF
--- a/frontend/web/static/css/daisyui-overrides.css
+++ b/frontend/web/static/css/daisyui-overrides.css
@@ -691,3 +691,28 @@ dialog.modal::backdrop {
     height: 3rem !important;
     min-height: 3rem;
 }
+
+/* ============================================== */
+/* 13. Modal Pointer Events Fix (Bug #5)          */
+/* ============================================== */
+
+/**
+ * DaisyUI sets .modal-backdrop { z-index: -1 } which prevents
+ * it from blocking clicks on content behind the modal on mobile (375px).
+ * Fix: raise backdrop to z-index: 0 when modal is open so it intercepts
+ * pointer events, and keep modal-box at z-index: 1 above it.
+ */
+
+/* When modal is open, backdrop must block clicks on content behind */
+.modal[open] .modal-backdrop,
+.modal.modal-open .modal-backdrop {
+    pointer-events: auto;
+    z-index: 0;
+}
+
+/* Ensure modal-box stays above backdrop within stacking context */
+.modal[open] .modal-box,
+.modal.modal-open .modal-box {
+    position: relative;
+    z-index: 1;
+}


### PR DESCRIPTION
## Summary
- Добавлены CSS overrides в `daisyui-overrides.css` для исправления блокировки pointer events на мобильном вьюпорте 375px
- DaisyUI задаёт `.modal-backdrop { z-index: -1 }`, что позволяло основному контенту перехватывать клики при открытом диалоге
- При открытом модале backdrop теперь получает `pointer-events: auto; z-index: 0`, а `.modal-box` — `position: relative; z-index: 1`

## Root cause
Playwright ошибка: `<div class="space-y-6"> subtree intercepts pointer events` — основной контент перехватывал клики предназначенные кнопкам диалогов ("Позже", "Обновить сейчас", "close")

## Test plan
- [ ] Открыть приложение на 375px viewport (мобильный)
- [ ] Проверить что кнопки "Позже" / "Обновить сейчас" в notification dialog кликабельны
- [ ] Проверить что кнопки "Отмена" / "Подтвердить" в confirm dialog кликабельны
- [ ] `npm run build:css` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)