### PR TITLE
fix: resolve 6 bugs from E2E testing

### DIFF
--- a/frontend/web/static/js/dashboard/features/editModal/deleteOperations.ts
+++ b/frontend/web/static/js/dashboard/features/editModal/deleteOperations.ts
@@ -6,9 +6,6 @@
 
 import { loadPendingRecords } from '../pendingRecords';
 import { closeEditModal, getCurrentEditingPendingId } from './formPopulation';
-import { ConfirmDialog } from '../../../modules/uiComponents/modals/ConfirmDialog';
-
-
 
 declare const debugLog: (...args: any[]) => void;
 // ============================================================================
@@ -85,7 +82,7 @@ export async function deleteFromEditModal(): Promise<void> {
   if (!recordId) return;
 
   // Confirm deletion
-  const confirmed = await ConfirmDialog.show(
+  const confirmed = await window.showConfirmDialog(
     'Вы уверены, что хотите удалить эту запись? Это действие необратимо.',
     'Подтверждение удаления'
   );
@@ -161,7 +158,7 @@ export async function deleteFactFromDashboard(factId: number, isRecurring: numbe
       deleteMode = choice; // 'single' or 'all'
     } else {
       // Regular fact - show standard confirmation
-      const confirmed = await ConfirmDialog.show(
+      const confirmed = await window.showConfirmDialog(
         'Вы уверены, что хотите удалить эту запись? Это действие необратимо.',
         'Подтверждение удаления'
       );

--- a/frontend/web/static/js/dashboard/features/modalFact/index.ts
+++ b/frontend/web/static/js/dashboard/features/modalFact/index.ts
@@ -155,6 +155,17 @@ function setupTransactionFCListener(): void {
     fcSelect.dataset.transactionHintsListenerAttached = 'true';
     debugLog('[ModalFact] Transaction FC hints listener attached');
   }
+
+  const categorySelect = document.querySelector<HTMLSelectElement>(
+    '#modal_fact-tab-transaction select[name="article_id"]'
+  );
+  if (categorySelect && !categorySelect.dataset.transactionHintsListenerAttached) {
+    categorySelect.addEventListener('change', () => {
+      loadFactTransactionHints();
+    });
+    categorySelect.dataset.transactionHintsListenerAttached = 'true';
+    debugLog('[ModalFact] Transaction category hints listener attached');
+  }
 }
 
 /**

--- a/frontend/web/static/js/dashboard/features/modalPlan/index.ts
+++ b/frontend/web/static/js/dashboard/features/modalPlan/index.ts
@@ -251,6 +251,20 @@ async function loadTransferTabData(): Promise<void> {
 }
 
 /**
+ * Auto-select the only available category in a ChoicesCategoryTree.
+ * For transfer forms where debit/credit typically have a single article.
+ */
+function autoSelectSingleCategory(tree: any): void {
+  if (!tree?.choices?._store?.choices) return;
+  const available = tree.choices._store.choices.filter(
+    (c: any) => c.value !== '' && !c.placeholder
+  );
+  if (available.length === 1) {
+    tree.choices.setChoiceByValue(available[0].value);
+  }
+}
+
+/**
  * Setup FC change listeners for transfer tab hints
  */
 function setupTransferFCListeners(): void {
@@ -268,6 +282,7 @@ function setupTransferFCListeners(): void {
           fromTree.disable();
         } else {
           fromTree.enable();
+          autoSelectSingleCategory(fromTree);
         }
       }
       loadPlanTransferHints('from');
@@ -286,6 +301,7 @@ function setupTransferFCListeners(): void {
           toTree.disable();
         } else {
           toTree.enable();
+          autoSelectSingleCategory(toTree);
         }
       }
       loadPlanTransferHints('to');

--- a/frontend/web/static/js/dashboard/integration/wsEventHandlers.ts
+++ b/frontend/web/static/js/dashboard/integration/wsEventHandlers.ts
@@ -184,6 +184,17 @@ function registerPlanHandlers(hasIncrementalUpdates: boolean): void {
       refreshQuickStats();
     }
   });
+
+  window.budgetWSClient.on('recurring_plan_created', (data: FactEventData) => {
+    debugLog('[WS] Recurring plan created:', data.id);
+    if (hasIncrementalUpdates && window.IncrementalUpdates) {
+      window.IncrementalUpdates.onPlanCreated(data);
+    } else {
+      refreshQuickStats();
+      refreshAccountBalances();
+    }
+    debouncedLoadRecurringPlans();
+  });
 }
 
 // ============================================================================

--- a/frontend/web/templates/components/push_permission_banner.html
+++ b/frontend/web/templates/components/push_permission_banner.html
@@ -21,12 +21,10 @@
 {% macro push_permission_banner() %}
     <!-- Push Notification Permission Banner (for iOS/Android) -->
     <!-- Positioned below navbar with 10px margin, horizontally centered -->
-    <!-- Z-index: 50 (same as navbar, stacks correctly via DOM order) -->
+    <!-- Z-index: 40 (same as navbar, stacks correctly via DOM order) -->
     <!-- Safe-area: Accounts for iOS Dynamic Island/notch and side padding -->
