### PR TITLE
fix(sw): bypass cache on version mismatch to prevent stale JS bundles

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -458,6 +458,23 @@ self.addEventListener('fetch', (event) => {
       caches.match(request, { ignoreSearch: true })
         .then((cachedResponse) => {
           if (cachedResponse) {
+            // Version mismatch check: if ?v= param differs between cached and requested URL,
+            // bypass cache to prevent serving stale bundles during SW transition period.
+            // Files without ?v= (e.g. icons, fonts) are served from cache as usual.
+            const cachedVersion = new URL(cachedResponse.url).searchParams.get('v');
+            const requestVersion = url.searchParams.get('v');
+            if (cachedVersion && requestVersion && cachedVersion !== requestVersion) {
+              if (DEBUG) console.log('[SW] Version mismatch, fetching fresh:', url.pathname, cachedVersion, '->', requestVersion);
+              return fetch(request).then((response) => {
+                if (response.ok) {
+                  const clonedResponse = response.clone();
+                  caches.open(CACHE_NAME).then((cache) => {
+                    cache.put(request, clonedResponse);
+                  });
+                }
+                return response;
+              });
+            }
             if (DEBUG) console.log('[SW] Serving from cache:', url.pathname);
             return cachedResponse;
           }


### PR DESCRIPTION
## Summary
- BUG-5: `ignoreSearch: true` в SW Стратегии 3 возвращал закэшированную `bundle.min.js?v=0.6.115` при запросе `?v=0.6.116` — смешение версий на одной странице
- Добавлена проверка `?v=` параметра: если версии различаются — bypass cache, fetch из сети и обновление кэша
- Файлы без `?v=` (иконки, шрифты) не затронуты

## Test plan
- [ ] После обновления SW новые JS бандлы загружаются из сети, а не из кэша
- [ ] Файлы без `?v=` (icon-192.png, fonts) продолжают обслуживаться из кэша
- [ ] В режиме DEBUG видно сообщение "Version mismatch, fetching fresh" при переходе версий

🤖 Generated with [Claude Code](https://claude.com/claude-code)