### PR TITLE
fix(pwa): prevent false update notification on first SW install

### DIFF
--- a/frontend/web/templates/scripts/service-worker-registration.html
+++ b/frontend/web/templates/scripts/service-worker-registration.html
@@ -572,12 +572,14 @@
 
             const savedVersion = localStorage.getItem(SW_VERSION_KEY);
 
-            // First install detection: If no saved version, this is first time
-            if (!savedVersion) {
+            // First install detection: If no saved version (or stale "null" from failed getSWVersion), this is first time
+            if (!savedVersion || savedVersion === 'null') {
 
                 try {
                     const newVersion = await getSWVersion(controller);
-                    localStorage.setItem(SW_VERSION_KEY, newVersion);
+                    if (newVersion && newVersion !== 'null') {
+                        localStorage.setItem(SW_VERSION_KEY, newVersion);
+                    }
                 } catch (error) {
                     console.error('[SW_UPDATE] ERROR getting initial version:', error);
                 }
@@ -591,6 +593,11 @@
                 newVersion = await getSWVersion(controller);
             } catch (error) {
                 console.error('[SW_UPDATE] ERROR getting new version:', error);
+                return;
+            }
+
+            // Guard: if getSWVersion returned null (timing issue), skip to avoid false update notification
+            if (!newVersion || newVersion === 'null') {
                 return;
             }
 


### PR DESCRIPTION
## Summary
- Fixes false 'Update available' notification showing on first-time install after cache clear
- Adds guards for `null` string stored in localStorage when `getSWVersion()` fails due to timing issues

## Root Cause
After cache clear, `getSWVersion()` could return `null` (timing — SW just activated). The `null` was stored as string `"null"`. On next SW cycle, `"0.6.115" !== "null"` triggered the update notification.

**Changes:**
- `!savedVersion || savedVersion === 'null'` for first-install detection
- Only save version when `newVersion` is non-null and not the string `'null'`
- Guard before comparison: skip if `newVersion` is null/falsy

## Test
1. Clear all browser cache + localStorage
2. Load app for the first time
3. No 'Update available' notification should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)