### PR TITLE
fix(pwa): clear stale SW update flags after browser cache clear (BUG-1)

### DIFF
--- a/frontend/web/templates/scripts/service-worker-registration.html
+++ b/frontend/web/templates/scripts/service-worker-registration.html
@@ -596,6 +596,10 @@
 
             // Compare versions
             if (newVersion === savedVersion) {
+                // Clean up stale flags from a previous update cycle that may not
+                // have been cleared (e.g. browser cache cleared without localStorage reset)
+                localStorage.removeItem(SW_UPDATE_AVAILABLE_KEY);
+                localStorage.removeItem(SW_NEW_VERSION_KEY);
                 return;
             }
 
@@ -655,6 +659,15 @@
                             const currentVersion = await getSWVersion(navigator.serviceWorker.controller);
                             if (currentVersion) {
                                 localStorage.setItem(SW_VERSION_KEY, currentVersion);
+                                // Clean up stale update flags if the "new" version equals current
+                                // (happens when browser cache is cleared but localStorage is not)
+                                const storedNewVersion = localStorage.getItem(SW_NEW_VERSION_KEY);
+                                if (storedNewVersion && storedNewVersion === currentVersion) {
+                                    localStorage.removeItem(SW_UPDATE_AVAILABLE_KEY);
+                                    localStorage.removeItem(SW_NEW_VERSION_KEY);
+                                    const icon = document.getElementById('sw-update-icon');
+                                    if (icon) icon.classList.add('hidden');
+                                }
                             } else {
                                 console.warn('[PWA] ⚠️ Failed to get current CACHE_VERSION');
                             }


### PR DESCRIPTION
## Summary
- **BUG-1 (Medium)**: Phantom update banner disappears after clearing browser cache

## Root Cause
After clearing browser cache (without clearing localStorage), `pwa_update_available='true'` and `pwa_new_version` flags remain from a previous update cycle. On next page load `checkForPendingUpdate()` finds them and shows the update banner, even though there's no actual update.

## Fix (two locations)
1. **`controllerchange` handler**: when `newVersion === savedVersion` (SW re-activated but no version change), clear stale flags before the early return
2. **`load` handler**: after saving current version, if `SW_NEW_VERSION_KEY` equals current version, remove both stale flags and hide the update icon

## Test plan
- [ ] Trigger SW update, accept it — update banner appears correctly
- [ ] After update completes, clear browser cache (keep localStorage) — on reload, no banner
- [ ] Normal page load with no update pending — no banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)