### PR TITLE
fix: resolve 6 bugs and 3 UX issues found during testing

### DIFF
--- a/frontend/shared/static/js/choicesCategoryTree.js
+++ b/frontend/shared/static/js/choicesCategoryTree.js
@@ -853,6 +853,26 @@ class ChoicesCategoryTree {
     /**
      * Destroy component and cleanup.
      */
+    /**
+     * Enable the Choices.js select (delegates to this.choices.enable()).
+     * Mirrors the Choices.js API so callers don't need to access this.choices directly.
+     */
+    enable() {
+        if (this.choices) {
+            this.choices.enable();
+        }
+    }
+
+    /**
+     * Disable the Choices.js select (delegates to this.choices.disable()).
+     * Mirrors the Choices.js API so callers don't need to access this.choices directly.
+     */
+    disable() {
+        if (this.choices) {
+            this.choices.disable();
+        }
+    }
+
     destroy() {
         if (this.choices) {
             this.choices.destroy();

--- a/frontend/shared/static/js/choicesCategoryTree.js
+++ b/frontend/shared/static/js/choicesCategoryTree.js
@@ -851,9 +851,6 @@ class ChoicesCategoryTree {
     }
 
     /**
-     * Destroy component and cleanup.
-     */
-    /**
      * Enable the Choices.js select (delegates to this.choices.enable()).
      * Mirrors the Choices.js API so callers don't need to access this.choices directly.
      */
@@ -873,6 +870,9 @@ class ChoicesCategoryTree {
         }
     }
 
+    /**
+     * Destroy component and cleanup.
+     */
     destroy() {
         if (this.choices) {
             this.choices.destroy();

--- a/frontend/web/static/css/daisyui-overrides.css
+++ b/frontend/web/static/css/daisyui-overrides.css
@@ -701,13 +701,24 @@ dialog.modal::backdrop {
  * it from blocking clicks on content behind the modal on mobile (375px).
  * Fix: raise backdrop to z-index: 0 when modal is open so it intercepts
  * pointer events, and keep modal-box at z-index: 1 above it.
+ *
+ * The form itself uses pointer-events: none so modal-box buttons (e.g. "Позже")
+ * are never blocked by the backdrop form on narrow viewports.
+ * The backdrop close button still captures click-outside via pointer-events: auto.
  */
 
-/* When modal is open, backdrop must block clicks on content behind */
+/* Backdrop form: transparent to pointer events, close button still works */
 .modal[open] .modal-backdrop,
 .modal.modal-open .modal-backdrop {
-    pointer-events: auto;
+    pointer-events: none;
     z-index: 0;
+}
+
+/* Close button inside backdrop captures click-outside events */
+.modal[open] .modal-backdrop > button,
+.modal.modal-open .modal-backdrop > button {
+    pointer-events: auto;
+    cursor: default;
 }
 
 /* Ensure modal-box stays above backdrop within stacking context */

--- a/frontend/web/static/js/facts/features/modalFact/categoryWidget.ts
+++ b/frontend/web/static/js/facts/features/modalFact/categoryWidget.ts
@@ -255,6 +255,11 @@ function setupTransferFCListeners(): void {
                     fromTree.enable();
                     const fromArticle = document.querySelector<HTMLSelectElement>(FROM_ARTICLE_SELECTOR);
                     if (fromArticle) fromArticle.removeAttribute('disabled');
+                    // Sync Choices.js visual state with existing DOM value (e.g. when editing transfer)
+                    const existingId = fromArticle?.value ? parseInt(fromArticle.value) : null;
+                    if (existingId) {
+                        fromTree.setSelectedCategory(existingId);
+                    }
                 }
             }
         });
@@ -275,6 +280,11 @@ function setupTransferFCListeners(): void {
                     toTree.enable();
                     const toArticle = document.querySelector<HTMLSelectElement>(TO_ARTICLE_SELECTOR);
                     if (toArticle) toArticle.removeAttribute('disabled');
+                    // Sync Choices.js visual state with existing DOM value (e.g. when editing transfer)
+                    const existingId = toArticle?.value ? parseInt(toArticle.value) : null;
+                    if (existingId) {
+                        toTree.setSelectedCategory(existingId);
+                    }
                 }
             }
         });

--- a/frontend/web/static/js/plan/crud.ts
+++ b/frontend/web/static/js/plan/crud.ts
@@ -10,6 +10,7 @@
 import * as PlanHelpers from './helpers';
 import * as PlanFactsTable from './factsTable';
 import { remindersMap, selectedFactIds } from './factsTable';
