### PR TITLE
fix(base): move sw-update-modal outside header stacking context

### DIFF
--- a/frontend/web/templates/base.html
+++ b/frontend/web/templates/base.html
@@ -715,10 +715,6 @@
                 </button>
             </div>
 
-            <!-- Service Worker Update Confirmation Modal -->
-            {% from "components/sw_update_modal.html" import sw_update_modal %}
-            {{ sw_update_modal() }}
-
             <!-- Theme Toggle -->
             <label class="swap swap-rotate cursor-pointer p-1 sm:p-2">
                 <input type="checkbox" class="theme-controller" value="dark" aria-label="Toggle dark mode" />
@@ -760,6 +756,10 @@
             {% endif %}
         </div>
     </header>
+
+    <!-- Service Worker Update Modal (outside header stacking context) -->
+    {% from "components/sw_update_modal.html" import sw_update_modal %}
+    {{ sw_update_modal() }}
 
     <!-- Navigation Fade Overlay (v5.2 - Elastic Morphing, no DaisyUI conflict) -->
     <div id="navigation-fade-overlay" class="navigation-fade-overlay" aria-hidden="true">


### PR DESCRIPTION
## Summary

- Перемещает `sw_update_modal()` из `<header>` в позицию после `</header>`
- Причина: header создаёт CSS stacking context, из-за которого кнопки модала (`position:fixed; z-index:900`) были перекрыты элементами `<main>`

## Test plan
- [ ] Установить `localStorage.setItem('pwa_update_available', 'true')` и `pwa_new_version`
- [ ] Кнопки "Позже" и "Обновить" кликабельны

🤖 Generated with [Claude Code](https://claude.com/claude-code)