### PR TITLE
fix(dashboard): add event.stopPropagation() to delete buttons [BUG-8]

### DIFF
--- a/backend/app/api/v1/endpoints/facts.py
+++ b/backend/app/api/v1/endpoints/facts.py
@@ -1050,7 +1050,7 @@ async def get_recent_facts_html(
 
             # Desktop table row with edit and delete buttons (at the end, after ☁️)
             edit_button = f'''<button class="btn btn-xs btn-primary gap-1" onclick="openEditFromDashboard({fact.id})">✏️</button>'''
-            delete_button = f'''<button class="btn btn-xs btn-error gap-1" onclick="deleteFactFromDashboard({fact.id}, {1 if fact.recurring_plan_id else 0})">🗑️</button>'''
+            delete_button = f'''<button class="btn btn-xs btn-error gap-1" onclick="event.stopPropagation(); deleteFactFromDashboard({fact.id}, {1 if fact.recurring_plan_id else 0})">🗑️</button>'''
             table_html += f"""
                     <tr>
                         <td>{record_type_badge_sm}</td>

--- a/frontend/web/static/js/dashboard/recentTransactions.ts
+++ b/frontend/web/static/js/dashboard/recentTransactions.ts
@@ -146,7 +146,7 @@ function buildRecentTransactionsHTML(facts: RecentTransaction[]): string {
 
     // Desktop row
     const editButton = `<button class="btn btn-xs btn-primary gap-1" onclick="openEditFromDashboard(${fact.id})">✏️</button>`;
-    const deleteButton = `<button class="btn btn-xs btn-error btn-square" onclick="deleteFactFromDashboard(${fact.id}, ${fact.recurring_plan_id ? 1 : 0})" title="Удалить">
+    const deleteButton = `<button class="btn btn-xs btn-error btn-square" onclick="event.stopPropagation(); deleteFactFromDashboard(${fact.id}, ${fact.recurring_plan_id ? 1 : 0})" title="Удалить">
       <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
       </svg>


### PR DESCRIPTION
## Summary
- Fixes BUG-8 (High): clicking the 🗑️ delete button opened the edit modal
- Added `event.stopPropagation()` to delete buttons in two locations:
  - `recentTransactions.ts:149` (JS-rendered desktop rows)
  - `facts.py:1053` (server-rendered desktop rows)

## Root Cause
Mobile card rows have `onclick="openEditFromDashboard()"` on the wrapper div. Delete buttons lacked `event.stopPropagation()`, so click events could bubble up to parent handlers on certain device/browser combinations.

## Test plan
- [ ] Desktop: click 🗑️ on a regular fact → confirm dialog appears, edit modal does NOT open
- [ ] Desktop: click 🗑️ on a recurring fact → recurring delete dialog appears
- [ ] Mobile: tap row → edit modal opens normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)