### PR TITLE
fix(facts): E2E bugs — row-html dedup, dead modal cleanup, logs startup delay

### DIFF
--- a/frontend/web/static/js/facts/adapters/windowExports.ts
+++ b/frontend/web/static/js/facts/adapters/windowExports.ts
@@ -134,20 +134,14 @@ async function openAddTransactionModal(): Promise<void> {
     }
 
     // Fallback: Open v10.x tabbed modal (modal_fact)
-    // Try modern modal first (v10.x+)
-    let modal = document.getElementById('modal_fact') as HTMLDialogElement | null;
-
-    // Fallback to legacy modal (v9.x)
-    if (!modal) {
-        modal = document.getElementById('modal_add_transaction') as HTMLDialogElement | null;
-    }
+    const modal = document.getElementById('modal_fact') as HTMLDialogElement | null;
 
     if (modal?.showModal) {
         // Set default date to today
         setTransactionDate(0);
         modal.showModal();
     } else {
-        console.warn('[FactsManager] Transaction modal not found (tried modal_fact and modal_add_transaction)');
+        console.warn('[FactsManager] Transaction modal not found (modal_fact)');
     }
 }
 
@@ -278,7 +272,7 @@ function setTransactionDate(offsetDays: number): void {
     );
 
     // Find date input in transaction modal