+import * as FilterAnalyticsSync from './filterAnalyticsSync';
 
 // Import BudgetShared from global
 declare const BudgetShared: {
@@ -758,6 +759,7 @@ export async function deleteFact(factId: number): Promise<void> {
       // Reload and show success
       deletingFactIds.delete(factId);
       await PlanFactsTable.loadFacts();
+      FilterAnalyticsSync.debouncedSyncFiltersToAnalytics();
       PlanHelpers.showToast(`Удалено ${factIdsToDelete.length} регламентных записей`, 'success');
     } else {
       // Delete single fact
@@ -773,6 +775,7 @@ export async function deleteFact(factId: number): Promise<void> {
       // Reload BEFORE showing toast (non-blocking)
       deletingFactIds.delete(factId);
       await PlanFactsTable.loadFacts();
+      FilterAnalyticsSync.debouncedSyncFiltersToAnalytics();
 
       // Non-blocking toast notification
       PlanHelpers.showToast('Факт успешно удален', 'success');
@@ -784,6 +787,7 @@ export async function deleteFact(factId: number): Promise<void> {
     // Reload even on error to sync UI
     deletingFactIds.delete(factId);
     await PlanFactsTable.loadFacts();
+    FilterAnalyticsSync.debouncedSyncFiltersToAnalytics();
 
     // Non-blocking toast notification
     PlanHelpers.showToast('Ошибка: ' + errorMessage, 'error');

--- a/frontend/web/static/js/plan/factsTable.ts
+++ b/frontend/web/static/js/plan/factsTable.ts
@@ -358,7 +358,7 @@ function renderFactsTable(facts: BudgetFact[]): void {
         <td class="max-w-xs truncate" title="${description}">${descriptionTruncated}</td>
         <td>${userName}</td>
         <td class="text-xs text-base-content/60">${TableFormatters.formatUpdatedAt(fact.updated_at)}</td>
-        <td class="text-center">${remindersMap.has(fact.id) ? '<span class="text-info" title="Напоминание установлено">🔔</span>' : ''}</td>
+        <td class="text-center">${fact.has_reminder ? '<span class="text-info" title="Напоминание установлено">🔔</span>' : ''}</td>
         <td class="text-center">${fact.recurring_plan_id ? '<span class="text-secondary" title="Регламентный платеж">🔄</span>' : ''}</td>
         <td class="text-center" title="${fact.is_offline_sync ? 'Создано offline' : ''}">${fact.is_offline_sync ? '☁️' : ''}</td>
         <td>
@@ -377,7 +377,7 @@ function renderFactsTable(facts: BudgetFact[]): void {
     // Mobile list item
     const mobileAmountClass = TableFormatters.getArticleColorClass(fact.article_type, 'amount');
     const mobileAmount = TableFormatters.formatAmount(fact.amount, fact.article_type);
-    const reminderIcon = remindersMap.has(fact.id)
+    const reminderIcon = fact.has_reminder
       ? '<span class="text-info text-xs" title="Напоминание">🔔</span>'
       : '';
     const offlineIcon = fact.is_offline_sync

--- a/frontend/web/static/js/plan/helpers.ts
+++ b/frontend/web/static/js/plan/helpers.ts
@@ -98,6 +98,7 @@ export interface BudgetFact {
   user_name: string;
   record_type: 'plan' | 'fact' | string;
   recurring_plan_id: number | null;
+  has_reminder?: boolean;
   is_offline_sync?: boolean;
   is_template?: boolean;
   created_at?: string;

--- a/frontend/web/static/js/plan/planModal.ts
+++ b/frontend/web/static/js/plan/planModal.ts
@@ -370,7 +370,7 @@ function renderRecurringPlansTable(plans: any[]): void {
     const amount = plan.amount
       ? parseFloat(plan.amount).toLocaleString('ru-RU', { minimumFractionDigits: 0 })
       : '—';
-    const nextDate = plan.next_execution_date || '—';
+    const nextDate = plan.next_generation_date || '—';
     const frequencyText = getFrequencyDisplayText(plan.frequency_type, plan.frequency_value);
     const durationText = getDurationDisplayText(plan);
 

--- a/frontend/web/static/js/utils/modalKeyboardAdapter.js
+++ b/frontend/web/static/js/utils/modalKeyboardAdapter.js
@@ -27,6 +27,9 @@ class ModalKeyboardAdapter {
         // Timers
         this._resizeTimer = null;
 
+        // Flag to suppress viewport scroll handler during programmatic modal-box scroll
+        this._isProgrammaticScroll = false;
+
         // Auto-initialize
         this._init();
     }
@@ -106,6 +109,8 @@ class ModalKeyboardAdapter {
     }
 
     _onViewportScroll() {
+        // Skip during programmatic modal-box scroll to prevent modal from closing
+        if (this._isProgrammaticScroll) return;
         // VisualViewport scrolls when keyboard opens on some devices
         // Update CSS variables to maintain correct positioning
         if (this._isKeyboardOpen) {
@@ -334,7 +339,9 @@ class ModalKeyboardAdapter {
             // Input is below visible area
             if (inputRect.bottom > modalRect.bottom) {
                 const scrollOffset = inputRect.bottom - modalRect.bottom + 20; // 20px padding
+                this._isProgrammaticScroll = true;
                 modalBox.scrollTop += scrollOffset;
+                setTimeout(() => { this._isProgrammaticScroll = false; }, 150);
 
                 logModalKB.debug('📜 Scrolled input into view (downward)', { scrollOffset });
             }
@@ -342,7 +349,9 @@ class ModalKeyboardAdapter {
             // Input is above visible area
             if (inputRect.top < modalRect.top) {
                 const scrollOffset = modalRect.top - inputRect.top + 20;
+                this._isProgrammaticScroll = true;
                 modalBox.scrollTop -= scrollOffset;
+                setTimeout(() => { this._isProgrammaticScroll = false; }, 150);
 
                 logModalKB.debug('📜 Scrolled input into view (upward)', { scrollOffset });
             }

--- a/frontend/web/templates/analytics.html
+++ b/frontend/web/templates/analytics.html
@@ -24,7 +24,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="space-y-6 pt-4">
+<div class="space-y-6 pt-4 pb-20 lg:pb-4">
     <!-- Page Header -->
     <div class="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
         <h1 class="text-xl sm:text-2xl font-bold mb-1 sm:mb-2">📊 Панель аналитики</h1>

--- a/frontend/web/templates/base.html
+++ b/frontend/web/templates/base.html
@@ -7,6 +7,7 @@
     <meta name="description" content="Семейный бюджет - Track your income and expenses with powerful analytics">
     <meta name="theme-color" content="#4CAF50">
     <meta name="app-env" content="{{ app_env|default('production') }}">
+    <meta name="app-version" content="{{ config.VERSION }}">
     <title>{% block title %}{{ page_title }}{% endblock %} - Семейный бюджет</title>
 
     <!-- CRITICAL CSS: Splash Screen - load BEFORE external CSS for instant display -->

--- a/frontend/web/templates/facts.html
+++ b/frontend/web/templates/facts.html
@@ -177,7 +177,7 @@
                     <button class="btn btn-sm btn-outline gap-1" data-action="export-csv" title="Экспорт отфильтрованных фактов в CSV">
                         📄 CSV
                     </button>
-                    <button class="btn btn-sm btn-error gap-1 hidden md:flex" id="batch-delete-btn" data-action="batch-delete" disabled>
+                    <button class="btn btn-sm btn-error gap-1 flex" id="batch-delete-btn" data-action="batch-delete" disabled>
                         🗑️ Удалить выбранные
                     </button>
                 </div>

--- a/frontend/web/templates/scripts/service-worker-registration.html
+++ b/frontend/web/templates/scripts/service-worker-registration.html
@@ -444,7 +444,9 @@
             }
 
             // Display new version (always shown)
-            const newText = newVersion || '(неизвестно)';
+            // Fallback to <meta name="app-version"> when SW MessageChannel times out
+            const metaVersion = document.querySelector('meta[name="app-version"]')?.content;
+            const newText = newVersion || metaVersion || '(неизвестно)';
             newElem.textContent = newText;
 
             // Show current version and arrow only when version is known and different


### PR DESCRIPTION
## Summary

- **Баг #1** — SW-версия "(неизвестно)": добавлен `<meta name="app-version">` как fallback когда SW не отвечает по MessageChannel
- **Баг #2** — Кнопка "Позже" заблокирована на 375px: `modal-backdrop` → `pointer-events: none`, только `>button` получает `auto`
- **Баг #3** — Иконка 🔔 отсутствует на странице планов: `has_reminder` добавлен в `BudgetFact`, `factsTable.ts` использует поле напрямую
- **Баг #4** — Аналитика не обновляется после удаления: `deleteFact()` теперь вызывает `debouncedSyncFiltersToAnalytics()`
- **Баг #5** — "Следующий платёж" всегда "—": `next_execution_date` → `next_generation_date`
- **Баг #6** — Модал закрывается при скролле: флаг `_isProgrammaticScroll` в `modalKeyboardAdapter.js`
- **Замечание #1** — Кнопка "Удалить выбранные" скрыта на мобильном: `hidden md:flex` → `flex`
- **Замечание #2** — FAB перекрывает кнопки аналитики: `pb-20 lg:pb-4` на странице аналитики
- **Замечание #3** — Choices.js показывает placeholder в форме переводов: добавлены `enable()`/`disable()` в `ChoicesCategoryTree`, синхронизация DOM-значения после `enable()`

## Test plan

- [ ] Открыть диалог обновления SW — версия отображается корректно (не "(неизвестно)")
- [ ] На мобильном (375px) — кнопка "Позже" в SW-диалоге нажимается
- [ ] Страница планов — иконка 🔔 отображается у записей с напоминанием
- [ ] Страница планов — удаление факта обновляет секцию аналитики
- [ ] Страница планов — "Следующий платёж" у повторяющегося плана отображается корректно
- [ ] Мобильный/PWA — ввод в модале с клавиатурой не закрывает модал
- [ ] Мобильный — кнопка "Удалить выбранные" на странице фактов видна
- [ ] Страница аналитики — кнопки периода не перекрываются FAB
- [ ] Форма переводов — при выборе ФЦ категория синхронизируется корректно

🤖 Generated with [Claude Code](https://claude.com/claude-code)