### PR TITLE
fix(pwa): prevent false SW update notification when version already installed

### DIFF
--- a/frontend/web/templates/scripts/service-worker-registration.html
+++ b/frontend/web/templates/scripts/service-worker-registration.html
@@ -684,22 +684,21 @@
                     // Save current SW version on load; skip if update pending (avoids X → X display)
                     if (navigator.serviceWorker.controller) {
                         const updatePending = localStorage.getItem(SW_UPDATE_AVAILABLE_KEY) === 'true';
-                        if (!updatePending) {
-                            const currentVersion = await getSWVersion(navigator.serviceWorker.controller);
-                            if (currentVersion) {
+                        const currentVersion = await getSWVersion(navigator.serviceWorker.controller);
+                        if (currentVersion) {
+                            if (!updatePending) {
                                 localStorage.setItem(SW_VERSION_KEY, currentVersion);
-                                // Clean up stale update flags if the "new" version equals current
-                                // (happens when browser cache is cleared but localStorage is not)
-                                const storedNewVersion = localStorage.getItem(SW_NEW_VERSION_KEY);
-                                if (storedNewVersion && storedNewVersion === currentVersion) {
-                                    localStorage.removeItem(SW_UPDATE_AVAILABLE_KEY);
-                                    localStorage.removeItem(SW_NEW_VERSION_KEY);
-                                    const icon = document.getElementById('sw-update-icon');
-                                    if (icon) icon.classList.add('hidden');
-                                }
-                            } else {
-                                console.warn('[PWA] ⚠️ Failed to get current CACHE_VERSION');
                             }
+                            // Always clean stale flags if the "new" version is already installed
+                            const storedNewVersion = localStorage.getItem(SW_NEW_VERSION_KEY);
+                            if (storedNewVersion && storedNewVersion === currentVersion) {
+                                localStorage.removeItem(SW_UPDATE_AVAILABLE_KEY);
+                                localStorage.removeItem(SW_NEW_VERSION_KEY);
+                                const icon = document.getElementById('sw-update-icon');
+                                if (icon) icon.classList.add('hidden');
+                            }
+                        } else {
+                            console.warn('[PWA] ⚠️ Failed to get current CACHE_VERSION');
                         }
                     }
 


### PR DESCRIPTION
## Summary
- Moves stale-flag cleanup (`storedNewVersion === currentVersion`) outside the `!updatePending` guard
- Previously, if `updatePending` was `true`, the cleanup block was skipped entirely — causing the update icon to persist even after the new SW version had already been fully installed
- Now `getSWVersion()` is called unconditionally and the stale-flag check always runs; only `localStorage.setItem(SW_VERSION_KEY)` remains gated behind `!updatePending`

## Test plan
- [ ] Simulate update: set `pwa_update_available=true` and `pwa_new_version=X` in localStorage, then reload when SW version X is already active → update icon should disappear immediately
- [ ] Normal load (no update pending): version saved to `pwa_sw_version` as before
- [ ] `npm run type-check` passes (no TypeScript files changed, HTML-only fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)