### PR TITLE
fix: facts table incremental update, transfer form validation, article select enablement

### DIFF
--- a/frontend/web/static/js/facts/adapters/windowExports.ts
+++ b/frontend/web/static/js/facts/adapters/windowExports.ts
@@ -545,14 +545,18 @@ async function saveFactModalFacts(button: HTMLElement): Promise<void> {
     setButtonLoading(button, true);
 
     // Validate active tab only — inactive tab fields are hidden and must not block submission
+    // Disable ALL fields in inactive tab (not just required) to prevent "not focusable" errors
+    // from hidden fields when checkValidity() / reportValidity() tries to focus them
     const inactiveTabName = activeTab === 'transfer' ? 'transaction' : 'transfer';
     const inactiveContainer = form.querySelector<HTMLElement>(`[data-tab="${inactiveTabName}"]`);
-    const inactiveRequired = inactiveContainer
-        ? Array.from(inactiveContainer.querySelectorAll<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>('[required]'))
+    const inactiveFields = inactiveContainer
+        ? Array.from(inactiveContainer.querySelectorAll<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>('input, select, textarea'))
         : [];
-    inactiveRequired.forEach(f => { f.required = false; });
+    const previousRequiredState = inactiveFields.map(f => f.required);
+    const previousDisabledState = inactiveFields.map(f => f.disabled);
+    inactiveFields.forEach(f => { f.required = false; f.disabled = true; });
     const isValid = form.checkValidity();
-    inactiveRequired.forEach(f => { f.required = true; });
+    inactiveFields.forEach((f, i) => { f.required = previousRequiredState[i]; f.disabled = previousDisabledState[i]; });
 
     if (!isValid) {
         setButtonLoading(button, false);

--- a/frontend/web/static/js/facts/index.ts
+++ b/frontend/web/static/js/facts/index.ts
@@ -488,6 +488,7 @@ function populateCreateModalArticles(articles: any[]): void {
             option.textContent = article.name;
             transferFromArticleSelect.appendChild(option);
         });
+        transferFromArticleSelect.disabled = false;
     }
 
     const transferToArticleSelect = document.querySelector('#modal_fact-tab-transfer select[name="to_article_id"]') as HTMLSelectElement;
@@ -501,6 +502,7 @@ function populateCreateModalArticles(articles: any[]): void {
             option.textContent = article.name;
             transferToArticleSelect.appendChild(option);
         });
+        transferToArticleSelect.disabled = false;
     }
 }
 

--- a/frontend/web/static/js/facts/integration/wsEventHandlers.ts
+++ b/frontend/web/static/js/facts/integration/wsEventHandlers.ts
@@ -128,17 +128,35 @@ async function fetchRowHtml(factId: number): Promise<string | null> {
 }
 
 /**
- * Parse HTML fragment into desktop <tr> and mobile <div> elements
+ * Parse HTML fragment into desktop <tr> and mobile <div> elements.
+ * Handles the <template data-plan-row="...">desktop|||mobile</template> wrapping
+ * returned by the /row-html endpoint (template content lives in a DocumentFragment,
+ * not queryable from the main document tree).
  *
  * @param html - Raw HTML string from /row-html endpoint
  * @returns Object with tr and mobileCard elements, or null if parsing fails
  */
