### PR TITLE
fix(lists): expand-all hierarchy now counts and updates every nested node

### DIFF
--- a/frontend/web/static/js/lists-bundle.ts
+++ b/frontend/web/static/js/lists-bundle.ts
@@ -157,22 +157,16 @@ const windowExports = {
       const btn = document.getElementById('hierarchy-toggle-btn');
       if (!btn) return;
 
+      // expandAll()/collapseAll() each call render() → updateHierarchyToggleButton(),
+      // which is the single source of truth for btn.dataset.action and the icon/text.
+      // Don't write to those here — the previous implementation raced with the
+      // counter and the manual writes left the button in a stale state on the
+      // very next click (BUG-4).
       const action = btn.dataset.action || 'expand';
-
       if (action === 'expand') {
         window.hierarchyView.expandAll();
-        btn.dataset.action = 'collapse';
-        const icon = document.getElementById('hierarchy-toggle-icon');
-        const text = document.getElementById('hierarchy-toggle-text');
-        if (icon) icon.textContent = '⬆️';
-        if (text) text.textContent = 'Свернуть';
       } else {
         window.hierarchyView.collapseAll();
-        btn.dataset.action = 'expand';
-        const icon = document.getElementById('hierarchy-toggle-icon');
-        const text = document.getElementById('hierarchy-toggle-text');
-        if (icon) icon.textContent = '⬇️';
-        if (text) text.textContent = 'Развернуть';
       }
     }
   },

--- a/frontend/web/static/js/lists/listsManager/rendering/hierarchyIntegration.ts
+++ b/frontend/web/static/js/lists/listsManager/rendering/hierarchyIntegration.ts
@@ -18,8 +18,25 @@ import { HierarchyView } from './HierarchyView';
 declare const debugLog: (...args: any[]) => void;
 
 /**
- * Count total nodes in hierarchy (stores + product groups)
- * Used by updateHierarchyToggleButton to determine toggle state
+ * Count nested product group nodes recursively.
+ * Mirrors the structure used by HierarchyView.expandProductGroupTree so the
+ * total matches what expandAll() actually adds to expandedNodes.
+ */
+function countProductGroupNodes(
+  pgTree: Record<number, any> | undefined | null
+): number {
+  if (!pgTree) return 0;
+  let count = 0;
+  Object.values(pgTree).forEach((pg: any) => {
+    count++;
+    count += countProductGroupNodes(pg?.children);
+  });
+  return count;
+}
+
+/**
+ * Count total nodes in hierarchy (stores + every nested product group).
+ * Used by updateHierarchyToggleButton to determine toggle state.
  */
 function getTotalNodeCount(): number {
   const state = getState();
@@ -35,9 +52,11 @@ function getTotalNodeCount(): number {
   let total = 0;
   Object.values(hierarchy).forEach((store: any) => {
     total++; // Store node
-    if (store.groups) {
-      total += Object.keys(store.groups).length; // Product group nodes
-    }
+    // HierarchyView.buildHierarchy stores nested groups under productGroupTree
+    // (the previous implementation read store.groups, which never existed —
+    // expandAll() registered far more nodes than this counter knew about and
+    // updateHierarchyToggleButton() never landed in the "all expanded" branch).
+    total += countProductGroupNodes(store.productGroupTree);
   });
 
   return total;


### PR DESCRIPTION
## Summary
- Fixes BUG-4. \"Развернуть\" appeared to only expand the first level and the button label stayed stale.
- Two combined causes:
  1. \`getTotalNodeCount()\` read \`store.groups\` (never exists — \`HierarchyView.buildHierarchy\` produces \`productGroupTree\`). Counter returned ~stores.length, so \`updateHierarchyToggleButton()\` never reached the \"all expanded\" branch.
  2. \`toggleAllNodes\` in \`lists-bundle.ts\` raced with \`updateHierarchyToggleButton()\` by manually writing \`dataset.action\` / icon / text after \`expandAll()\` returned.
- Recurse \`productGroupTree\` to count nested groups, and let \`updateHierarchyToggleButton()\` own button state end-to-end.

## Test plan
- [ ] Coordinator: click \"Развернуть\" → all stores + all nested PGs expanded on first click; click again → all collapse; cycle works repeatedly.

See \`.claude/plans/zazzy-coalescing-flute.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)