### PR TITLE
fix(articles): prevent duplicate categories with unique index (BUG-3)

### DIFF
--- a/backend/app/api/v1/endpoints/articles.py
+++ b/backend/app/api/v1/endpoints/articles.py
@@ -99,6 +99,24 @@ async def create_article(
                 detail=f"Parent article with id={article_data.parent_id} not found"
             )
 
+    # Validate: No duplicate active article with same (parent_id, name, type)
+    from sqlalchemy import func as sa_func
+    dup_stmt = select(Article).where(
+        sa_func.lower(Article.name) == sa_func.lower(article_data.name),
+        Article.type == article_data.type,
+        Article.is_current == True,  # noqa: E712
+        Article.parent_id == article_data.parent_id,
+    )
+    dup_result = await session.execute(dup_stmt)
+    if dup_result.scalar_one_or_none() is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                f"Article with name='{article_data.name}' and type='{article_data.type}' "
+                "already exists under the same parent"
+            )
+        )
+
     # Generate code for article (natural key, auto-generated, immutable after creation)
     generated_code = await generate_code(session, Article)
 
@@ -259,6 +277,29 @@ async def update_article(
     old_article, update_data, financial_center_ids = await prepare_article_update(
         session, article_id, article_data, current_user
     )
+
+    # Validate: No duplicate active article with same (parent_id, name, type) on rename
+    new_name = update_data.get("name")
+    new_type = update_data.get("type", old_article.type)
+    new_parent_id = update_data.get("parent_id", old_article.parent_id)
+    if new_name and (new_name != old_article.name or new_type != old_article.type or new_parent_id != old_article.parent_id):
+        from sqlalchemy import func as sa_func
+        dup_stmt = select(Article).where(
+            sa_func.lower(Article.name) == sa_func.lower(new_name),
+            Article.type == new_type,
+            Article.is_current == True,  # noqa: E712
+            Article.parent_id == new_parent_id,
+            Article.id != article_id,
+        )
+        dup_result = await session.execute(dup_stmt)
+        if dup_result.scalar_one_or_none() is not None:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=(
+                    f"Article with name='{new_name}' and type='{new_type}' "
+                    "already exists under the same parent"
+                )
+            )
 
     changed, changed_fields = has_changes(old_article, update_data)
     logger.info("[ARTICLE UPDATE] article_id=%s, changed=%s, changed_fields=%s", article_id, changed, changed_fields)

--- a/backend/db/migrations/versions/20260408_c4e9f1a2b3d0_add_unique_constraint_article_parent_name_type.py
+++ b/backend/db/migrations/versions/20260408_c4e9f1a2b3d0_add_unique_constraint_article_parent_name_type.py
@@ -1,0 +1,40 @@
+"""add_unique_constraint_article_parent_name_type
+
+Revision ID: c4e9f1a2b3d0
+Revises: b3d9f5e7c2a1
+Create Date: 2026-04-08 12:00:00.000000
+
+Adds a partial unique index on t_d_article to prevent duplicate active
+categories with the same (parent_id, name, type) combination.
+
+Using a partial index (WHERE is_current = TRUE) so that deleted/historical
+records (is_current = FALSE) are excluded from the uniqueness check and
+historical categories with the same name can coexist.
+
+LOWER(name) ensures case-insensitive uniqueness (e.g. "Food" and "food"
+are treated as duplicates).
+
+COALESCE(parent_id, -1) treats NULL parent_id as a sentinel value so
+PostgreSQL partial index can enforce uniqueness on NULL columns.
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = 'c4e9f1a2b3d0'
+down_revision = 'b3d9f5e7c2a1'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_article_parent_name_type_current
+        ON t_d_article (COALESCE(parent_id, -1), LOWER(name), type)
+        WHERE is_current = TRUE
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS idx_article_parent_name_type_current")


### PR DESCRIPTION
## Summary
- **BUG-3 (Low)**: Prevents duplicate active budget categories with same name/type/parent

## Root Cause
The `t_d_article` model/table had no unique constraint on `(parent_id, name, type)`, allowing users to create categories with identical names under the same parent.

## Fix

### 1. Database Migration
```sql
CREATE UNIQUE INDEX idx_article_parent_name_type_current
ON t_d_article (COALESCE(parent_id, -1), LOWER(name), type)
WHERE is_current = TRUE
```
- Partial index: deleted/historical records (`is_current=FALSE`) are excluded
- `LOWER(name)`: case-insensitive ("Food" and "food" are duplicates)
- `COALESCE(parent_id, -1)`: handles NULL equality in unique indexes

### 2. API Validation
- `create_article`: checks for duplicate before INSERT, returns HTTP 409 with descriptive message
- `update_article`: checks for duplicate on rename/retype, returns HTTP 409

## Test plan
- [ ] Create category "Food" under parent → succeeds
- [ ] Create category "food" (same parent, same type) → HTTP 409
- [ ] Create category "Food" under a different parent → succeeds
- [ ] Rename existing category to collide with another → HTTP 409
- [ ] Alembic migration runs cleanly on test DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)