### PR TITLE
fix: исправление 6 багов по итогам тестирования v0.6.134

### DIFF
--- a/backend/app/api/v1/endpoints/facts.py
+++ b/backend/app/api/v1/endpoints/facts.py
@@ -1810,6 +1810,11 @@ async def delete_fact(
             f"by user {current_user.id}"
         )
 
+    # Invalidate cache BEFORE WebSocket broadcast so that when the client's
+    # debounced refresh fires (~300ms after the WS event), Redis already
+    # serves fresh data instead of the stale cached quick-stats HTML.
+    await cache_service.invalidate_dashboard()
+
     # WebSocket Broadcast: Notify connected clients about deleted fact
     try:
         ws = _get_budget_ws_broadcast()
@@ -1823,10 +1828,6 @@ async def delete_fact(
     except Exception as e:
         logger.warning("WebSocket broadcast failed for deleted fact %s: %s", fact_id, e)
         # Don't fail the request if broadcast fails
-
-    # AWAIT cache invalidation to ensure fresh data on subsequent requests
-    # Performance: adds ~5-20ms latency, but prevents stale data display
-    await cache_service.invalidate_dashboard()
 
     return None
 
@@ -1924,6 +1925,9 @@ async def batch_delete_facts(
     deleted_count = len(facts_to_delete)
     logger.info("[BULK_DELETE] Batch deleted %s facts by user %s", deleted_count, current_user.id)
 
+    # Invalidate cache BEFORE WebSocket broadcast (same race-condition fix as single delete).
+    await cache_service.invalidate_dashboard()
+
     # 5. WebSocket broadcast: SINGLE summary event (NEW PATTERN)
     # Replaces individual fact_deleted/plan_deleted events to eliminate toast spam
     try:
@@ -1938,10 +1942,6 @@ async def batch_delete_facts(
     except Exception as e:
         logger.warning("[BULK_DELETE] WebSocket broadcast failed: %s", e)
         # Don't fail the request if broadcast fails
-
-    # AWAIT cache invalidation to ensure fresh data on subsequent requests
-    # Performance: adds ~5-20ms latency, but prevents stale data display
-    await cache_service.invalidate_dashboard()
 
     return {
         "message": f"Deleted {deleted_count} facts",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -224,8 +224,8 @@ services:
       test: ["CMD", "python", "/app/healthcheck.py"]
       interval: 30s
       timeout: 10s
-      retries: 3
-      start_period: 40s
+      retries: 5
+      start_period: 60s
     # Command removed: Using Dockerfile CMD instead (correct array syntax for distroless)
     # Dockerfile CMD: ["python", "-m", "uvicorn", "backend.app.main:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "1"]
     # Workers: Default 1 for legacy SSE mode, can be increased via WORKERS env var with Redis Pub/Sub

--- a/frontend/web/static/js/facts/integration/wsEventHandlers.ts
+++ b/frontend/web/static/js/facts/integration/wsEventHandlers.ts
@@ -406,25 +406,25 @@ function handleFinancialCenterUpdated(_data: any): void {
  * Called during Facts Manager initialization
  */
 export function registerWSHandlers(): void {
-    if (typeof window === 'undefined' || !window.budgetWSManager) {
+    if (typeof window === 'undefined' || !window.budgetWSClient) {
         // WebSocket not available (offline mode or not initialized yet)
         return;
     }
 
     // Fact CRUD events
-    window.budgetWSManager.on('fact_created', handleFactCreated);
-    window.budgetWSManager.on('fact_updated', handleFactUpdated);
-    window.budgetWSManager.on('fact_deleted', handleFactDeleted);
+    window.budgetWSClient.on('fact_created', handleFactCreated);
+    window.budgetWSClient.on('fact_updated', handleFactUpdated);
+    window.budgetWSClient.on('fact_deleted', handleFactDeleted);
 
     // Batch operations
-    window.budgetWSManager.on('batch_delete_completed', handleBatchDeleteCompleted);
+    window.budgetWSClient.on('batch_delete_completed', handleBatchDeleteCompleted);
 
     // Transfer events (transfers create facts)
-    window.budgetWSManager.on('transfer_created', handleTransferCreated);
+    window.budgetWSClient.on('transfer_created', handleTransferCreated);
 
     // Dropdown data updates
-    window.budgetWSManager.on('article_updated', handleArticleUpdated);
-    window.budgetWSManager.on('financial_center_updated', handleFinancialCenterUpdated);
+    window.budgetWSClient.on('article_updated', handleArticleUpdated);
+    window.budgetWSClient.on('financial_center_updated', handleFinancialCenterUpdated);
 }
 
 /**
@@ -432,15 +432,15 @@ export function registerWSHandlers(): void {
  * Called during cleanup (if needed)
  */
 export function unregisterWSHandlers(): void {
-    if (typeof window === 'undefined' || !window.budgetWSManager) {
+    if (typeof window === 'undefined' || !window.budgetWSClient) {
         return;
     }
 
-    window.budgetWSManager.off('fact_created', handleFactCreated);
-    window.budgetWSManager.off('fact_updated', handleFactUpdated);
-    window.budgetWSManager.off('fact_deleted', handleFactDeleted);
-    window.budgetWSManager.off('batch_delete_completed', handleBatchDeleteCompleted);
-    window.budgetWSManager.off('transfer_created', handleTransferCreated);
-    window.budgetWSManager.off('article_updated', handleArticleUpdated);
-    window.budgetWSManager.off('financial_center_updated', handleFinancialCenterUpdated);
+    window.budgetWSClient.off('fact_created', handleFactCreated);
+    window.budgetWSClient.off('fact_updated', handleFactUpdated);
+    window.budgetWSClient.off('fact_deleted', handleFactDeleted);
+    window.budgetWSClient.off('batch_delete_completed', handleBatchDeleteCompleted);
+    window.budgetWSClient.off('transfer_created', handleTransferCreated);
+    window.budgetWSClient.off('article_updated', handleArticleUpdated);
+    window.budgetWSClient.off('financial_center_updated', handleFinancialCenterUpdated);
 }

--- a/frontend/web/static/js/facts/types/dependencies.ts
+++ b/frontend/web/static/js/facts/types/dependencies.ts
@@ -164,11 +164,11 @@ export function getCalendarWidget(): CalendarWidgetConstructor {
 }
 
 /**
- * Get budgetWSManager
+ * Get budgetWSClient (window export from budgetWSClient.js)
  */
 export function getWSManager(): WebSocketManager | null {
-    if (typeof window !== 'undefined' && (window as any).budgetWSManager) {
-        return (window as any).budgetWSManager;
+    if (typeof window !== 'undefined' && (window as any).budgetWSClient) {
+        return (window as any).budgetWSClient;
     }
     return null;
 }

--- a/frontend/web/static/js/facts/types/globals.d.ts
+++ b/frontend/web/static/js/facts/types/globals.d.ts
@@ -17,7 +17,7 @@ declare global {
         // Third-party libraries
         CategoryTreeSelect: CategoryTreeSelectConstructor;
         CalendarWidget: CalendarWidgetConstructor;
-        budgetWSManager: WebSocketManager | undefined;
+        budgetWSClient: WebSocketManager | undefined;
         htmx: HTMX;
 
         // AdminFactsCommon (admin-facts-common.js)

--- a/frontend/web/templates/components/plan/filters_section.html
+++ b/frontend/web/templates/components/plan/filters_section.html
@@ -9,12 +9,12 @@
 {% macro filters_section() %}
     <div class="collapse collapse-arrow bg-base-100 shadow-lg">
         <input type="checkbox" id="filters-toggle" class="peer" />
-        <label for="filters-toggle" class="collapse-title text-xl font-medium flex justify-between items-center cursor-pointer">
+        <label for="filters-toggle" class="collapse-title text-xl font-medium flex flex-wrap justify-between items-center gap-y-1 cursor-pointer">
             <span>
                 🔍 Фильтры
                 <span id="filter-indicator" class="badge badge-primary badge-sm ml-2 hidden">активны</span>
             </span>
-            <button class="btn btn-sm btn-ghost" data-action="reset-filters">Сбросить</button>
+            <button class="btn btn-sm btn-ghost shrink-0 whitespace-nowrap" data-action="reset-filters">Сбросить</button>
         </label>
         <div class="collapse-content">
             <div class="pt-4">

--- a/frontend/web/templates/facts.html
+++ b/frontend/web/templates/facts.html
@@ -30,7 +30,7 @@
                 🔍 Фильтры
                 <span id="filter-indicator" class="badge badge-primary badge-sm ml-2 hidden">активны</span>
             </span>
-            <button class="btn btn-sm btn-ghost shrink-0" data-action="reset-filters">Сбросить</button>
+            <button class="btn btn-sm btn-ghost shrink-0 whitespace-nowrap" data-action="reset-filters">Сбросить</button>
         </label>
         <div class="collapse-content">
             <div class="pt-4">

--- a/frontend/web/templates/login_email.html
+++ b/frontend/web/templates/login_email.html
@@ -443,7 +443,7 @@ async function handlePasswordLogin(e) {
     try {
         console.log('[AUTH_EMAIL] Login attempt:', identifier);
 
-        const response = await fetch('/api/v1/auth/login', {
+        const loginOptions = {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json'
@@ -453,7 +453,12 @@ async function handlePasswordLogin(e) {
                 email: identifier,
                 password: password
             })
-        });
+        };
+        let response = await fetch('/api/v1/auth/login', loginOptions);
+        if (response.status === 502 || response.status === 503) {
+            await new Promise(r => setTimeout(r, 1500));
+            response = await fetch('/api/v1/auth/login', loginOptions);
+        }
 
         const data = await response.json();
 

--- a/frontend/web/templates/scripts/service-worker-registration.html
+++ b/frontend/web/templates/scripts/service-worker-registration.html
@@ -490,9 +490,10 @@
             const currentText = currentVersion || '(неизвестно)';
             currentElem.textContent = currentText;
 
-            // Display new version: prefer localStorage (actual new SW version), fall back to meta tag
+            // Display new version: prefer meta tag (server-authoritative, always current page version)
+            // over localStorage which may lag on pages where SW hasn't activated yet (e.g. /login).
             const metaVersion = document.querySelector('meta[name="app-version"]')?.content;
-            const newText = newVersion || metaVersion || '';
+            const newText = metaVersion || newVersion || '';
             if (newText) {
                 newElem.textContent = newText;
             }


### PR DESCRIPTION
## Summary

Исправления по результатам тестирования fbd.ikeniborn.ru (ветка test, v0.6.134).

- **Bug #3 (High)** `fix(facts)`: WS-обработчики на /facts никогда не регистрировались — `window.budgetWSManager` не существует, реальный экспорт `window.budgetWSClient`. Исправлено в 3 TypeScript файлах.
- **Bug #5 (Medium)** `fix(backend)`: Быстрая статистика не обновлялась после удаления факта — гонка: Redis-кеш инвалидировался ПОСЛЕ WS-события, клиент получал устаревшие данные. Порядок переставлен.
- **Bug #4 (Medium)** — побочный эффект исправления Bug #3: toast теперь сопровождается корректным обновлением таблицы.
- **Bug #2 (Medium)** `fix(auth)`: 502 при первом логине — добавлен однократный retry (1.5с), увеличен `start_period` healthcheck 40s→60s, `retries` 3→5.
- **Bug #1 (Low)** `fix(sw)`: SW-диалог на /login показывал старую версию — мета-тег (server-injected) теперь приоритетнее localStorage.
- **Bug #6 (Low)** `fix(ui)`: Кнопка "Сбросить" обрезалась на 375px — добавлен `whitespace-nowrap shrink-0`.

## Test plan

- [ ] `/facts` — добавить факт-перевод → таблица обновляется без перезагрузки (Bug #3)
- [ ] `/facts` — toast "Факт сохранён" виден после перевода (Bug #4)
- [ ] Dashboard → удалить факт → "Быстрая статистика" обновляется за ~1 сек (Bug #5)
- [ ] `/login` → SW-диалог обновления показывает версию 0.6.135 (Bug #1)
- [ ] Свежий деплой → первый логин без 502 (Bug #2)
- [ ] `/facts` на 375px → "Сбросить" не обрезается (Bug #6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)