### PR TITLE
fix(offline): allow negative amount for transfer debit in Dexie validation

### DIFF
--- a/frontend/shared/db/dexie/DexieManager.ts
+++ b/frontend/shared/db/dexie/DexieManager.ts
@@ -336,7 +336,8 @@ export class DexieManager {
       date: fact.date,
       record_type: fact.record_type,
       user_id: fact.user_id,
-      article_id: fact.article_id
+      article_id: fact.article_id,
+      is_transfer: fact.is_transfer,
     });
 
     const temp_id = generateUUID();

--- a/frontend/shared/db/dexie/operations/factOperations.ts
+++ b/frontend/shared/db/dexie/operations/factOperations.ts
@@ -41,7 +41,8 @@ export async function createFact(
       date: fact.date,
       record_type: fact.record_type,
       user_id: fact.user_id,
-      article_id: fact.article_id
+      article_id: fact.article_id,
+      is_transfer: fact.is_transfer,
     });
 
     // Convert amount to cents

--- a/frontend/shared/db/dexie/utils/validation.ts
+++ b/frontend/shared/db/dexie/utils/validation.ts
@@ -39,9 +39,10 @@ export function validateFact(fact: {
   record_type: string;
   user_id: number;
   article_id: number;
+  is_transfer?: boolean;
 }): void {
-  // Validate amount (positive number)
-  if (!validateAmount(fact.amount)) {
+  // Validate amount: positive for regular facts, negative allowed for transfer debit records
+  if (!validateAmount(fact.amount) && !(fact.is_transfer && fact.amount < 0)) {
     throw new Error(`Invalid amount: ${fact.amount}. Must be a positive number`);
   }
 


### PR DESCRIPTION
## Summary

- **Баг #1**: Offline-сохранение перевода (transfer) завершалось ошибкой `Invalid amount: -1000. Must be a positive number`
- `validateFact()` обновлена: разрешает отрицательную сумму для debit-стороны перевода (`is_transfer=true && amount<0`)
- `is_transfer` теперь передаётся в `validateFact()` из двух мест: `factOperations.ts` и `DexieManager.ts`

## Изменённые файлы

- `frontend/shared/db/dexie/utils/validation.ts` — обновлена проверка суммы в `validateFact()`
- `frontend/shared/db/dexie/operations/factOperations.ts` — передаётся `is_transfer`
- `frontend/shared/db/dexie/DexieManager.ts` — передаётся `is_transfer` (второй call site)

## Test plan

- [ ] `npm run type-check` — пройдено
- [ ] Offline-тест: fbd.ikeniborn.ru → отключить сеть → создать перевод → убедиться что сохраняется без ошибок

🤖 Generated with [Claude Code](https://claude.com/claude-code)