### PR TITLE
fix: update stat counter on incremental add/delete (facts & plan)

### DIFF
--- a/frontend/web/static/js/facts/integration/wsEventHandlers.ts
+++ b/frontend/web/static/js/facts/integration/wsEventHandlers.ts
@@ -10,7 +10,7 @@
 
 import { loadFacts, fetchAndInjectRow } from '../operations/factsController';
 import { buildFilterQuery } from '../operations/filterOperations';
-import { getCurrentPage } from '../core/stateManager';
+import { getCurrentPage, getTotalFacts, setTotalFacts } from '../core/stateManager';
 import type { BudgetFact } from '../types/models';
 
 // ============================================================================
@@ -232,6 +232,18 @@ function animateAndRemoveRow(factId: number): void {
     });
 }
 
+/**
+ * Adjust the displayed total facts counter by delta (+1 or -1).
+ * Used after incremental add/delete to keep the counter in sync
+ * without a full table reload.
+ */
+function adjustStatTotal(delta: number): void {
+    const newTotal = Math.max(0, getTotalFacts() + delta);
+    setTotalFacts(newTotal);
+    const el = document.getElementById('stat-total');
+    if (el) el.textContent = String(newTotal);
+}
+
 // ============================================================================
 // Event Handlers
 // ============================================================================
@@ -269,6 +281,7 @@ async function handleFactCreated(data: Partial<BudgetFact>): Promise<void> {
     }
 
     prependRowToTable(parsed.tr, parsed.mobileCard);
+    adjustStatTotal(+1);
 }
 
 /**
@@ -315,6 +328,7 @@ function handleFactDeleted(data: { id: number }): void {
         return;
     }
     animateAndRemoveRow(data.id);
+    adjustStatTotal(-1);
 }
 
 /**
@@ -337,8 +351,11 @@ async function handleTransferCreated(data: { expense_fact_id?: number; income_fa
     }
     const ids = [data.expense_fact_id, data.income_fact_id].filter(Boolean) as number[];
     const results = await Promise.all(ids.map(id => fetchAndInjectRow(id, 'create')));
-    if (!results.some(Boolean)) {
+    const injectedCount = results.filter(Boolean).length;
+    if (injectedCount === 0) {
         debouncedReloadFacts();
+    } else {
+        adjustStatTotal(injectedCount);
     }
 }
 

--- a/frontend/web/static/js/facts/operations/factsController.ts
+++ b/frontend/web/static/js/facts/operations/factsController.ts
@@ -7,7 +7,7 @@
  */
 
 import { loadFactsWithCount } from '../integration/factsAPI';
-import { setTotalFacts, getCurrentPage, getPageSize, setCurrentPage, getFilters } from '../core/stateManager';
+import { setTotalFacts, getTotalFacts, getCurrentPage, getPageSize, setCurrentPage, getFilters } from '../core/stateManager';
 import { buildFilterQuery } from './filterOperations';
 import type { CreateFactData, UpdateFactData, FactRow } from '../types/models';
 import { escapeHtml, sanitizeErrorMessage } from '../../shared/htmlSanitizer';
@@ -222,6 +222,11 @@ function removeRowFromTable(factId: number): boolean {
         desktopRow?.remove();
         mobileRow?.remove();
     }, 200);
+
+    const newTotal = Math.max(0, getTotalFacts() - 1);
+    setTotalFacts(newTotal);
+    const statEl = document.getElementById('stat-total');
+    if (statEl) statEl.textContent = String(newTotal);
 
     return true;
 }

--- a/frontend/web/static/js/plan/factsTable.ts
+++ b/frontend/web/static/js/plan/factsTable.ts
@@ -617,6 +617,9 @@ export async function fetchAndInjectPlanRow(
         allItems[i].remove();
       }
     }
+    totalFacts++;
+    updateStats();
+    updatePagination();
     return true;
   }
 
@@ -650,6 +653,12 @@ export function removePlanRow(planId: number): void {
 
   const trEl = document.querySelector<HTMLElement>(`tr[data-plan-id="${planId}"]`);
   const divEl = document.querySelector<HTMLElement>(`div[data-plan-id="${planId}"]`);
+
+  if (trEl || divEl) {
+    totalFacts = Math.max(0, totalFacts - 1);
+    updateStats();
+    updatePagination();
+  }
 
   if (trEl) fadeAndRemove(trEl);
   if (divEl) fadeAndRemove(divEl);


### PR DESCRIPTION
## Summary
- **Баг #1**: Счётчик `#stat-total` не обновлялся при добавлении записи через WebSocket (facts page)
- **Баг #2**: Счётчик не обновлялся при удалении записи (facts и plan page)

## Changes

**Facts page (`wsEventHandlers.ts`):**
- `handleFactCreated`: `adjustStatTotal(+1)` после `prependRowToTable`
- `handleFactDeleted`: `adjustStatTotal(-1)` после `animateAndRemoveRow`
- `handleTransferCreated`: `adjustStatTotal(+injectedCount)` для переводов (2 строки)

**Facts page (`factsController.ts`):**
- `removeRowFromTable`: декремент `#stat-total` при прямом удалении

**Plan page (`factsTable.ts`):**
- `fetchAndInjectPlanRow` (create): `totalFacts++` → `updateStats()` → `updatePagination()`
- `removePlanRow`: `totalFacts--` → `updateStats()` → `updatePagination()`

## Test plan
- [ ] /facts: добавить запись → `#stat-total` сразу увеличивается
- [ ] /facts: удалить запись → `#stat-total` сразу уменьшается
- [ ] /facts: создать перевод → счётчик увеличивается на 2
- [ ] /plan: добавить запись → счётчик увеличивается
- [ ] /plan: удалить запись → счётчик уменьшается
- [ ] `npm run type-check` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)