### PR TITLE
fix: remove required from disabled transfer article selects

### DIFF
--- a/frontend/web/templates/components/tabs/fact_transfer_tab.html
+++ b/frontend/web/templates/components/tabs/fact_transfer_tab.html
@@ -35,7 +35,7 @@
         <label class="label py-0.5">
             <span class="label-text text-xs">Категория *</span>
         </label>
-        <select name="from_article_id" required class="select select-bordered select-sm" disabled>
+        <select name="from_article_id" class="select select-bordered select-sm" disabled>
             <option value="">-- Выберите категорию --</option>
         </select>
     </div>
@@ -70,7 +70,7 @@
         <label class="label py-0.5">
             <span class="label-text text-xs">Категория *</span>
         </label>
-        <select name="to_article_id" required class="select select-bordered select-sm" disabled>
+        <select name="to_article_id" class="select select-bordered select-sm" disabled>
             <option value="">-- Выберите категорию --</option>
         </select>
     </div>


### PR DESCRIPTION
## Summary
- Removed `required` attribute from `from_article_id` and `to_article_id` selects in the Transfer tab
- These selects are `disabled` (populated dynamically after account selection), so `required` was conflicting and triggering browser native validation error "Заполните это поле" on submit
- JS validation in `saveFactModalFacts()` already handles these fields correctly via `parseIntOrNull` (optional)

## Test plan
- [ ] Open /facts → click "Перевод" tab in the add modal
- [ ] Fill in date, from account, to account, amount — leave category selects untouched (they remain disabled)
- [ ] Submit — should save without browser "fill this field" popup
- [ ] Select an account to populate a category select, choose a category, submit — should still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)