### PR TITLE
fix(lists): drop stale current list id on offline reconnect

### DIFF
--- a/frontend/web/static/js/lists/listsManager/core/stateManager.ts
+++ b/frontend/web/static/js/lists/listsManager/core/stateManager.ts
@@ -200,8 +200,26 @@ export async function initializeListsManager(): Promise<void> {
         debugLog('[ListsManager] Network restored, refreshing data...');
         await loadShoppingLists();
         const currentState = getState();
-        if (currentState.currentListId) {
-          await loadShoppingListItems(currentState.currentListId);
+        const currentListId = currentState.currentListId;
+        if (currentListId) {
+          // BUG-7: if the currently-open list was deleted while we were
+          // offline, currentListId still points at it on reconnect, and we
+          // would fire a 404 against /api/v1/shopping-lists/<id>. Verify
+          // the list still exists in the freshly-loaded set; if not, drop
+          // the stale id and bounce back to the landing view.
+          const stillExists = currentState.shoppingLists.some(
+            (list) => list.id === currentListId
+          );
+          if (!stillExists) {
+            debugLog('[ListsManager] Current list no longer exists, returning to landing', {
+              currentListId,
+            });
+            updateState({ currentListId: null, currentItems: [] });
+            const { renderLandingView } = await import('../rendering/listRenderer');
+            renderLandingView();
+            return;
+          }
+          await loadShoppingListItems(currentListId);
         }
       }
     });


### PR DESCRIPTION
## Summary
- Fixes BUG-7. After reconnecting, \`offline-status-change\` called \`loadShoppingListItems(currentListId)\` without verifying the list still existed, producing a 404 in the console and a broken detail view if the list was deleted while offline.
- After \`loadShoppingLists()\` resolves, check that \`currentListId\` is still present in the freshly-loaded set. If not, clear state and \`renderLandingView()\`.
- Dynamic import for \`renderLandingView\` to avoid the existing \`listRenderer\` ↔ \`stateManager\` cycle.

## Test plan
- [ ] Coordinator: open a list, go offline, delete that list from another device, reconnect → no \`GET /api/v1/shopping-lists/<deleted>\` request, page returns to landing view.

See \`.claude/plans/zazzy-coalescing-flute.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)