-    <div id="push-permission-banner" class="fixed left-1/2 -translate-x-1/2 w-auto max-w-96 bg-base-100 border border-primary rounded-lg shadow-lg p-4 z-50 hidden"
-         style="top: calc(64px + 10px + env(safe-area-inset-top, 0px));
-                margin-left: max(16px, env(safe-area-inset-left, 0px));
-                margin-right: max(16px, env(safe-area-inset-right, 0px));">
+    <div id="push-permission-banner" class="fixed left-1/2 -translate-x-1/2 w-[calc(100vw-2rem)] max-w-96 bg-base-100 border border-primary rounded-lg shadow-lg p-4 z-40 hidden"
+         style="top: calc(64px + 10px + env(safe-area-inset-top, 0px));">
         <div class="flex items-start gap-3">
             <span class="text-2xl">🔔</span>
             <div class="flex-1">

--- a/frontend/web/templates/components/sw_update_modal.html
+++ b/frontend/web/templates/components/sw_update_modal.html
@@ -30,7 +30,7 @@
                     <span class="opacity-70 whitespace-nowrap">Версия:</span>
                     <span id="sw-current-version" class="badge badge-ghost badge-sm font-mono break-all hidden"></span>
                     <span id="sw-version-arrow" class="opacity-70 hidden">→</span>
-                    <span id="sw-new-version" class="badge badge-warning badge-sm font-mono break-all">(неизвестно)</span>
+                    <span id="sw-new-version" class="badge badge-warning badge-sm font-mono break-all">{{ config.VERSION }}</span>
                 </div>
             </div>
             <div class="mb-6 text-sm">

--- a/frontend/web/templates/scripts/service-worker-registration.html
+++ b/frontend/web/templates/scripts/service-worker-registration.html
@@ -449,10 +449,12 @@
             const currentText = currentVersion || '(неизвестно)';
             currentElem.textContent = currentText;
 
-            // Display new version: prefer meta tag (always available from server), fall back to localStorage
+            // Display new version: prefer localStorage (actual new SW version), fall back to meta tag
             const metaVersion = document.querySelector('meta[name="app-version"]')?.content;
-            const newText = metaVersion || newVersion || '(неизвестно)';
-            newElem.textContent = newText;
+            const newText = newVersion || metaVersion || '';
+            if (newText) {
+                newElem.textContent = newText;
+            }
 
             // Show current version and arrow only when version is known and different
             const hasTransition = currentVersion && currentVersion !== newVersion;


### PR DESCRIPTION
## Summary

Fixes 6 bugs discovered during comprehensive E2E testing via MCP Playwright:

- **Bug #6** (Critical): Delete confirmation dialog never triggered DELETE API — ConfirmDialog singleton clash between `dashboard.min.js` and `confirm-dialog.min.js` Rollup bundles. Both bundles had independent copies of the `ConfirmDialog` class with separate static state.
- **Bug #2** (Medium): Dashboard stats not updating after recurring plan creation — WS event name mismatch (`recurring_plan_created` vs `plan_created`)
- **Bug #1** (High): SW update modal showing "(неизвестно)" instead of version number
- **Bug #3** (High): Transfer plan form validation error — hidden `from_article_id`/`to_article_id` selects not auto-populated
- **Bug #4** (Medium): Fact dialog "План мес / Факт мес" hints always showing "--" — missing category change listener
- **Bug #8** (Low): Push notification banner overlapping stats on mobile 375px

### Bug #5 (reminder icon) — NOT A BUG
Investigation showed the `/api/v1/facts/recent-html` endpoint already includes 🔔 icons. The Jinja2 template `recent_transactions.html` is not used on the dashboard — content is loaded via HTMX.

### Bug #7 (UI not updating after deletion) — consequence of Bug #6
Once Bug #6 is fixed and deletion works through the UI, `refreshDashboardWidgets()` (HTMX) will properly update all 3 widgets (table, stats, balances).

## Files Changed
| File | Bug | Change |
|------|-----|--------|
| `deleteOperations.ts` | #6 | `ConfirmDialog.show()` → `window.showConfirmDialog()` |
| `wsEventHandlers.ts` | #2 | Add `recurring_plan_created` WS event handler |
| `sw_update_modal.html` | #1 | Default text uses `{{ config.VERSION }}` |
| `service-worker-registration.html` | #1 | Improve version fallback logic |
| `modalPlan/index.ts` | #3 | Auto-select single category in transfer form |
| `modalFact/index.ts` | #4 | Add category select change listener for hints |
| `push_permission_banner.html` | #8 | Constrain width, lower z-index |

## Test plan
- [x] `npm run type-check` passes
- [x] `npm run build` passes (all 39 bundles)
- [ ] Manual E2E: verify delete confirmation works on dashboard
- [ ] Manual E2E: verify stats update after recurring plan creation
- [ ] Manual E2E: verify SW version displays correctly
- [ ] Manual E2E: verify transfer plan form submits without validation errors
- [ ] Manual E2E: verify fact dialog hints load on category change
- [ ] Manual E2E: verify notification banner doesn't overlap on mobile

🤖 Generated with [Claude Code](https://claude.com/claude-code)