### PR TITLE
fix(facts): update total counter and pagination on incremental row add

### DIFF
--- a/frontend/web/static/js/facts/operations/factsController.ts
+++ b/frontend/web/static/js/facts/operations/factsController.ts
@@ -180,7 +180,16 @@ export async function fetchAndInjectRow(factId: number, operation: 'create' | 'u
                 mobileList.insertBefore(parsed.mobileCard, mobileList.firstChild);
             }
             // Return true only if we actually injected into a container
-            return !!(tbody || mobileList);
+            const injected = !!(tbody || mobileList);
+            if (injected) {
+                const newTotal = getTotalFacts() + 1;
+                setTotalFacts(newTotal);
+                const rowCount = tbody ? tbody.querySelectorAll('tr').length : 0;
+                const pageStart = 1; // canInjectRow() guarantees page 0
+                const pageEnd = Math.min(rowCount, newTotal);
+                updateStats(newTotal, pageStart, pageEnd);
+            }
+            return injected;
         }
 
         if (operation === 'update') {


### PR DESCRIPTION
## Summary
- Fixes 'Total facts' counter (#stat-total) not updating when a new fact is added via incremental HTMX injection
- Also updates pagination info (e.g. '1-28 из 28' → '1-29 из 29')
- `fetchAndInjectRow()` now calls `updateStats()` after successful DOM injection, mirroring the existing pattern in `removeRowFromTable()` for deletions

## Root Cause
`createFact()` skips `loadFacts()` (which would update stats) when `injected === true`. The `fetchAndInjectRow()` function was adding the DOM row but not updating the stat counters.

## Test
1. Go to /facts, note current 'Total facts' count
2. Add a new fact
3. Counter immediately increments without page reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)