-    const dateInput = document.querySelector('#modal_add_transaction input[name="fact_date"]') as HTMLInputElement;
+    const dateInput = document.querySelector('#modal_fact input[name="fact_date"]') as HTMLInputElement;
     if (dateInput) {
         dateInput.value = formattedDate;
         // Trigger change event for any listeners
@@ -299,11 +293,7 @@ async function loadFactHintsWrapper(_category?: any): Promise<void> {
     if (!hintsContainer) return;
 
     try {
-        // modal_fact form (v10.x+) with fallback to legacy modal
-        const form = (
-            document.getElementById('form_modal_fact') ||
-            document.getElementById('form_modal_add_transaction')
-        ) as HTMLFormElement | null;
+        const form = document.getElementById('form_modal_fact') as HTMLFormElement | null;
         if (!form) return;
 
         const formData = new FormData(form);

--- a/frontend/web/static/js/facts/integration/wsEventHandlers.ts
+++ b/frontend/web/static/js/facts/integration/wsEventHandlers.ts
@@ -8,7 +8,7 @@
  * Phase 3: WebSocket Integration
  */
 
-import { loadFacts, fetchAndInjectRow } from '../operations/factsController';
+import { loadFacts, fetchAndInjectRow, fetchRowHtmlDeduped } from '../operations/factsController';
 import { buildFilterQuery } from '../operations/filterOperations';
 import { getCurrentPage, getTotalFacts, setTotalFacts } from '../core/stateManager';
 import { updatePaginationUI } from '../operations/paginationOperations';
@@ -115,17 +115,7 @@ function matchesCurrentFilters(fact: Partial<BudgetFact>): boolean {
  * @returns HTML string (desktop tr + mobile div) or null on error
  */
 async function fetchRowHtml(factId: number): Promise<string | null> {
-    try {
-        const response = await fetch(`/api/v1/facts/${factId}/row-html`, {
-            headers: { 'Accept': 'text/html' }
-        });
-        if (!response.ok) {
-            return null;
-        }
-        return await response.text();
-    } catch {
-        return null;
-    }
+    return fetchRowHtmlDeduped(factId);
 }
 
 /**

--- a/frontend/web/static/js/facts/operations/factsController.ts
+++ b/frontend/web/static/js/facts/operations/factsController.ts
@@ -146,6 +146,49 @@ function canInjectRow(): boolean {
 }
 
 /**
+ * Deduplicated fetch for /row-html.
+ * Collapses concurrent requests for the same factId into one in-flight promise,
+ * and returns a recently fetched response for ROW_HTML_TTL_MS to avoid a second
+ * network round-trip when both the optimistic UI path and the WS handler ask
+ * for the same row within the same event cycle.
+ */
+const ROW_HTML_TTL_MS = 1000;
+const rowHtmlCache = new Map<number, { ts: number; html: string }>();
+const rowHtmlInFlight = new Map<number, Promise<string | null>>();
+
+export async function fetchRowHtmlDeduped(factId: number): Promise<string | null> {
+    const now = Date.now();
+    const cached = rowHtmlCache.get(factId);
+    if (cached && now - cached.ts < ROW_HTML_TTL_MS) {
+        return cached.html;
+    }
+    const existing = rowHtmlInFlight.get(factId);
+    if (existing) return existing;
+
+    const promise = (async () => {
+        try {
+            const response = await fetch(`/api/v1/facts/${factId}/row-html`, {
+                credentials: 'include'
+            });
+            if (!response.ok) {
+                logger.warn(`fetchRowHtmlDeduped: HTTP ${response.status} for fact ${factId}`);
+                return null;
+            }
+            const html = await response.text();
+            rowHtmlCache.set(factId, { ts: Date.now(), html });
+            return html;
+        } catch (error) {
+            logger.warn('fetchRowHtmlDeduped failed:', error);
+            return null;
+        } finally {
+            rowHtmlInFlight.delete(factId);
+        }
+    })();
+    rowHtmlInFlight.set(factId, promise);
+    return promise;
+}
+
+/**
  * Fetch HTML for a single row from the backend and inject it into the table.
  * For 'create': prepend to tbody.
  * For 'update': replace existing tr[data-id] and div[data-id].
@@ -157,16 +200,11 @@ export async function fetchAndInjectRow(factId: number, operation: 'create' | 'u
     }
 
     try {
-        const response = await fetch(`/api/v1/facts/${factId}/row-html`, {
-            credentials: 'include'
-        });
-
-        if (!response.ok) {
-            logger.warn(`fetchAndInjectRow: HTTP ${response.status} for fact ${factId}`);
+        const html = await fetchRowHtmlDeduped(factId);
+        if (html === null) {
             return false;
         }
 
-        const html = await response.text();
         const parsed = parseRowHtml(html);
 
         if (operation === 'create') {

--- a/frontend/web/static/js/utils/logsCollector.js
+++ b/frontend/web/static/js/utils/logsCollector.js
@@ -128,6 +128,12 @@ class LogsCollector {
             return;
         }
 
+        // Startup grace period: defer first POST until page has settled (2.5s)
+        // Avoids races with page init, auth, and service worker activation.
+        if (this._readyAt && Date.now() < this._readyAt) {
+            return;
+        }
+
         // Skip send when offline or auto-offline-mode is active
         const isOffline = !navigator.onLine || localStorage.getItem('budget_auto_offline_mode') === 'true';
         if (isOffline) {
@@ -187,6 +193,7 @@ class LogsCollector {
         }
 
         this.isRunning = true;
+        this._readyAt = Date.now() + 2500;
 
         // Send batch every 30 seconds (sendBatch handles offline guard internally)
         this.intervalId = setInterval(() => {

--- a/frontend/web/templates/facts.html
+++ b/frontend/web/templates/facts.html
@@ -195,9 +195,6 @@
     </div>
 </div>
 
-<!-- Create Fact Modal -->
-{{ modal_fact('modal_add_transaction') }}
-
 <!-- Edit Fact Modal -->
 {{ edit_fact_modal('edit-modal') }}
 


### PR DESCRIPTION
## Summary

Правки по результатам E2E-прогона `/facts` (сценарий 02, Playwright MCP). Пользователь подтвердил: баги 5/7/9 — реальные; 6 — by design, не правим.

- **Bug 5**: дедупликация `GET /api/v1/facts/<id>/row-html`. Добавлен модульный кэш `fetchRowHtmlDeduped` в `factsController.ts` (in-flight `Map` + TTL 1 с). Оптимистичный путь (`fetchAndInjectRow`) и WS-хэндлер (`fetchRowHtml` в `wsEventHandlers.ts`) теперь используют общий кэш — второй запрос в окне 1 с возвращается без сети.
- **Bug 7**: удалён мёртвый `modal_add_transaction`. Из `facts.html` убрана дублирующая инстанциация макроса `modal_fact('modal_add_transaction')` (оставлен только `modal_fact('modal_fact')`). В `windowExports.ts` удалены legacy-fallback'и на старый id; селектор даты переведён на `#modal_fact`.
- **Bug 9**: `LogsCollector.sendBatch()` — грейс-период 2.5 с после `start()`. Избегает POST `/admin/logs/browser` во время инициализации страницы/auth/SW.

## Test plan

- [ ] `/facts` — создание/редактирование/удаление факта: в Network только один `/row-html` на операцию (вместо двух)
- [ ] Создание перевода — два `/row-html` (expense+income), оба уникальные
- [ ] Открытие модалки добавления/перевода/редактирования из `/facts` работает
- [ ] В первые 2.5 с после загрузки нет POST `/api/v1/admin/logs/browser`; после — идут штатно по интервалу
- [ ] `npm run type-check` зелёный (локально ✅)

🤖 Generated with [Claude Code](https://claude.com/claude-code)