### PR TITLE
fix(admin-articles): fix emoji, stale FC state and FC binding on create

### DIFF
--- a/backend/app/api/v1/endpoints/articles.py
+++ b/backend/app/api/v1/endpoints/articles.py
@@ -135,6 +135,10 @@ async def create_article(
     # Create initial history record (SCD Type 2 for history)
     await create_initial_history(session=session, article=article, change_type="CREATE")
 
+    # Handle financial center links (M2M relation, not a model field)
+    if article_data.financial_center_ids:
+        await update_financial_center_links(session, article.id, article_data.financial_center_ids)
+
     # Invalidate articles cache
     await cache_service.invalidate_articles()
 

--- a/frontend/web/templates/admin_articles.html
+++ b/frontend/web/templates/admin_articles.html
@@ -138,11 +138,11 @@
             </div>
             <div class="form-control">
                 <label class="label">
-                    <span class="label-text">💰 Тип*</span>
+                    <span class="label-text">🏷️ Тип*</span>
                 </label>
                 <select id="edit-type" name="type" required class="select select-bordered">
                     <option value="expense">💸 Расход</option>
-                    <option value="income">💵 Доход</option>
+                    <option value="income">💰 Доход</option>
                     <option value="debit">📤 Списание</option>
                     <option value="credit">📥 Пополнение</option>
                 </select>
@@ -754,13 +754,14 @@ function showCreateModal() {
     document.getElementById('create-type').value = initialType;
     // maxLevel=1: показываем только уровень 1 и 2 как родители (не более 3 уровней вложенности)
     populateParentSelect('create-parent', initialType, null, 1);
+    // Reset FC selection when opening
+    populateFinancialCenterSelect('create-financial-centers', []);
 }
 
 // Close create modal
 function closeCreateModal() {
     document.getElementById('create-modal').close();
     document.getElementById('create-form').reset();
-    // Clear financial center selection
     populateFinancialCenterSelect('create-financial-centers', []);
 }
 


### PR DESCRIPTION
## Summary

Fixes bugs #2, #4, #5 found during Playwright testing of `/admin/articles`.

**Bug #4 — Emoji inconsistency between Create and Edit dialogs:**
- Edit dialog label `💰 Тип*` → `🏷️ Тип*` (matches Create dialog)
- Edit dialog income option `💵 Доход` → `💰 Доход` (matches Create dialog)

**Bug #5 — Stale FC selection in Create dialog:**
- `showCreateModal()` now calls `populateFinancialCenterSelect('create-financial-centers', [])` on open, clearing any previous selections

**Bug #2 — FC binding not saved on create:**
- POST `/api/v1/articles` now calls `update_financial_center_links()` after creating the article if `financial_center_ids` were provided
- Uses the same helper already used by the PUT handler

## Test Plan

- [ ] Create dialog: label shows `🏷️ Тип*`, income option shows `💰 Доход`
- [ ] Edit dialog: same emoji as create dialog
- [ ] Create dialog: open with FC selected → close → reopen → FC is empty
- [ ] Create category with FC restrictions → Edit → FC accounts are shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)