### PR TITLE
fix(lists): upload pending toggle/update to server after Dexie write

### DIFF
--- a/frontend/web/static/js/lists/listsManager/core/listOperations.ts
+++ b/frontend/web/static/js/lists/listsManager/core/listOperations.ts
@@ -283,6 +283,11 @@ export async function updateItem(itemId: number, data: Partial<ItemData>): Promi
       result = { tempId: item.temp_id, id: itemId };
       debugLog('[LIST_OPS] Item updated in Dexie', { temp_id: item.temp_id });
 
+      // Background upload: push update to server immediately (same pattern as createItem/deleteItem)
+      dexie.uploadPendingShoppingData().catch((err: unknown) => {
+        console.warn('[LIST_OPS] Background update upload failed:', err);
+      });
+
       // Reload items from Dexie
       if (state.currentListId) {
         await loadShoppingListItems(state.currentListId);
@@ -359,6 +364,11 @@ export async function toggleItemCompleted(itemId: number, isCompleted: boolean):
       // Toggle in Dexie (auto-adds to pending queue)
       await toggleItemCompletedDexie(item.temp_id, isCompleted);
       debugLog('[LIST_OPS] Item completion toggled in Dexie', { temp_id: item.temp_id, isCompleted });
+
+      // Background upload: push completion to server immediately (same pattern as createItem/deleteItem)
+      dexie.uploadPendingShoppingData().catch((err: unknown) => {
+        console.warn('[LIST_OPS] Background toggle upload failed:', err);
+      });
 
       // Reload items from Dexie
       if (state.currentListId) {


### PR DESCRIPTION
## Summary

- `toggleItemCompleted` (Dexie path) писал `sync_status='pending'` в Dexie, но никогда не вызывал `uploadPendingShoppingData()` → данные не попадали на сервер → WS broadcast не срабатывал → другие устройства не обновлялись даже после перезагрузки страницы
- Та же проблема в `updateItem` (редактирование товара)
- Добавлен fire-and-forget вызов `uploadPendingShoppingData()` в оба места — идентично паттерну из `createItem` и `deleteItem`

## Root Cause

`createItem` и `deleteItem` оба вызывают `dexie.uploadPendingShoppingData()` после записи в Dexie.  
`toggleItemCompleted` и `updateItem` — не вызывали. Пропущен один вызов.

## Test plan

- [ ] Отметить товар как купленный на устройстве A → на устройстве B должно обновиться без перезагрузки (WS)
- [ ] Перезагрузить страницу на устройстве B → статус должен сохраниться (персистентность в БД)
- [ ] Редактировать товар → изменения видны на другом устройстве
- [ ] Проверить оффлайн режим: отметить товар → выйти онлайн → изменение синхронизируется

🤖 Generated with [Claude Code](https://claude.com/claude-code)