### PR TITLE
fix(sw): suppress false update modal when pending version matches current

### DIFF
--- a/frontend/web/templates/scripts/service-worker-registration.html
+++ b/frontend/web/templates/scripts/service-worker-registration.html
@@ -499,6 +499,19 @@
                     // User already dismissed this version — don't show again
                     return;
                 }
+
+                // Stale-flag guard: if pending version equals the version currently
+                // shipped by the server (meta tag injected from VERSION file), the
+                // update has already been installed — clear the flags and bail.
+                const currentMetaVersion = document.querySelector('meta[name="app-version"]')?.content;
+                if (pendingVersion && currentMetaVersion && pendingVersion === currentMetaVersion) {
+                    localStorage.removeItem(SW_UPDATE_AVAILABLE_KEY);
+                    localStorage.removeItem(SW_NEW_VERSION_KEY);
+                    // Sync the running-version key so subsequent loads start clean
+                    localStorage.setItem(SW_VERSION_KEY, currentMetaVersion);
+                    return;
+                }
+
                 showUpdateIcon();
             }
         }


### PR DESCRIPTION
## Summary
- Fixes BUG-1 (Playwright /lists test report).
- After a partial cache clear or stale snooze, `checkForPendingUpdate()` could read `SW_UPDATE_AVAILABLE_KEY=true` with `SW_NEW_VERSION_KEY` pointing at the already-installed version and pop the update modal on every page load.
- Now compare the pending version against `meta[name="app-version"]` (rendered from `VERSION`); when they match, clear the stale flags, sync `SW_VERSION_KEY`, and return without showing the icon.

## Test plan
- [ ] Coordinator: clear cookies/storage + reload `/lists` → `sw-update-modal` should NOT be open.
- [ ] Verify the controllerchange flow (real new SW activation) still surfaces the update icon as before.

See `.claude/plans/zazzy-coalescing-flute.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)