### PR TITLE
fix(dashboard): correct recurring delete modal ID selector [BUG-10]

### DIFF
--- a/frontend/web/static/js/dashboard/features/editModal/deleteOperations.ts
+++ b/frontend/web/static/js/dashboard/features/editModal/deleteOperations.ts
@@ -21,7 +21,7 @@ let recurringDeleteResolveCallback: ((value: string | null) => void) | null = nu
  */
 export function showRecurringDeleteDialog(): Promise<string | null> {
   return new Promise((resolve) => {
-    const dialog = document.getElementById('recurring-delete-dialog') as HTMLDialogElement | null;
+    const dialog = document.getElementById('recurring-delete-modal') as HTMLDialogElement | null;
     if (!dialog) {
       resolve(null);
       return;
@@ -36,7 +36,7 @@ export function showRecurringDeleteDialog(): Promise<string | null> {
  * Handle recurring delete dialog choice.
  */
 export function handleRecurringDeleteChoice(choice: string | null): void {
-  const dialog = document.getElementById('recurring-delete-dialog') as HTMLDialogElement | null;
+  const dialog = document.getElementById('recurring-delete-modal') as HTMLDialogElement | null;
   dialog?.close();
 
   if (recurringDeleteResolveCallback) {


### PR DESCRIPTION
## Summary
- Fixes BUG-10 (High): recurring record delete modal doesn't open on dashboard
- `showRecurringDeleteDialog()` in `deleteOperations.ts` searched for `'recurring-delete-dialog'` but HTML templates use `id="recurring-delete-modal"`
- Two string replacements (lines 24, 39) — now matches the correct element ID

## Root Cause
`deleteOperations.ts` used the wrong ID `'recurring-delete-dialog'` while:
- `frontend/web/templates/index.html:195` → `id="recurring-delete-modal"`
- `frontend/web/static/js/plan/crud.ts:942` → already used correct ID

## Test plan
- [ ] On dashboard, click 🗑️ on a recurring fact (🔄 icon) → recurring delete dialog should open with "Only this" / "All recurring" options
- [ ] Confirm single deletion works
- [ ] Confirm "all recurring" deletion works

🤖 Generated with [Claude Code](https://claude.com/claude-code)