### PR TITLE
fix(offline): auto-sync pending ops on network reconnect

### DIFF
--- a/frontend/web/static/js/dashboard/adapters/windowExports.ts
+++ b/frontend/web/static/js/dashboard/adapters/windowExports.ts
@@ -205,6 +205,25 @@ function setupPendingRecordsListeners(): void {
   window.addEventListener('online', () => loadPendingRecordsImpl());
   window.addEventListener('offline', () => loadPendingRecordsImpl());
 
+  // Auto-sync pending operations when connection is restored
+  window.addEventListener('network-status-change', async (event: Event) => {
+    const customEvent = event as CustomEvent<{ status: string; previousStatus: string }>;
+    if (customEvent.detail?.status === 'online' && customEvent.detail?.previousStatus !== 'online') {
+      if (!window.offlineManager) return;
+      try {
+        const { items } = await window.offlineManager.getAllUnsyncedItems();
+        if (items.length > 0) {
+          debugLog('[Dashboard] Connection restored — auto-syncing', items.length, 'pending items');
+          retryFailedItemsImpl().catch(err => {
+            debugLog('[Dashboard] Auto-sync on reconnect failed:', err);
+          });
+        }
+      } catch (err) {
+        debugLog('[Dashboard] Auto-sync check failed:', err);
+      }
+    }
+  });
+
   // Listen for offline-sync-complete event
   window.addEventListener('offline-sync-complete', async (event: Event) => {
     const customEvent = event as CustomEvent<{ synced?: number; status?: string }>;


### PR DESCRIPTION
## Summary

- Adds a `network-status-change` event listener in `setupPendingRecordsListeners()` that fires when the network detector transitions from any state to `online`
- When connection is restored and there are pending items, automatically calls `retryFailedItems()` — previously the user had to press "Повторить" manually
- Guards with `previousStatus !== 'online'` to avoid triggering on redundant online→online transitions

## Root cause

`handleOnline()` in `detectionEngine.ts` dispatches `network-status-change` with `detail.status: 'online'`, but no listener in the dashboard acted on it. The existing `window.addEventListener('online', ...)` only refreshed the pending records display, not the sync itself.

## Test plan

- [ ] TypeScript type-check passes (`npm run type-check`) ✅
- [ ] Go offline (DevTools → Network → Offline)
- [ ] Add a transaction offline — verify it appears in "Ожидающие операции"
- [ ] Restore connection — within 3-5 seconds: toast "Синхронизировано: N записей" appears and pending section empties automatically
- [ ] Verify no toast fires when coming online with no pending items

🤖 Generated with [Claude Code](https://claude.com/claude-code)