### PR TITLE
fix(dashboard): refresh quick stats on transfer WS events [BUG-5,6,7]

### DIFF
--- a/frontend/web/static/js/budget/incrementalUpdates.js
+++ b/frontend/web/static/js/budget/incrementalUpdates.js
@@ -472,7 +472,8 @@
          * @param {Object} data - Transfer data
          */
         onTransferCreated(data) {
-            // Transfers affect two accounts
+            // Transfers affect two accounts and quick stats totals
+            this.fallbackRefreshDebounced('quick-stats');
             this.fallbackRefreshDebounced('account-balances');
             this.fallbackRefreshDebounced('recent-transactions');
         },
@@ -482,6 +483,7 @@
          * @param {Object} data - Transfer data
          */
         onTransferDeleted(data) {
+            this.fallbackRefreshDebounced('quick-stats');
             this.fallbackRefreshDebounced('account-balances');
             this.fallbackRefreshDebounced('recent-transactions');
         },

--- a/frontend/web/static/js/dashboard/integration/wsEventHandlers.ts
+++ b/frontend/web/static/js/dashboard/integration/wsEventHandlers.ts
@@ -209,6 +209,7 @@ function registerTransferHandlers(hasIncrementalUpdates: boolean): void {
     if (hasIncrementalUpdates && window.IncrementalUpdates) {
       window.IncrementalUpdates.onTransferCreated(data);
     } else {
+      refreshQuickStats();
       refreshRecentTransactions();
       refreshAccountBalances();
     }
@@ -219,6 +220,7 @@ function registerTransferHandlers(hasIncrementalUpdates: boolean): void {
     if (hasIncrementalUpdates && window.IncrementalUpdates) {
       window.IncrementalUpdates.onTransferDeleted(data);
     } else {
+      refreshQuickStats();
       refreshRecentTransactions();
       refreshAccountBalances();
     }


### PR DESCRIPTION
## Summary
- Fixes BUG-5 (Medium), BUG-6 (Low), BUG-7 (High): quick stats (Пополнение/Списание) not updating after transfer operations
- Added `refreshQuickStats()` to transfer WS event handlers in two files
- Also fixed the IncrementalUpdates path which had the same omission

## Changes
- `wsEventHandlers.ts`: `transfer_created` and `transfer_deleted` now call `refreshQuickStats()` alongside `refreshAccountBalances()` and `refreshRecentTransactions()`
- `incrementalUpdates.js`: `onTransferCreated` and `onTransferDeleted` now call `fallbackRefreshDebounced('quick-stats')`

## Root Cause
Plan handlers (plan_created, plan_deleted) already called `refreshQuickStats()`. Transfer handlers were added later but the quick stats refresh was missed in both the fallback and IncrementalUpdates paths.

## Test plan
- [ ] Create a transfer → quick stats (Пополнение/Списание) update immediately
- [ ] Delete a transfer fact → quick stats update immediately (no page reload needed)
- [ ] Account balances also update correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)