### PR TITLE
fix(lists): re-render after toggle so hide-completed actually hides the row

### DIFF
--- a/frontend/web/static/js/lists/listsManager/core/listOperations.ts
+++ b/frontend/web/static/js/lists/listsManager/core/listOperations.ts
@@ -333,6 +333,18 @@ export async function toggleItemCompleted(itemId: number, isCompleted: boolean):
   // Optimistic DOM update (instant visual feedback)
   updateItemCompletedDom(itemId, isCompleted);
 
+  // Optimistically reflect state in the in-memory items list so an immediate
+  // re-render with hideCompleted on actually drops the row (otherwise the
+  // optimistic class toggle leaves the row visible with opacity-60 until the
+  // network round-trip finishes — see BUG-3).
+  const optimisticItem = state.currentItems.find(i => i.id === itemId);
+  if (optimisticItem) {
+    optimisticItem.is_completed = isCompleted;
+  }
+  if (getState().hideCompleted) {
+    renderCurrentView();
+  }
+
   try {
     // Dexie-first strategy
     if (isDexieActive() && dexie.isReady() && item.temp_id) {
@@ -373,6 +385,15 @@ export async function toggleItemCompleted(itemId: number, isCompleted: boolean):
 
     // Revert DOM update on error
     updateItemCompletedDom(itemId, !isCompleted);
+    // Also revert optimistic in-memory state and re-render so a hidden row
+    // re-appears if the toggle ultimately failed (BUG-3 revert path).
+    const revertItem = getState().currentItems.find(i => i.id === itemId);
+    if (revertItem) {
+      revertItem.is_completed = !isCompleted;
+    }
+    if (getState().hideCompleted) {
+      renderCurrentView();
+    }
     showToast('Ошибка обновления статуса', 'error');
   }
 }


### PR DESCRIPTION
## Summary
- Fixes BUG-3. With \"Скрыть выполненные\" enabled, marking an item complete left the row visible (just opacity-60) until the network round-trip finished.
- Root cause: \`toggleItemCompleted\` only did an optimistic *class* toggle. \`is_completed\` in \`currentItems\` was never updated, so an immediate \`renderCurrentView()\` would have re-rendered the same row anyway.
- Fix: also flip \`is_completed\` in the in-memory item, then call \`renderCurrentView()\` when \`hideCompleted\` is on. Same revert path runs on error.

## Test plan
- [ ] Coordinator: with \"Скрыть выполненные\" on, mark an item complete → row disappears from DOM (not just opacity).
- [ ] Toggle back via uncheck (item still in store) — list refreshes correctly when filter is off.
- [ ] Force a network failure → row reappears after error toast.

See \`.claude/plans/zazzy-coalescing-flute.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)