### PR TITLE
fix(lists): URL history, stale counter on back navigation, search reset on view switch

### DIFF
--- a/frontend/web/static/js/lists-bundle.ts
+++ b/frontend/web/static/js/lists-bundle.ts
@@ -243,6 +243,15 @@ const windowExports = {
   openDexieDiagnostic
 };
 
+// Handle browser back/forward navigation
+window.addEventListener('popstate', (event: PopStateEvent) => {
+  if (event.state?.view === 'detail' && event.state?.listId) {
+    (window as any).showDetailView(event.state.listId);
+  } else {
+    (window as any).showLandingView();
+  }
+});
+
 // Экспорт в window (Object.assign - надёжнее работает после минификации)
 try {
   if (typeof window !== 'undefined') {

--- a/frontend/web/static/js/lists/listsManager/rendering/listRenderer.ts
+++ b/frontend/web/static/js/lists/listsManager/rendering/listRenderer.ts
@@ -11,7 +11,7 @@
 import { getState, updateState } from '../core/ListsState';
 import { loadShoppingLists, loadShoppingListItems } from '../core/stateManager';
 import { renderCurrentView } from './tableBuilder';
-import { updateHideCompletedButton, updateFABButtons } from '../features/searchFilter';
+import { updateHideCompletedButton, updateFABButtons, clearSearch } from '../features/searchFilter';
 
 // ============================================================================
 // Type Definitions
@@ -205,6 +205,9 @@ export function switchView(viewName: 'table' | 'hierarchy', savePreference: bool
     if (hierarchyControls) hierarchyControls.classList.add('hidden');
   }
 
+  // Clear search when switching views for UX consistency
+  clearSearch();
+
   // Render current view content
   renderCurrentView();
 
@@ -395,6 +398,11 @@ export function renderShoppingListCards(): void {
 export async function renderLandingView(): Promise<void> {
   debugLog('[ListsManager] Showing landing view');
 
+  // Restore URL when returning to landing view
+  if (window.location.pathname !== '/lists') {
+    history.pushState({ view: 'landing' }, '', '/lists');
+  }
+
   // Reset state
   updateState({
     currentListId: null,
@@ -415,7 +423,10 @@ export async function renderLandingView(): Promise<void> {
   document.getElementById('landing-view')?.classList.remove('hidden');
   document.getElementById('detail-view')?.classList.add('hidden');
 
-  // Load shopping lists
+  // Immediate render from current state (shows WS-updated data before API completes)
+  renderShoppingListCards();
+
+  // Load fresh data from server
   await loadShoppingLists();
   renderShoppingListCards();
 
@@ -432,6 +443,9 @@ export async function renderLandingView(): Promise<void> {
  */
 export async function renderDetailView(listId: number): Promise<void> {
   debugLog('[ListsManager] Showing detail view for list:', listId);
+
+  // Update URL for deep linking and browser back button
+  history.pushState({ view: 'detail', listId }, '', `/lists/${listId}`);
 
   const state = getState();
 


### PR DESCRIPTION
## Summary
- Fix #2: URL updates when opening a list (`history.pushState` in `renderDetailView`/`renderLandingView`)
- Fix #3: Stale item counter on back navigation (immediate render from WS-updated state before API call)
- Fix #5: Search query not reset on view mode switch (`clearSearch()` in `switchView()`)
- Added `popstate` listener for browser back/forward navigation

## Test plan
- [ ] Click list card → URL changes to `/lists/{id}`
- [ ] Press browser Back → URL returns to `/lists`, cards visible
- [ ] Delete item → go back → counter shows correct "0/0"
- [ ] Enter search → switch Table/Hierarchy → search field clears

🤖 Generated with [Claude Code](https://claude.com/claude-code)