### PR TITLE
fix(lists): fix stale list ID, modal form reset, hidden select validation

### DIFF
--- a/frontend/web/static/js/lists/listsManager/rendering/listRenderer.ts
+++ b/frontend/web/static/js/lists/listsManager/rendering/listRenderer.ts
@@ -444,10 +444,17 @@ export async function renderLandingView(): Promise<void> {
 export async function renderDetailView(listId: number): Promise<void> {
   debugLog('[ListsManager] Showing detail view for list:', listId);
 
+  // Validate list exists BEFORE setting state (prevents stale currentListId on 404)
+  const state = getState();
+  const list = state.shoppingLists.find(l => l.id === listId);
+  if (!list) {
+    showToast('Список не найден', 'error');
+    await renderLandingView();
+    return;
+  }
+
   // Update URL for deep linking and browser back button
   history.pushState({ view: 'detail', listId }, '', `/lists/${listId}`);
-
-  const state = getState();
 
   // IMPORTANT: Full state reset BEFORE loading new list
   // This prevents showing old list data while new list loads
@@ -503,13 +510,6 @@ export async function renderDetailView(listId: number): Promise<void> {
   // Each list should start with fresh tree state
   if (state.hierarchyView) {
     state.hierarchyView.expandedNodes.clear();
-  }
-
-  // Find the list
-  const list = state.shoppingLists.find(l => l.id === listId);
-  if (!list) {
-    showToast('Список не найден', 'error');
-    return;
   }
 
   // Update breadcrumb

--- a/frontend/web/static/js/lists/listsManager/ui/modalManager.ts
+++ b/frontend/web/static/js/lists/listsManager/ui/modalManager.ts
@@ -218,6 +218,13 @@ export function openAddItemModal(): void {
   const modalTitle = document.getElementById('item-modal-title');
   if (modalTitle) modalTitle.textContent = '📝 Добавить товар';
 
+  // Explicitly reset hidden selects before Choices.js reinit
+  // form.reset() doesn't clear Choices.js internal state
+  const storeSelect = document.getElementById('item-store') as HTMLSelectElement | null;
+  if (storeSelect) storeSelect.value = '';
+  const groupSelect = document.getElementById('item-product-group') as HTMLSelectElement | null;
+  if (groupSelect) groupSelect.value = '';
+
   // Reinitialize Choices.js with latest data (fixes issue after CSV import)
   // This ensures newly created stores/groups are visible
   initStoreChoices();
@@ -577,6 +584,9 @@ export async function confirmDeleteList(): Promise<void> {
 
     debugLog('[DeleteList] List deleted successfully:', listId);
 
+    // Clear currentListId immediately to prevent race with WS events
+    updateState({ currentListId: null });
+
     // Force Dexie cache invalidation + fresh API load
     if (deletedListTempId) {
       // DEBUG: Skip Dexie operations if disabled for testing
@@ -714,6 +724,7 @@ export function initStoreChoices(): void {
   const stores = state.stores || [];
   selectElement.innerHTML = '<option value="">Выберите магазин</option>' +
     stores.map(store => `<option value="${store.id}">${store.name}</option>`).join('');
+  selectElement.value = '';
 
   // Initialize Choices.js
   try {
@@ -763,6 +774,7 @@ export function initProductGroupChoices(): void {
   const groups = state.productGroups || [];
   selectElement.innerHTML = '<option value="">Выберите группу</option>' +
     buildProductGroupOptions(groups);
+  selectElement.value = '';
 
   // Initialize Choices.js
   try {

--- a/frontend/web/templates/components/lists/modal_item.html
+++ b/frontend/web/templates/components/lists/modal_item.html
@@ -34,7 +34,7 @@
                 <label class="label py-1">
                     <span class="label-text font-medium text-xs sm:text-sm">🏪 Магазин <span class="text-error">*</span></span>
                 </label>
-                <select name="store_id" id="item-store" class="select select-bordered select-sm sm:select-md" required>
+                <select name="store_id" id="item-store" class="select select-bordered select-sm sm:select-md">
                     <option value="">Магазин</option>
                     <!-- Options populated dynamically via Choices.js -->
                 </select>
@@ -45,7 +45,7 @@
                 <label class="label py-1">
                     <span class="label-text font-medium text-xs sm:text-sm">📦 Группа <span class="text-error">*</span></span>
                 </label>
-                <select name="product_group_id" id="item-product-group" class="select select-bordered select-sm sm:select-md" required>
+                <select name="product_group_id" id="item-product-group" class="select select-bordered select-sm sm:select-md">
                     <option value="">Группа</option>
                     <!-- Options populated dynamically with hierarchy -->
                 </select>


### PR DESCRIPTION
## Summary
- **BUG-2**: Validate list existence before setting `currentListId` in `renderDetailView` — prevents 404 requests to deleted list endpoints. Also clear `currentListId` immediately after successful deletion to prevent race with WS events.
- **BUG-3**: Explicitly reset Choices.js select values (`store_id`, `product_group_id`) when opening add-item modal — form fields no longer retain previous values after save.
- **BUG-5**: Remove `required` attribute from `<select>` elements hidden behind Choices.js wrappers — eliminates "not focusable" console error. JS validation in `handleSaveItem()` already covers these fields.

## Test plan
- [ ] Delete a shopping list → verify no 404 errors in browser console
- [ ] Add item → save → reopen modal → verify all fields are empty (especially store and group dropdowns)
- [ ] Open item modal → clear all fields → click "Сохранить" → verify no "not focusable" console error
- [ ] Verify existing item edit flow still works correctly
- [ ] Test on mobile (375px), tablet (768px), desktop (1280px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)