### PR TITLE
fix: plan page 'Всего' counter updates via WebSocket events

### DIFF
--- a/frontend/web/static/js/plan/factsTable.ts
+++ b/frontend/web/static/js/plan/factsTable.ts
@@ -654,11 +654,11 @@ export function removePlanRow(planId: number): void {
   const trEl = document.querySelector<HTMLElement>(`tr[data-plan-id="${planId}"]`);
   const divEl = document.querySelector<HTMLElement>(`div[data-plan-id="${planId}"]`);
 
-  if (trEl || divEl) {
-    totalFacts = Math.max(0, totalFacts - 1);
-    updateStats();
-    updatePagination();
-  }
+  // Always decrement the counter: the record was deleted from DB regardless of
+  // whether it is visible on the current page (matches facts-page pattern).
+  totalFacts = Math.max(0, totalFacts - 1);
+  updateStats();
+  updatePagination();
 
   if (trEl) fadeAndRemove(trEl);
   if (divEl) fadeAndRemove(divEl);


### PR DESCRIPTION
## Summary

- **Bug #2**: The `Всего: N` counter in the plan page header did not update in real-time when plan records were deleted while browsing a page other than the page containing the deleted record.
- `removePlanRow()` previously only decremented `totalFacts` when the deleted row was found in the DOM. Records on off-screen pages caused the counter to stay stale after a `plan_deleted` WS event.
- Aligned with the facts-page pattern (`adjustStatTotal(-1)` fires unconditionally on `fact_deleted`): always decrement `totalFacts` and call `updateStats()`/`updatePagination()` in `removePlanRow()`, regardless of DOM presence.

Note: The `plan_created` counter fix (`totalFacts++` inside `fetchAndInjectPlanRow`) was already applied in the prior batch commit (a4ddc8a8).

## Test plan

- [ ] Open `/plan` page
- [ ] Create a plan record via form → verify `Всего` counter increments in real-time (no page reload)
- [ ] Delete a plan record visible on the current page → verify counter decrements immediately
- [ ] Navigate to page 2 (or add enough records to paginate), then delete a record on page 1 while viewing page 2 → verify counter on page 2 decrements correctly
- [ ] Verify `plan_deleted` WS events from another browser tab/device also decrement the counter

🤖 Generated with [Claude Code](https://claude.com/claude-code)