### PR TITLE
fix(articles): load financial_center_ids in build_article_responses

### DIFF
--- a/backend/app/services/article_service.py
+++ b/backend/app/services/article_service.py
@@ -413,12 +413,23 @@ async def execute_article_list_query(
 async def build_article_responses(
     session: AsyncSession, rows: list
 ) -> list[ArticleResponse]:
-    """Build ArticleResponse list with usage_count and is_leaf from query rows."""
+    """Build ArticleResponse list with usage_count, is_leaf and financial_center_ids from query rows."""
     parent_ids_query = select(Article.parent_id).where(
         Article.parent_id.isnot(None)
     ).distinct()
     parent_ids_result = await session.execute(parent_ids_query)
     parent_ids = {row[0] for row in parent_ids_result.all()}
+
+    # Load FC links for all articles in one query
+    article_ids = [row[0].id for row in rows]
+    fc_links: dict[int, list[int]] = {aid: [] for aid in article_ids}
+    if article_ids:
+        fc_query = select(ArticleFinancialCenter).where(
+            ArticleFinancialCenter.article_id.in_(article_ids)
+        )
+        fc_result = await session.execute(fc_query)
+        for link in fc_result.scalars().all():
+            fc_links[link.article_id].append(link.financial_center_id)
 
     articles = []
     for row in rows:
@@ -428,6 +439,7 @@ async def build_article_responses(
             **article.model_dump(),
             "usage_count": usage_count,
             "is_leaf": article.id not in parent_ids,
+            "financial_center_ids": fc_links.get(article.id, []),
         }
         articles.append(ArticleResponse.model_validate(article_dict))
     return articles


### PR DESCRIPTION
## Summary

- Fixes the second part of Bug #2: after creating a category with account (FC) restrictions, opening the Edit dialog showed empty account selection
- Root cause: `build_article_responses()` built `ArticleResponse` objects without loading `financial_center_ids`, so the client-side `articlesData` cache always had empty FC lists
- Fix: load all FC links for the result set in a single batched query and populate `financial_center_ids` per article

## Changes

`backend/app/services/article_service.py` — `build_article_responses()`:
- After loading `parent_ids`, also loads all `ArticleFinancialCenter` records for the result set in one query
- Groups links by `article_id` into a dict; populates `financial_center_ids` in each `ArticleResponse`

## Test Plan

- [ ] Create category with 1+ FC restrictions → click Edit → verify FC accounts are shown
- [ ] Edit category, change FC restrictions → Save → reopen Edit → verify changes persisted
- [ ] Category with no FC restrictions → Edit → FC field is empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)