### PR TITLE
fix(tabs): prevent tab desync with click-based radio update (BUG-11)

### DIFF
--- a/frontend/web/static/js/dashboard/shared/tabManagerFactory.ts
+++ b/frontend/web/static/js/dashboard/shared/tabManagerFactory.ts
@@ -36,12 +36,15 @@ export function createTabManager(config: TabManagerConfig): TabManager {
   };
 
   let currentTab: 'transaction' | 'transfer' = 'transaction';
+  let switching = false; // Guard to prevent recursive calls when using input.click()
 
   /**
    * Switch active tab
    * Saves current tab data to cache before switching
    */
   function switchTab(newTab: 'transaction' | 'transfer'): void {
+    if (switching) return;
+    switching = true;
     const transactionTab = document.getElementById(`${modalId}-tab-transaction`);
     const transferTab = document.getElementById(`${modalId}-tab-transfer`);
 
@@ -71,10 +74,12 @@ export function createTabManager(config: TabManagerConfig): TabManager {
       el.removeAttribute('data-was-required');
     });
 
-    // Update radio buttons
+    // Update radio buttons — use input.click() so DaisyUI :checked CSS and change listeners fire
     const tabInputs = document.querySelectorAll<HTMLInputElement>(`[name="${modalId}_tabs"]`);
     tabInputs.forEach(input => {
-      input.checked = input.dataset.tab === newTab;
+      if (input.dataset.tab === newTab && !input.checked) {
+        input.click(); // Triggers :checked CSS update + change event (guard prevents recursion)
+      }
     });
 
     // Update hidden field
@@ -85,6 +90,7 @@ export function createTabManager(config: TabManagerConfig): TabManager {
     restoreTabData(newTab);
 
     currentTab = newTab;
+    switching = false;
   }
 
   /**


### PR DESCRIPTION
## Summary
- **BUG-11 (Low)**: Programmatic tab switching now correctly updates DaisyUI CSS and fires change listeners

## Root Cause
DaisyUI tabs-boxed uses CSS `:checked` selector for visual state and `change` event listeners to call `switchTab()`. Setting `input.checked = true` programmatically updates DOM state but does **not** fire the `change` event, so `setupTabListeners()` never gets notified and the tab content does not sync with the radio button state.

## Fix
- Replace `input.checked = value` with `input.click()` on the target input (unchecked → clicked)
- `input.click()` fires the `change` event → `switchTab()` is called again with the correct tab
- Added `let switching = false` guard to prevent infinite recursion: `click()` → `change` → `switchTab()` → guard → return

## Test plan
- [ ] Open edit modal, switch between Transaction and Transfer tabs manually — both tabs render correctly
- [ ] Open edit modal on an existing transfer record — Transfer tab is pre-selected and shows correct data
- [ ] Tab switch saves form data to cache and restores it when switching back

🤖 Generated with [Claude Code](https://claude.com/claude-code)