-function parseRowHtml(html: string): { tr: HTMLTableRowElement; mobileCard: HTMLDivElement } | null {
-    const wrapper = document.createElement('div');
-    wrapper.innerHTML = html;
+export function parseRowHtml(html: string): { tr: HTMLTableRowElement; mobileCard: HTMLDivElement } | null {
+    const parser = new DOMParser();
 
-    const tr = wrapper.querySelector('tr[data-id]') as HTMLTableRowElement | null;
-    const mobileCard = wrapper.querySelector('div[data-id]') as HTMLDivElement | null;
+    const templateDoc = parser.parseFromString(html, 'text/html');
+    const templateEl = templateDoc.querySelector('template[data-plan-row]');
+
+    let tr: HTMLTableRowElement | null = null;
+    let mobileCard: HTMLDivElement | null = null;
+
+    if (templateEl) {
+        const parts = templateEl.innerHTML.split('|||');
+        const desktopDoc = parser.parseFromString(`<table><tbody>${parts[0] || ''}</tbody></table>`, 'text/html');
+        const mobileDoc = parser.parseFromString(parts[1] || '', 'text/html');
+        tr = desktopDoc.querySelector('tr[data-id]') as HTMLTableRowElement | null;
+        mobileCard = mobileDoc.querySelector('div[data-id]') as HTMLDivElement | null;
+    } else {
+        // Fallback: direct parsing (legacy or changed endpoint format)
+        const doc = parser.parseFromString(`<table><tbody>${html}</tbody></table>`, 'text/html');
+        tr = doc.querySelector('tr[data-id]') as HTMLTableRowElement | null;
+        mobileCard = doc.querySelector('div[data-id]') as HTMLDivElement | null;
+    }
 
     if (!tr || !mobileCard) {
         return null;

--- a/frontend/web/static/js/facts/operations/factsController.ts
+++ b/frontend/web/static/js/facts/operations/factsController.ts
@@ -9,6 +9,7 @@
 import { loadFactsWithCount } from '../integration/factsAPI';
 import { setTotalFacts, getTotalFacts, getCurrentPage, getPageSize, setCurrentPage, getFilters } from '../core/stateManager';
 import { buildFilterQuery } from './filterOperations';
+import { parseRowHtml } from '../integration/wsEventHandlers';
 import type { CreateFactData, UpdateFactData, FactRow } from '../types/models';
 import { escapeHtml, sanitizeErrorMessage } from '../../shared/htmlSanitizer';
 import { TableFormatters } from '../../shared/tableUtils';
@@ -166,32 +167,31 @@ export async function fetchAndInjectRow(factId: number, operation: 'create' | 'u
         }
 
         const html = await response.text();
-
-        const parser = new DOMParser();
-        const doc = parser.parseFromString(`<table><tbody>${html}</tbody></table>`, 'text/html');
-        const newTr = doc.querySelector('tr[data-id]');
-        const newMobileDiv = doc.querySelector('div.transaction-item[data-id]');
+        const parsed = parseRowHtml(html);
 
         if (operation === 'create') {
+            if (!parsed) return false;
             const tbody = document.querySelector('.facts-desktop-table tbody');
-            if (tbody && newTr) {
-                tbody.insertBefore(newTr, tbody.firstChild);
+            if (tbody) {
+                tbody.insertBefore(parsed.tr, tbody.firstChild);
             }
             const mobileList = document.querySelector('.facts-mobile-list');
-            if (mobileList && newMobileDiv) {
-                mobileList.insertBefore(newMobileDiv, mobileList.firstChild);
+            if (mobileList) {
+                mobileList.insertBefore(parsed.mobileCard, mobileList.firstChild);
             }
+            // Return true only if we actually injected into a container
             return !!(tbody || mobileList);
         }
 
         if (operation === 'update') {
+            if (!parsed) return false;
             const existingTr = document.querySelector(`tr[data-id="${factId}"]`);
-            if (existingTr && newTr) {
-                existingTr.replaceWith(newTr);
+            if (existingTr) {
+                existingTr.replaceWith(parsed.tr);
             }
             const existingMobile = document.querySelector(`div.transaction-item[data-id="${factId}"]`);
-            if (existingMobile && newMobileDiv) {
-                existingMobile.replaceWith(newMobileDiv);
+            if (existingMobile) {
+                existingMobile.replaceWith(parsed.mobileCard);
             }
             return !!(existingTr || existingMobile);
         }


### PR DESCRIPTION
## Summary

- **Bug #2/#3**: `fetchAndInjectRow()` silently failed — the `/row-html` endpoint wraps content in `<template data-plan-row="...">` whose `DocumentFragment` is invisible to `querySelector`. Fixed `parseRowHtml()` in `wsEventHandlers.ts` (the shared parsing function) to unwrap the template by splitting on `|||`, then reuse it from `factsController.ts` instead of duplicating logic. Also fixed the return value for `create` to return `false` when `parseRowHtml` returns null (row was parsed but not injected).
- **Bug #4a**: `saveFactModalFacts()` validation was blocked by hidden fields in the inactive tab throwing a browser "not focusable" error on `reportValidity()`. Fixed by disabling ALL inactive tab fields (not just `[required]` ones) during `checkValidity()` and restoring their original `disabled`/`required` state afterward.
- **Bug #4b**: Transfer article selects (`from_article_id`, `to_article_id`) start with `disabled` in the HTML template but were never re-enabled after `populateCreateModalArticles()` populated them. Fixed by setting `disabled = false` after population.

## Test plan

- [ ] `npm run type-check` passes (verified)
- [ ] `npm run bundle` compiles successfully (verified)
- [ ] Create a fact via modal — row appears immediately in table without full reload
- [ ] Edit a fact via edit modal — row updates in place without full reload
- [ ] Open transfer modal — article selects (From/To Category) are interactive and populated
- [ ] Save a transaction while transfer tab is open — no "not focusable" browser error, form submits

🤖 Generated with [Claude Code](https://claude.com/claude-code)