### PR TITLE
fix(ux): prevent false SW update notification and improve cost center modal UX

### DIFF
--- a/frontend/web/templates/admin_cost_centers.html
+++ b/frontend/web/templates/admin_cost_centers.html
@@ -72,7 +72,8 @@
                                autocomplete="off"
                                oninput="renderFCDropdown('create', this.value)"
                                onfocus="showFCDropdown('create')"
-                               onblur="hideFCDropdown('create')" />
+                               onblur="hideFCDropdown('create')"
+                               onkeydown="if(event.key==='Escape'){event.stopPropagation();hideFCDropdown('create');}" />
                         <div id="create-fc-dropdown"
                              class="hidden absolute z-20 w-full mt-1 bg-base-100 border border-base-300 rounded-lg shadow-lg max-h-[150px] overflow-y-auto">
                         </div>
@@ -125,7 +126,8 @@
                                autocomplete="off"
                                oninput="renderFCDropdown('edit', this.value)"
                                onfocus="showFCDropdown('edit')"
-                               onblur="hideFCDropdown('edit')" />
+                               onblur="hideFCDropdown('edit')"
+                               onkeydown="if(event.key==='Escape'){event.stopPropagation();hideFCDropdown('edit');}" />
                         <div id="edit-fc-dropdown"
                              class="hidden absolute z-20 w-full mt-1 bg-base-100 border border-base-300 rounded-lg shadow-lg max-h-[150px] overflow-y-auto">
                         </div>
@@ -725,6 +727,11 @@ async function archiveCenter(centerId) {
 
 // Restore cost location
 async function restoreCenter(centerId) {
+    const confirmed = await showConfirmDialog(
+        '♻️ Вы уверены, что хотите восстановить это МЗ из архива?',
+        '♻️ Восстановление МЗ'
+    );
+    if (!confirmed) return;
     try {
         const response = await fetch(`/api/v1/cost-centers/${centerId}/restore`, {
             method: 'PUT',

--- a/frontend/web/templates/scripts/service-worker-registration.html
+++ b/frontend/web/templates/scripts/service-worker-registration.html
@@ -670,11 +670,13 @@
             }
 
             // Compare versions
-            if (newVersion === savedVersion) {
+            const currentMetaVersion = document.querySelector('meta[name="app-version"]')?.content;
+            if (newVersion === savedVersion || (currentMetaVersion && newVersion === currentMetaVersion)) {
                 // Clean up stale flags from a previous update cycle that may not
                 // have been cleared (e.g. browser cache cleared without localStorage reset)
                 localStorage.removeItem(SW_UPDATE_AVAILABLE_KEY);
                 localStorage.removeItem(SW_NEW_VERSION_KEY);
+                if (!savedVersion && currentMetaVersion) localStorage.setItem(SW_VERSION_KEY, currentMetaVersion);
                 return;
             }
 


### PR DESCRIPTION
## Summary

- **BUG-3**: Add `meta[name="app-version"]` guard in the `controllerchange` handler to prevent a false "update available" notification when `localStorage` is empty (first visit or cleared storage). The `newVersion === savedVersion` check alone fails when `savedVersion` is `null`, so the meta tag provides a fallback identity check.
- **BUG-4**: Add `onkeydown` handlers to `#create-fc-search` and `#edit-fc-search` inputs so pressing Escape only closes the FC dropdown (via `stopPropagation` + `hideFCDropdown`) instead of closing the entire `<dialog>`.
- **ЗАМЕЧАНИЕ-1**: Add `showConfirmDialog` confirmation gate to `restoreCenter()` to match the existing pattern in `archiveCenter()`.

## Test plan

- [ ] Open cost centers admin page, open Create modal, focus FC search input, press Escape — dropdown closes, modal stays open
- [ ] Same for Edit modal
- [ ] Click Restore (♻️) on an archived cost center — confirmation dialog appears before the restore API call
- [ ] On first visit (clear localStorage), update a deployed SW — no false "update available" notification appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)