### PR TITLE
fix: Dexie hard-deletes records on server-initiated delta sync

### DIFF
--- a/frontend/shared/db/dexie/DexieManager.ts
+++ b/frontend/shared/db/dexie/DexieManager.ts
@@ -537,6 +537,18 @@ export class DexieManager {
     });
   }
 
+  /**
+   * Bulk hard delete facts by temp_id (removes records from IndexedDB entirely)
+   * Used for server-initiated deletes during delta sync
+   */
+  async bulkHardDeleteFacts(temp_ids: number[]): Promise<void> {
+    logger.info('[DexieManager] bulkHardDeleteFacts', { count: temp_ids.length });
+    await this.getDB().budgetFacts
+      .where('temp_id').anyOf(temp_ids)
+      .delete();
+    logger.info('[DexieManager] ✅ Bulk hard delete complete', { count: temp_ids.length });
+  }
+
   // ============================================================
   // SYNC OPERATIONS
   // ============================================================

--- a/frontend/web/static/js/budget/budgetWSClient/integration/syncHandler.ts
+++ b/frontend/web/static/js/budget/budgetWSClient/integration/syncHandler.ts
@@ -216,8 +216,8 @@ export async function handleSyncIncremental(data: SyncIncrementalResponse['data'
     }
 
     if (data.deleted.length > 0) {
-      // Convert server IDs to temp_ids (TODO: server should send temp_ids instead)
-      await dexie.bulkSoftDeleteFacts(data.deleted.map(String));
+      // Hard-delete records that were deleted on the server
+      await dexie.bulkHardDeleteFacts(data.deleted);
     }
 
     // Update sync metadata with new timestamp


### PR DESCRIPTION
## Summary

- Bug #7: Dexie не синхронизирует удалённые записи с сервера
- Заменяет `bulkSoftDeleteFacts` (помечает `sync_status='deleted'`) на `bulkHardDeleteFacts` — физически удаляет записи из IndexedDB при дельта-синке от сервера
- Добавлен метод `bulkHardDeleteFacts(temp_ids: number[])` в `DexieManager.ts`

Closes #570

🤖 Generated with [Claude Code](https://claude.com/claude-code)